### PR TITLE
Execute OpenHospital GUI with Docker compose

### DIFF
--- a/Dockerfile-oh
+++ b/Dockerfile-oh
@@ -1,0 +1,35 @@
+FROM maven:3.6.0-jdk-11
+
+ENV OH_CORE_REPO https://github.com/informatici/openhospital-core.git
+ENV OH_CORE_BRANCH master
+
+ENV OH_GUI_REPO https://github.com/pviotti/openhospital-gui.git
+ENV OH_GUI_BRANCH startup-script
+
+# Running GUI application as root (Docker's default) is problematic
+# see https://unix.stackexchange.com/questions/118811/why-cant-i-run-gui-apps-from-root-no-protocol-specified#answer-118826
+RUN /usr/sbin/useradd --comment ohuser --home-dir /home/ohuser \
+    --non-unique --uid 1000 --user-group --system \
+    --shell /bin/bash ohuser \
+    && mkdir -p /home/ohuser \
+    && chown -R ohuser:ohuser /home/ohuser \
+    && chown -R ohuser:ohuser /opt
+USER ohuser
+ENV HOME /home/ohuser
+
+RUN cd /opt \
+    && git clone $OH_CORE_REPO open-hospital-core \
+    && cd  open-hospital-core \
+    && git checkout $OH_CORE_BRANCH \
+    && mvn install -DskipTests
+
+RUN cd /opt \
+    && git clone $OH_GUI_REPO open-hospital \
+    && cd  open-hospital \
+    && git checkout $OH_GUI_BRANCH \
+    && mvn install -DskipTests
+
+RUN rm -rf /opt/open-hospital-core /home/ohuser/.m2
+
+WORKDIR /opt/open-hospital
+CMD XAUTHORITY=/home/ohuser/.Xauthority  /opt/open-hospital/startup.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,13 @@ services:
      dockerfile: Dockerfile-ohdb
     ports: 
     - "3306:3306"
+  openhospital:
+    depends_on:
+     - database
+    image: "pviotti/openhospital:latest"
+    environment:
+     - DISPLAY
+    network_mode: host
+    volumes:
+     - /tmp/.X11-unix:/tmp/.X11-unix
+     - ~/.Xauthority:/home/ohuser/.Xauthority

--- a/startup.sh
+++ b/startup.sh
@@ -16,16 +16,15 @@ fi
 # EXEDIR is the directory where this executable is.
 EXEDIR=${0%/*}
 
-DIRLIBS=${EXEDIR}/bin/*.jar
-for i in ${DIRLIBS}
-do
-  if [ -z "$OPENHOSPITAL_CLASSPATH" ] ; then
-    OPENHOSPITAL_CLASSPATH=$i
-  else
-    OPENHOSPITAL_CLASSPATH="$i":$OPENHOSPITAL_CLASSPATH
-  fi
-done
-
+#DIRLIBS=${EXEDIR}/bin/*.jar
+#for i in ${DIRLIBS}
+#do
+#  if [ -z "$OPENHOSPITAL_CLASSPATH" ] ; then
+#    OPENHOSPITAL_CLASSPATH=$i
+#  else
+#    OPENHOSPITAL_CLASSPATH="$i":$OPENHOSPITAL_CLASSPATH
+#  fi
+#done
 
 DIRLIBS=${EXEDIR}/lib/*.jar
 for i in ${DIRLIBS}
@@ -37,7 +36,57 @@ do
   fi
 done
 
-DIRLIBS=${EXEDIR}/lib/h8/*.jar
+#DIRLIBS=${EXEDIR}/lib/h8/*.jar
+#for i in ${DIRLIBS}
+#do
+#  if [ -z "$OPENHOSPITAL_CLASSPATH" ] ; then
+#    OPENHOSPITAL_CLASSPATH=$i
+#  else
+#    OPENHOSPITAL_CLASSPATH="$i":$OPENHOSPITAL_CLASSPATH
+#  fi
+#done
+#
+#DIRLIBS=${EXEDIR}/lib/dicom/*.jar
+#for i in ${DIRLIBS}
+#do
+#  if [ -z "$OPENHOSPITAL_CLASSPATH" ] ; then
+#    OPENHOSPITAL_CLASSPATH=$i
+#  else
+#    OPENHOSPITAL_CLASSPATH="$i":$OPENHOSPITAL_CLASSPATH
+#  fi
+#done
+#
+#DIRLIBS=${EXEDIR}/lib/dicom/dcm4che/*.jar
+#for i in ${DIRLIBS}
+#do
+#  if [ -z "$OPENHOSPITAL_CLASSPATH" ] ; then
+#    OPENHOSPITAL_CLASSPATH=$i
+#  else
+#    OPENHOSPITAL_CLASSPATH="$i":$OPENHOSPITAL_CLASSPATH
+#  fi
+#done
+#
+#DIRLIBS=${EXEDIR}/lib/dicom/jai/*.jar
+#for i in ${DIRLIBS}
+#do
+#  if [ -z "$OPENHOSPITAL_CLASSPATH" ] ; then
+#    OPENHOSPITAL_CLASSPATH=$i
+#  else
+#    OPENHOSPITAL_CLASSPATH="$i":$OPENHOSPITAL_CLASSPATH
+#  fi
+#done
+#
+#DIRLIBS=${EXEDIR}/lib/*.zip
+#for i in ${DIRLIBS}
+#do
+#  if [ -z "$OPENHOSPITAL_CLASSPATH" ] ; then
+#    OPENHOSPITAL_CLASSPATH=$i
+#  else
+#    OPENHOSPITAL_CLASSPATH="$i":$OPENHOSPITAL_CLASSPATH
+#  fi
+#done
+
+DIRLIBS=${EXEDIR}/target/OpenHospital20/lib/*.jar
 for i in ${DIRLIBS}
 do
   if [ -z "$OPENHOSPITAL_CLASSPATH" ] ; then
@@ -47,37 +96,7 @@ do
   fi
 done
 
-DIRLIBS=${EXEDIR}/lib/dicom/*.jar
-for i in ${DIRLIBS}
-do
-  if [ -z "$OPENHOSPITAL_CLASSPATH" ] ; then
-    OPENHOSPITAL_CLASSPATH=$i
-  else
-    OPENHOSPITAL_CLASSPATH="$i":$OPENHOSPITAL_CLASSPATH
-  fi
-done
-
-DIRLIBS=${EXEDIR}/lib/dicom/dcm4che/*.jar
-for i in ${DIRLIBS}
-do
-  if [ -z "$OPENHOSPITAL_CLASSPATH" ] ; then
-    OPENHOSPITAL_CLASSPATH=$i
-  else
-    OPENHOSPITAL_CLASSPATH="$i":$OPENHOSPITAL_CLASSPATH
-  fi
-done
-
-DIRLIBS=${EXEDIR}/lib/dicom/jai/*.jar
-for i in ${DIRLIBS}
-do
-  if [ -z "$OPENHOSPITAL_CLASSPATH" ] ; then
-    OPENHOSPITAL_CLASSPATH=$i
-  else
-    OPENHOSPITAL_CLASSPATH="$i":$OPENHOSPITAL_CLASSPATH
-  fi
-done
-
-DIRLIBS=${EXEDIR}/lib/*.zip
+DIRLIBS=${EXEDIR}/target/OpenHospital20/bin/*.jar
 for i in ${DIRLIBS}
 do
   if [ -z "$OPENHOSPITAL_CLASSPATH" ] ; then
@@ -105,4 +124,6 @@ case $ARCH in
 		;;
 esac
 
+# XXX DEBUG: echo the startup command
+echo $JAVA_EXE -Dsun.java2d.dpiaware=false -Djava.library.path=${NATIVE_LIB_PATH} -classpath "$OPENHOSPITAL_CLASSPATH:$CLASSPATH" org.isf.menu.gui.Menu "$@"
 $JAVA_EXE -Dsun.java2d.dpiaware=false -Djava.library.path=${NATIVE_LIB_PATH} -classpath "$OPENHOSPITAL_CLASSPATH:$CLASSPATH" org.isf.menu.gui.Menu "$@"


### PR DESCRIPTION
This PR adds the OpenHospital Swing-based GUI to the Docker Compose file, so that one can run both database and GUI with a simple `docker-compose up`.  

Notes:
 - I had to modify `startup.sh` because it wasn't working - several folders of those included in the Java classpath do not exist, and the one created by the Maven build (`/target/*`) are not present
 - I only tested this on Linux (and I suspect there will be issues at using this on Windows since it uses X11 for graphics..)
 - the Docker file for the GUI downloads and builds both core and gui with Maven. I guess it would be quicker to build if we published the Maven artifacts somewhere.
 - running GUI applications in Docker is less than trivial, as you have to use a non-root user, and somehow map the X11 server configuration in the container to a local one on the host machine (see for instance [this](https://medium.com/@learnwell/how-to-dockerize-a-java-gui-application-bce560abf62a))
 - the Docker image for the GUI is published [here](https://cloud.docker.com/repository/docker/pviotti/openhospital) as pviotti/openhospital, and can be run separately (tested only on Linux) with this command: `docker run -ti --rm -v /tmp/.X11-unix:/tmp/.X11-unix -v /home/$(whoami)/.Xauthority:/home/ohuser/.Xauthority:ro -e DISPLAY --network=host pviotti/openhospital:latest`
 - in the Docker file I used my fork of this repo since the `startup.sh` file does not work on the main repo

Related issues: [OP-68](https://openhospital.atlassian.net/projects/OP/issues/OP-68?filter=allopenissues) (and child taks)