### PR TITLE
OP-111 Defined Managers of M modules as Spring Bean #time 1h

### DIFF
--- a/src/org/isf/malnutrition/gui/InsertMalnutrition.java
+++ b/src/org/isf/malnutrition/gui/InsertMalnutrition.java
@@ -17,6 +17,7 @@ import javax.swing.event.EventListenerList;
 import org.isf.generaldata.MessageBundle;
 import org.isf.malnutrition.manager.MalnutritionManager;
 import org.isf.malnutrition.model.Malnutrition;
+import org.isf.menu.manager.Context;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.gui.OHServiceExceptionUtil;
 import org.isf.utils.time.DateTextField;
@@ -80,7 +81,7 @@ public class InsertMalnutrition extends JDialog {
 
 	private boolean inserting;
 	
-	private MalnutritionManager manager = new MalnutritionManager();
+	private MalnutritionManager manager = Context.getApplicationContext().getBean(MalnutritionManager.class);
 
 	InsertMalnutrition(JDialog owner, Malnutrition malnutrition, boolean insert) {
 		super(owner, true);

--- a/src/org/isf/malnutrition/gui/MalnutritionBrowser.java
+++ b/src/org/isf/malnutrition/gui/MalnutritionBrowser.java
@@ -23,6 +23,7 @@ import org.isf.generaldata.MessageBundle;
 import org.isf.malnutrition.gui.InsertMalnutrition.MalnutritionListener;
 import org.isf.malnutrition.manager.MalnutritionManager;
 import org.isf.malnutrition.model.Malnutrition;
+import org.isf.menu.manager.Context;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.gui.OHServiceExceptionUtil;
 import org.isf.utils.time.TimeTools;
@@ -84,6 +85,8 @@ public class MalnutritionBrowser extends JDialog implements MalnutritionListener
 	private int selectedrow;
 
 	private Admission adm;
+
+	private MalnutritionManager manager = Context.getApplicationContext().getBean(MalnutritionManager.class);
 
 	public MalnutritionBrowser(JFrame owner, Admission aAdm) {
 		super(owner, true);
@@ -165,7 +168,6 @@ public class MalnutritionBrowser extends JDialog implements MalnutritionListener
 		deleteButton.setMnemonic(KeyEvent.VK_D);
 		deleteButton.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent event) {
-				MalnutritionManager manager = new MalnutritionManager();
 				if (table.getSelectedRow() < 0) {
 					JOptionPane.showMessageDialog(
 							MalnutritionBrowser.this,
@@ -237,8 +239,7 @@ public class MalnutritionBrowser extends JDialog implements MalnutritionListener
 		private static final long serialVersionUID = 1L;
 
 		public MalnBrowsingModel(String s) {
-			MalnutritionManager manager = new MalnutritionManager();
-			
+
 			pMaln = null;
 			
 			if (null != s && false == s.isEmpty()) {

--- a/src/org/isf/medicals/gui/MedicalBrowser.java
+++ b/src/org/isf/medicals/gui/MedicalBrowser.java
@@ -48,6 +48,7 @@ import org.isf.medicals.model.Medical;
 import org.isf.medtype.manager.MedicalTypeBrowserManager;
 import org.isf.medtype.model.MedicalType;
 import org.isf.menu.gui.MainMenu;
+import org.isf.menu.manager.Context;
 import org.isf.stat.gui.report.GenericReportFromDateToDate;
 import org.isf.stat.gui.report.GenericReportPharmaceuticalOrder;
 import org.isf.stat.gui.report.GenericReportPharmaceuticalStock;
@@ -134,6 +135,10 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 	protected boolean altKeyReleased = true;
 	private String lastKey = "";
 	private JButton buttonAMC;
+
+	private MedicalTypeBrowserManager medicalTypeManager = Context.getApplicationContext().getBean(MedicalTypeBrowserManager.class);
+	private MedicalBrowsingManager medicalBrowsingManager = Context.getApplicationContext().getBean(MedicalBrowsingManager.class);
+
 	private void filterMedical(String key) {
 		model = new MedicalBrowsingModel(key, false);
 		table.setModel(model);
@@ -459,7 +464,6 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 					return;									
 				} else {
 					selectedrow = table.convertRowIndexToModel(table.getSelectedRow());
-					MedicalBrowsingManager manager = new MedicalBrowsingManager();
 					Medical med = (Medical) (((MedicalBrowsingModel) model).getValueAt(selectedrow, -1));
 					StringBuilder deleteMessage = new StringBuilder()
 							.append(MessageBundle.getMessage("angal.medicals.deletemedical"))
@@ -473,7 +477,7 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 									JOptionPane.YES_NO_OPTION);
 					boolean deleted;
 					try {
-						deleted = manager.deleteMedical(med);
+						deleted = medicalBrowsingManager.deleteMedical(med);
 					} catch (OHServiceException e) {
 						deleted = false;
 						OHServiceExceptionUtil.showMessages(e);
@@ -535,10 +539,9 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 		if (pbox == null) {
 			pbox = new JComboBox();
 			pbox.addItem(MessageBundle.getMessage("angal.medicals.allm"));
-			MedicalTypeBrowserManager manager = new MedicalTypeBrowserManager();
 			ArrayList<MedicalType> type;
 			try {
-				type = manager.getMedicalType();
+				type = medicalTypeManager.getMedicalType();
 				for (MedicalType elem : type) {
 					pbox.addItem(elem);
 				}
@@ -675,9 +678,8 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 
 		public MedicalBrowsingModel(String key, boolean isType) {
 			if (isType) {
-				MedicalBrowsingManager manager = new MedicalBrowsingManager();
 				try {
-					medicalList = pMedicals = manager.getMedicals(key, false);
+					medicalList = pMedicals = medicalBrowsingManager.getMedicals(key, false);
 				} catch (OHServiceException e) {
 					pMedicals = null;
 					OHServiceExceptionUtil.showMessages(e);
@@ -706,9 +708,8 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 			}
 		}
 		public MedicalBrowsingModel() {
-			MedicalBrowsingManager manager = new MedicalBrowsingManager();
 			try {
-				medicalList = pMedicals = manager.getMedicals(null, false);
+				medicalList = pMedicals = medicalBrowsingManager.getMedicals(null, false);
 			} catch (OHServiceException e) {
 				pMedicals = null;
 				OHServiceExceptionUtil.showMessages(e);

--- a/src/org/isf/medicals/gui/MedicalEdit.java
+++ b/src/org/isf/medicals/gui/MedicalEdit.java
@@ -23,6 +23,7 @@ import org.isf.medicals.manager.MedicalBrowsingManager;
 import org.isf.medicals.model.Medical;
 import org.isf.medtype.manager.MedicalTypeBrowserManager;
 import org.isf.medtype.model.MedicalType;
+import org.isf.menu.manager.Context;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.gui.OHServiceExceptionUtil;
 import org.isf.utils.exception.model.OHExceptionMessage;
@@ -106,6 +107,9 @@ public class MedicalEdit extends JDialog {
 	private Medical oldMedical = null;
 	private Medical medical = null;
 	private boolean insert = false;
+
+	private MedicalTypeBrowserManager medicalTypeManager = Context.getApplicationContext().getBean(MedicalTypeBrowserManager.class);
+	private MedicalBrowsingManager medicalBrowsingManager = Context.getApplicationContext().getBean(MedicalBrowsingManager.class);
 
 	/**
 	 * 
@@ -243,7 +247,6 @@ public class MedicalEdit extends JDialog {
 			okButton.setMnemonic(KeyEvent.VK_O);
 			okButton.addActionListener(new java.awt.event.ActionListener() {
 				public void actionPerformed(java.awt.event.ActionEvent e) {
-					MedicalBrowsingManager manager = new MedicalBrowsingManager();
 					Medical newMedical = null;
 					try {
 						newMedical = (Medical) medical.clone();
@@ -258,7 +261,7 @@ public class MedicalEdit extends JDialog {
 					boolean result = false;
 					if (insert) { // inserting
 						try {
-							result = manager.newMedical(newMedical);
+							result = medicalBrowsingManager.newMedical(newMedical);
 						} catch (OHServiceException e1) {
 							OHServiceExceptionUtil.showMessages(e1, MedicalEdit.this);
 							List<OHExceptionMessage> errors = e1.getMessages();
@@ -270,7 +273,7 @@ public class MedicalEdit extends JDialog {
 
 										if (ok == JOptionPane.OK_OPTION) {
 											try {
-												result = manager.newMedical(newMedical, true);
+												result = medicalBrowsingManager.newMedical(newMedical, true);
 											} catch (OHServiceException e2) {
 												OHServiceExceptionUtil.showMessages(e2);
 											}
@@ -285,7 +288,7 @@ public class MedicalEdit extends JDialog {
 						}
 					} else { // updating
 						try {
-							result = manager.updateMedical(newMedical);
+							result = medicalBrowsingManager.updateMedical(newMedical);
 						} catch (OHServiceException e1) {
 							List<OHExceptionMessage> errors = e1.getMessages();
 
@@ -297,7 +300,7 @@ public class MedicalEdit extends JDialog {
 
 										if (ok == JOptionPane.OK_OPTION) {
 											try {
-												result = manager.updateMedical(newMedical, true);
+												result = medicalBrowsingManager.updateMedical(newMedical, true);
 											} catch (OHServiceException e2) {
 												OHServiceExceptionUtil.showMessages(e2);
 											}
@@ -400,10 +403,9 @@ public class MedicalEdit extends JDialog {
 		if (typeComboBox == null) {
 			typeComboBox = new JComboBox();
 			if (insert) {
-				MedicalTypeBrowserManager manager = new MedicalTypeBrowserManager();
 				ArrayList<MedicalType> types;
 				try {
-					types = manager.getMedicalType();
+					types = medicalTypeManager.getMedicalType();
 					
 					for (MedicalType elem : types) {
 						typeComboBox.addItem(elem);

--- a/src/org/isf/medicalstock/gui/MovStockBrowser.java
+++ b/src/org/isf/medicalstock/gui/MovStockBrowser.java
@@ -158,6 +158,12 @@ public class MovStockBrowser extends ModalJFrame {
 	private SupplierBrowserManager supMan = new SupplierBrowserManager();
 	private HashMap<Integer, String> supMap = new HashMap<Integer, String>();
 
+	private MedicalBrowsingManager medicalManager = Context.getApplicationContext().getBean(MedicalBrowsingManager.class);
+	private MedicalTypeBrowserManager medicalTypeBrowserManager = Context.getApplicationContext().getBean(MedicalTypeBrowserManager.class);
+	private MedicaldsrstockmovTypeBrowserManager medicaldsrstockmovTypeBrowserManager = Context.getApplicationContext().getBean(MedicaldsrstockmovTypeBrowserManager.class);
+	private MovBrowserManager movBrowserManager = Context.getApplicationContext().getBean(MovBrowserManager.class);
+	private HospitalBrowsingManager hospitalManager = Context.getApplicationContext().getBean(HospitalBrowsingManager.class);
+
 	public MovStockBrowser() {
 		myFrame = this;
 		setTitle(MessageBundle.getMessage("angal.medicalstock.stockmovementbrowser"));
@@ -483,7 +489,6 @@ public class MovStockBrowser extends ModalJFrame {
                 @Override
                 public void actionPerformed(ActionEvent ae) {
                     medicalBox.removeAllItems();
-                    MedicalBrowsingManager medicalManager = new MedicalBrowsingManager();
                     ArrayList<Medical> medicals;
                     try {
                             medicals = medicalManager.getMedicals();
@@ -534,7 +539,6 @@ public class MovStockBrowser extends ModalJFrame {
 		medicalBox.setMaximumSize(new Dimension(150, 25));
 		medicalBox.setMinimumSize(new Dimension(150, 25));
 		medicalBox.setPreferredSize(new Dimension(150, 25));
-		MedicalBrowsingManager medicalManager = new MedicalBrowsingManager();
 		ArrayList<Medical> medical;
 		try {
 			medical = medicalManager.getMedicals();
@@ -574,13 +578,12 @@ public class MovStockBrowser extends ModalJFrame {
 	private JComboBox getMedicalTypeBox() {
 		medicalTypeBox = new JComboBox();
 		medicalTypeBox.setPreferredSize(new Dimension(130,25));
-		MedicalTypeBrowserManager medicalManager = new MedicalTypeBrowserManager();
 		ArrayList<MedicalType> medical;
 		
 		medicalTypeBox.addItem(MessageBundle.getMessage("angal.medicalstock.all"));
 		
 		try {
-			medical = medicalManager.getMedicalType();
+			medical = medicalTypeBrowserManager.getMedicalType();
 			
 			for (MedicalType aMedicalType : medical) {
 				medicalTypeBox.addItem(aMedicalType);
@@ -615,10 +618,9 @@ public class MovStockBrowser extends ModalJFrame {
 	private JComboBox getMovementTypeBox() {
 		typeBox = new JComboBox();
 		typeBox.setPreferredSize(new Dimension(130,25));
-		MedicaldsrstockmovTypeBrowserManager typeManager = new MedicaldsrstockmovTypeBrowserManager();
 		ArrayList<MovementType> type;
 		try {
-			type = typeManager.getMedicaldsrstockmovType();
+			type = medicaldsrstockmovTypeBrowserManager.getMedicaldsrstockmovType();
 		} catch (OHServiceException e1) {
 			type = null;
 			OHServiceExceptionUtil.showMessages(e1);
@@ -684,7 +686,6 @@ public class MovStockBrowser extends ModalJFrame {
 		if (jTableTotal == null) {
 			jTableTotal = new JTable();
 			
-			HospitalBrowsingManager hospitalManager = Context.getApplicationContext().getBean(HospitalBrowsingManager.class);;
 			String currencyCod;
 			try {
 				currencyCod = hospitalManager.getHospitalCurrencyCod();
@@ -1147,9 +1148,8 @@ public class MovStockBrowser extends ModalJFrame {
 				GregorianCalendar movTo, GregorianCalendar lotPrepFrom,
 				GregorianCalendar lotPrepTo, GregorianCalendar lotDueFrom,
 				GregorianCalendar lotDueTo) {
-			MovBrowserManager manager = Context.getApplicationContext().getBean(MovBrowserManager.class);
 			try {
-				moves = manager.getMovements(medicalCode, medicalType, ward,
+				moves = movBrowserManager.getMovements(medicalCode, medicalType, ward,
 						movType, movFrom, movTo, lotPrepFrom, lotPrepTo,
 						lotDueFrom, lotDueTo);
 			} catch (OHServiceException e) {

--- a/src/org/isf/medicalstock/gui/MovStockMultipleCharging.java
+++ b/src/org/isf/medicalstock/gui/MovStockMultipleCharging.java
@@ -111,6 +111,8 @@ public class MovStockMultipleCharging extends JDialog {
 	private int optionSelected = UNITS;
 	
 	private MovStockInsertingManager movManager = Context.getApplicationContext().getBean(MovStockInsertingManager.class);
+	private MedicalBrowsingManager medicalBrowsingManager = Context.getApplicationContext().getBean(MedicalBrowsingManager.class);
+	private MedicaldsrstockmovTypeBrowserManager medicaldsrstockmovTypeBrowserManager = Context.getApplicationContext().getBean(MedicaldsrstockmovTypeBrowserManager.class);
 
 	/**
 	 * Launch the application.
@@ -141,10 +143,9 @@ public class MovStockMultipleCharging extends JDialog {
 	}
 
 	private void initialize() {
-		MedicalBrowsingManager medMan = new MedicalBrowsingManager();
 		ArrayList<Medical> medicals;
 		try {
-			medicals = medMan.getMedicals();
+			medicals = medicalBrowsingManager.getMedicals();
 		} catch (OHServiceException e) {
 			OHServiceExceptionUtil.showMessages(e);
 			medicals = null;
@@ -479,10 +480,9 @@ public class MovStockMultipleCharging extends JDialog {
 	private JComboBox getJComboBoxChargeType() {
 		if (jComboBoxChargeType == null) {
 			jComboBoxChargeType = new JComboBox();
-			MedicaldsrstockmovTypeBrowserManager movMan = new MedicaldsrstockmovTypeBrowserManager();
 			ArrayList<MovementType> movTypes;
 			try {
-				movTypes = movMan.getMedicaldsrstockmovType();
+				movTypes = medicaldsrstockmovTypeBrowserManager.getMedicaldsrstockmovType();
 			} catch (OHServiceException e) {
 				movTypes = null;
 				OHServiceExceptionUtil.showMessages(e);

--- a/src/org/isf/medicalstock/gui/MovStockMultipleDischarging.java
+++ b/src/org/isf/medicalstock/gui/MovStockMultipleDischarging.java
@@ -1,45 +1,6 @@
 package org.isf.medicalstock.gui;
 
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.HashMap;
-import java.util.ListIterator;
-
-import javax.swing.DefaultCellEditor;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JDialog;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.ListSelectionModel;
-import javax.swing.SwingConstants;
-import javax.swing.border.EmptyBorder;
-import javax.swing.table.AbstractTableModel;
-import javax.swing.table.DefaultTableCellRenderer;
-import javax.swing.table.DefaultTableModel;
-import javax.swing.table.TableColumn;
-
+import com.toedter.calendar.JDateChooser;
 import org.apache.log4j.PropertyConfigurator;
 import org.isf.generaldata.GeneralData;
 import org.isf.generaldata.MessageBundle;
@@ -62,7 +23,19 @@ import org.isf.ward.model.Ward;
 import org.isf.xmpp.gui.CommunicationFrame;
 import org.isf.xmpp.manager.Interaction;
 
-import com.toedter.calendar.JDateChooser;
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableColumn;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.io.File;
+import java.util.*;
 
 public class MovStockMultipleDischarging extends JDialog {
 	/**
@@ -113,6 +86,8 @@ public class MovStockMultipleDischarging extends JDialog {
 	private ArrayList<Medical> pool = new ArrayList<Medical>();
 	
 	private MovStockInsertingManager movManager = Context.getApplicationContext().getBean(MovStockInsertingManager.class);
+	private MedicalBrowsingManager medicalBrowsingManager = Context.getApplicationContext().getBean(MedicalBrowsingManager.class);
+	private MedicaldsrstockmovTypeBrowserManager medicaldsrstockmovTypeBrowserManager = Context.getApplicationContext().getBean(MedicaldsrstockmovTypeBrowserManager.class);
 
 	/**
 	 * Launch the application.
@@ -148,11 +123,10 @@ public class MovStockMultipleDischarging extends JDialog {
 	}
 
 	private void initialize() {
-		MedicalBrowsingManager medMan = new MedicalBrowsingManager();
-		
+
 		ArrayList<Medical> medicals;
 		try {
-			medicals = medMan.getMedicals();
+			medicals = medicalBrowsingManager.getMedicals();
 		} catch (OHServiceException e) {
 			medicals = null;
 			OHServiceExceptionUtil.showMessages(e);
@@ -511,10 +485,9 @@ public class MovStockMultipleDischarging extends JDialog {
 	private JComboBox getJComboBoxChargeType() {
 		if (jComboBoxDischargeType == null) {
 			jComboBoxDischargeType = new JComboBox();
-			MedicaldsrstockmovTypeBrowserManager movMan = new MedicaldsrstockmovTypeBrowserManager();
 			ArrayList<MovementType> movTypes;
 			try {
-				movTypes = movMan.getMedicaldsrstockmovType();
+				movTypes = medicaldsrstockmovTypeBrowserManager.getMedicaldsrstockmovType();
 			} catch (OHServiceException e) {
 				movTypes = null;
 				OHServiceExceptionUtil.showMessages(e);

--- a/src/org/isf/medicalstockward/gui/WardPharmacy.java
+++ b/src/org/isf/medicalstockward/gui/WardPharmacy.java
@@ -197,7 +197,9 @@ public class WardPharmacy extends ModalJFrame implements
 	private MovBrowserManager movManager = Context.getApplicationContext().getBean(MovBrowserManager.class);
 	private PrintManager printManager = Context.getApplicationContext().getBean(PrintManager.class);
 	private ArrayList<Movement> listMovementCentral = new ArrayList<Movement>();
-	private MovWardBrowserManager wardManager = new MovWardBrowserManager();
+	private MovWardBrowserManager wardManager = Context.getApplicationContext().getBean(MovWardBrowserManager.class);
+	private MedicalTypeBrowserManager medicalTypeBrowserManager = Context.getApplicationContext().getBean(MedicalTypeBrowserManager.class);
+	private MedicalBrowsingManager medicalManager = Context.getApplicationContext().getBean(MedicalBrowsingManager.class);
 	private ArrayList<MovementWard> listMovementWardFromTo = new ArrayList<MovementWard>();
 	private ArrayList<MedicalWard> wardDrugs;
 	private ArrayList<MovementWard> wardOutcomes;
@@ -795,13 +797,12 @@ public class WardPharmacy extends ModalJFrame implements
 			jComboBoxTypes = new JComboBox();
 			jComboBoxTypes.setMaximumSize(new Dimension(filterWidth, 24));
 			jComboBoxTypes.setPreferredSize(new Dimension(filterWidth, 24));
-			MedicalTypeBrowserManager medicalManager = new MedicalTypeBrowserManager();
 			ArrayList<MedicalType> medicalTypes;
 			
 			jComboBoxTypes.addItem(MessageBundle.getMessage("angal.medicalstockward.alltypes")); //$NON-NLS-1$
 			
 			try {
-				medicalTypes = medicalManager.getMedicalType();
+				medicalTypes = medicalTypeBrowserManager.getMedicalType();
 				
 				for (MedicalType aMedicalType : medicalTypes) {
 					jComboBoxTypes.addItem(aMedicalType);
@@ -830,7 +831,6 @@ public class WardPharmacy extends ModalJFrame implements
                 @Override
                 public void actionPerformed(ActionEvent ae) {
                     jComboBoxMedicals.removeAllItems();
-                    MedicalBrowsingManager medicalManager = new MedicalBrowsingManager();
                     ArrayList<Medical> medicals;
                     try {
                             medicals = medicalManager.getMedicals();
@@ -892,7 +892,6 @@ public class WardPharmacy extends ModalJFrame implements
 			jComboBoxMedicals.setMaximumSize(new Dimension(filterWidth, 24));
 			jComboBoxMedicals.setPreferredSize(new Dimension(filterWidth, 24));
 		}
-		MedicalBrowsingManager medicalManager = new MedicalBrowsingManager();
 		ArrayList<Medical> medicals;
 		try {
 			medicals = medicalManager.getMedicals();

--- a/src/org/isf/medicalstockward/gui/WardPharmacyEdit.java
+++ b/src/org/isf/medicalstockward/gui/WardPharmacyEdit.java
@@ -73,6 +73,7 @@ public class WardPharmacyEdit extends JDialog {
 	private int movSelectedAge;
 	private float movSelectedWeight;
 	private PatientBrowserManager patBrowser = Context.getApplicationContext().getBean(PatientBrowserManager.class);
+	private MovWardBrowserManager movWardBrowserManager = Context.getApplicationContext().getBean(MovWardBrowserManager.class);
 	private ArrayList<Patient> pat = new ArrayList<Patient>();
 	private ArrayList<MedicalWard> medList = null;
 	
@@ -344,10 +345,9 @@ public class WardPharmacyEdit extends JDialog {
 					movSelected.setQuantity((Double)jSpinnerQty.getValue());
 					movSelected.setUnits((String)jComboBoxType.getSelectedItem());
 					
-					MovWardBrowserManager manager = new MovWardBrowserManager();
 					boolean result;
 					try {
-						result = manager.updateMovementWard(movSelected);
+						result = movWardBrowserManager.updateMovementWard(movSelected);
 					} catch (OHServiceException e1) {
 						result = false;
 						OHServiceExceptionUtil.showMessages(e1);

--- a/src/org/isf/medicalstockward/gui/WardPharmacyNew.java
+++ b/src/org/isf/medicalstockward/gui/WardPharmacyNew.java
@@ -1,9 +1,23 @@
 package org.isf.medicalstockward.gui;
 
-import java.awt.AWTEvent;
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.FlowLayout;
+import org.isf.generaldata.MessageBundle;
+import org.isf.medicals.model.Medical;
+import org.isf.medicalstockward.manager.MovWardBrowserManager;
+import org.isf.medicalstockward.model.MedicalWard;
+import org.isf.medicalstockward.model.MovementWard;
+import org.isf.menu.manager.Context;
+import org.isf.patient.gui.SelectPatient;
+import org.isf.patient.gui.SelectPatient.SelectionListener;
+import org.isf.patient.model.Patient;
+import org.isf.utils.exception.OHException;
+import org.isf.utils.exception.OHServiceException;
+import org.isf.ward.model.Ward;
+
+import javax.swing.*;
+import javax.swing.event.EventListenerList;
+import javax.swing.event.TableModelListener;
+import javax.swing.table.TableModel;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -13,38 +27,6 @@ import java.util.EventListener;
 import java.util.GregorianCalendar;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import javax.swing.BoxLayout;
-import javax.swing.ButtonGroup;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JDialog;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
-import javax.swing.JScrollPane;
-import javax.swing.JSpinner;
-import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.SpinnerNumberModel;
-import javax.swing.event.EventListenerList;
-import javax.swing.event.TableModelListener;
-import javax.swing.table.TableModel;
-
-import org.isf.generaldata.MessageBundle;
-import org.isf.medicals.model.Medical;
-import org.isf.medicalstockward.manager.MovWardBrowserManager;
-import org.isf.medicalstockward.model.MedicalWard;
-import org.isf.medicalstockward.model.MovementWard;
-import org.isf.patient.gui.SelectPatient;
-import org.isf.patient.gui.SelectPatient.SelectionListener;
-import org.isf.patient.model.Patient;
-import org.isf.utils.exception.OHException;
-import org.isf.utils.exception.OHServiceException;
-import org.isf.ward.model.Ward;
 
 public class WardPharmacyNew extends JDialog implements SelectionListener {
 
@@ -155,7 +137,9 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
         private JButton searchButton;
         private JComboBox jComboBoxMedicals;
         //private JLabel jLabelSelectWard;
-        
+
+		private MovWardBrowserManager wardManager = Context.getApplicationContext().getBean(MovWardBrowserManager.class);
+
 	public WardPharmacyNew(JFrame owner, Ward ward, ArrayList<MedicalWard> drugs) {
 		super(owner, true);
 		wardDrugs = drugs;
@@ -494,7 +478,6 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
                                         
                     ArrayList<MovementWard> manyMovementWard = new ArrayList<MovementWard>();
                     //MovStockInsertingManager movManager = new MovStockInsertingManager();
-					MovWardBrowserManager wardManager = new MovWardBrowserManager();
                     boolean result;
 					try {
 						// MovementType typeCharge = new

--- a/src/org/isf/medicalstockward/gui/WardPharmacyRectify.java
+++ b/src/org/isf/medicalstockward/gui/WardPharmacyRectify.java
@@ -36,6 +36,7 @@ import org.isf.medicals.model.Medical;
 import org.isf.medicalstockward.manager.MovWardBrowserManager;
 import org.isf.medicalstockward.model.MedicalWard;
 import org.isf.medicalstockward.model.MovementWard;
+import org.isf.menu.manager.Context;
 import org.isf.utils.exception.OHException;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.gui.OHServiceExceptionUtil;
@@ -84,7 +85,8 @@ public class WardPharmacyRectify extends JDialog {
 	private JSpinner jSpinnerNewQty;
 	
 	//Medicals (ALL)
-	private MedicalBrowsingManager medManager = new MedicalBrowsingManager();
+	private MedicalBrowsingManager medManager = Context.getApplicationContext().getBean(MedicalBrowsingManager.class);
+	private MovWardBrowserManager movWardBrowserManager = Context.getApplicationContext().getBean(MovWardBrowserManager.class);
 	private ArrayList<Medical> medicals;
 	private HashMap<String, Medical> medicalMap; //map medicals by their prod_code
 	private HashMap<Integer, Double> wardMap; //map quantities by their medical_id
@@ -269,10 +271,9 @@ public class WardPharmacyRectify extends JDialog {
 						double quantity = stock.doubleValue() - newQty.doubleValue();
 						if (quantity == 0.) return;
 						
-						MovWardBrowserManager wardMan = new MovWardBrowserManager();
 						boolean result;
 						try {
-							result = wardMan.newMovementWard(new MovementWard(
+							result = movWardBrowserManager.newMovementWard(new MovementWard(
 									wardSelected, 
 									new GregorianCalendar(), 
 									false, null, 0, 0, 

--- a/src/org/isf/medstockmovtype/gui/MedicaldsrstockmovTypeBrowser.java
+++ b/src/org/isf/medstockmovtype/gui/MedicaldsrstockmovTypeBrowser.java
@@ -1,9 +1,6 @@
 package org.isf.medstockmovtype.gui;
 
-import java.awt.AWTEvent;
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.Toolkit;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -21,6 +18,7 @@ import org.isf.generaldata.MessageBundle;
 import org.isf.medstockmovtype.gui.MedicaldsrstockmovTypeBrowserEdit.MedicaldsrstockmovTypeListener;
 import org.isf.medstockmovtype.manager.MedicaldsrstockmovTypeBrowserManager;
 import org.isf.medstockmovtype.model.MovementType;
+import org.isf.menu.manager.Context;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.gui.OHServiceExceptionUtil;
 import org.isf.utils.jobjects.ModalJFrame;
@@ -55,7 +53,7 @@ public class MedicaldsrstockmovTypeBrowser extends ModalJFrame implements Medica
 	private JTable jTable = null;
 	private MedicaldsrstockmovTypeBrowserModel model;
 	private int selectedrow;
-	private MedicaldsrstockmovTypeBrowserManager manager = new MedicaldsrstockmovTypeBrowserManager();
+	private MedicaldsrstockmovTypeBrowserManager manager = Context.getApplicationContext().getBean(MedicaldsrstockmovTypeBrowserManager.class);
 	private MovementType medicaldsrstockmovType = null;
 	private final JFrame myFrame;
 	
@@ -244,7 +242,6 @@ public class MedicaldsrstockmovTypeBrowser extends ModalJFrame implements Medica
 		private static final long serialVersionUID = 1L;
 
 		public MedicaldsrstockmovTypeBrowserModel() {
-			MedicaldsrstockmovTypeBrowserManager manager = new MedicaldsrstockmovTypeBrowserManager();
 			try {
 				pMedicaldsrstockmovType = manager.getMedicaldsrstockmovType();
 			} catch (OHServiceException e) {

--- a/src/org/isf/medstockmovtype/gui/MedicaldsrstockmovTypeBrowserEdit.java
+++ b/src/org/isf/medstockmovtype/gui/MedicaldsrstockmovTypeBrowserEdit.java
@@ -19,6 +19,7 @@ import javax.swing.event.EventListenerList;
 import org.isf.generaldata.MessageBundle;
 import org.isf.medstockmovtype.manager.MedicaldsrstockmovTypeBrowserManager;
 import org.isf.medstockmovtype.model.MovementType;
+import org.isf.menu.manager.Context;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.gui.OHServiceExceptionUtil;
 import org.isf.utils.jobjects.VoLimitedTextField;
@@ -87,6 +88,8 @@ public class MedicaldsrstockmovTypeBrowserEdit extends JDialog{
 	private JPanel jCodeLabelPanel = null;
 	private JPanel jDescriptionLabelPanel = null;
 	private JLabel jDescripitonLabel = null;
+
+	private MedicaldsrstockmovTypeBrowserManager manager = Context.getApplicationContext().getBean(MedicaldsrstockmovTypeBrowserManager.class);
 	
 	/**
      * 
@@ -201,7 +204,6 @@ public class MedicaldsrstockmovTypeBrowserEdit extends JDialog{
 					medicaldsrstockmovType.setCode(codeTextField.getText());
 					medicaldsrstockmovType.setType((String) typeComboBox.getSelectedItem());
 					
-					MedicaldsrstockmovTypeBrowserManager manager = new MedicaldsrstockmovTypeBrowserManager();
 					boolean result;
 					if (insert) { // inserting
 						try {

--- a/src/org/isf/medtype/gui/MedicalTypeBrowser.java
+++ b/src/org/isf/medtype/gui/MedicalTypeBrowser.java
@@ -21,6 +21,7 @@ import org.isf.generaldata.MessageBundle;
 import org.isf.medtype.gui.MedicalTypeBrowserEdit.MedicalTypeListener;
 import org.isf.medtype.manager.MedicalTypeBrowserManager;
 import org.isf.medtype.model.MedicalType;
+import org.isf.menu.manager.Context;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.gui.OHServiceExceptionUtil;
 import org.isf.utils.jobjects.ModalJFrame;
@@ -53,7 +54,7 @@ public class MedicalTypeBrowser extends ModalJFrame implements MedicalTypeListen
 	private JTable jTable = null;
 	private MedicalTypeBrowserModel model;
 	private int selectedrow;
-	private MedicalTypeBrowserManager manager = new MedicalTypeBrowserManager();
+	private MedicalTypeBrowserManager manager = Context.getApplicationContext().getBean(MedicalTypeBrowserManager.class);
 	private MedicalType medicalType = null;
 	private final JFrame myFrame;
 	
@@ -236,7 +237,6 @@ public class MedicalTypeBrowser extends ModalJFrame implements MedicalTypeListen
 		private static final long serialVersionUID = 1L;
 
 		public MedicalTypeBrowserModel() {
-			MedicalTypeBrowserManager manager = new MedicalTypeBrowserManager();
 			try {
 				pMedicalType = manager.getMedicalType();
 			} catch (OHServiceException e) {

--- a/src/org/isf/medtype/gui/MedicalTypeBrowserEdit.java
+++ b/src/org/isf/medtype/gui/MedicalTypeBrowserEdit.java
@@ -18,6 +18,7 @@ import javax.swing.event.EventListenerList;
 import org.isf.generaldata.MessageBundle;
 import org.isf.medtype.manager.MedicalTypeBrowserManager;
 import org.isf.medtype.model.MedicalType;
+import org.isf.menu.manager.Context;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.gui.OHServiceExceptionUtil;
 import org.isf.utils.jobjects.VoLimitedTextField;
@@ -83,6 +84,9 @@ public class MedicalTypeBrowserEdit extends JDialog{
 	private JPanel jCodeLabelPanel = null;
 	private JPanel jDescriptionLabelPanel = null;
 	private JLabel jDescripitonLabel = null;
+
+	private MedicalTypeBrowserManager manager = Context.getApplicationContext().getBean(MedicalTypeBrowserManager.class);
+
 	/**
      * 
 	 * This is the default constructor; we pass the arraylist and the selectedrow
@@ -192,7 +196,6 @@ public class MedicalTypeBrowserEdit extends JDialog{
 			okButton.setMnemonic(KeyEvent.VK_O);
 			okButton.addActionListener(new java.awt.event.ActionListener() {
 				public void actionPerformed(java.awt.event.ActionEvent e) {
-					MedicalTypeBrowserManager manager = new MedicalTypeBrowserManager();
 
 					medicalType.setDescription(descriptionTextField.getText());
 					medicalType.setCode(codeTextField.getText());

--- a/src/org/isf/menu/gui/GroupEdit.java
+++ b/src/org/isf/menu/gui/GroupEdit.java
@@ -16,6 +16,7 @@ import javax.swing.JTextField;
 import javax.swing.event.EventListenerList;
 
 import org.isf.generaldata.MessageBundle;
+import org.isf.menu.manager.Context;
 import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.menu.model.UserGroup;
 import org.isf.utils.exception.OHServiceException;
@@ -28,6 +29,8 @@ public class GroupEdit extends JDialog {
 	 */
 	private static final long serialVersionUID = 1L;
 	private EventListenerList groupListeners = new EventListenerList();
+
+	private UserBrowsingManager manager = Context.getApplicationContext().getBean(UserBrowsingManager.class);
 
     public interface GroupListener extends EventListener {
         public void groupUpdated(AWTEvent e);
@@ -200,11 +203,7 @@ public class GroupEdit extends JDialog {
 						return;
 					}
 					
-															
-					UserBrowsingManager manager = new UserBrowsingManager();
-					
 					group.setCode(nameTextField.getText());
-					
 					
 					group.setDesc(descriptionTextField.getText());
 					boolean result = false;

--- a/src/org/isf/menu/gui/Login.java
+++ b/src/org/isf/menu/gui/Login.java
@@ -21,6 +21,7 @@ import javax.swing.JPasswordField;
 import javax.swing.event.EventListenerList;
 
 import org.isf.generaldata.MessageBundle;
+import org.isf.menu.manager.Context;
 import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.menu.model.User;
 import org.isf.utils.db.BCrypt;
@@ -38,6 +39,8 @@ public class Login extends JDialog implements ActionListener, KeyListener {
 	private final Logger logger = LoggerFactory.getLogger(Login.class);
 
 	private EventListenerList loginListeners = new EventListenerList();
+
+	private UserBrowsingManager manager = Context.getApplicationContext().getBean(UserBrowsingManager.class);
 
 	public interface LoginListener extends EventListener {
 		public void loginInserted(AWTEvent e);
@@ -166,7 +169,6 @@ public class Login extends JDialog implements ActionListener, KeyListener {
 
 		public LoginPanel(Login myFrame) {
 
-			UserBrowsingManager manager = new UserBrowsingManager();
             try {
                 users = manager.getUser();
             } catch (OHServiceException e1) {

--- a/src/org/isf/menu/gui/MainMenu.java
+++ b/src/org/isf/menu/gui/MainMenu.java
@@ -96,7 +96,8 @@ public class MainMenu extends JFrame implements ActionListener, Login.LoginListe
 	private boolean debug = false;
 	private MainMenu myFrame;
 
-		
+	private UserBrowsingManager manager = Context.getApplicationContext().getBean(UserBrowsingManager.class);
+
 	public MainMenu() {
 		myFrame = this;
 
@@ -138,7 +139,6 @@ public class MainMenu extends JFrame implements ActionListener, Login.LoginListe
 		}
 
 		// get menu items
-		UserBrowsingManager manager = Context.getApplicationContext().getBean(UserBrowsingManager.class);
         try {
             myMenu = manager.getMenu(myUser);
         } catch (OHServiceException e) {

--- a/src/org/isf/menu/gui/PrivilegeTree.java
+++ b/src/org/isf/menu/gui/PrivilegeTree.java
@@ -26,6 +26,7 @@ import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreePath;
 
 import org.isf.generaldata.MessageBundle;
+import org.isf.menu.manager.Context;
 import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.menu.model.UserGroup;
 import org.isf.menu.model.UserMenuItem;
@@ -47,6 +48,8 @@ class PrivilegeTree extends JDialog {
 	private static final long serialVersionUID = 1L;
 
 	private UserGroup aGroup;
+
+	private UserBrowsingManager manager = Context.getApplicationContext().getBean(UserBrowsingManager.class);
 	
 	public PrivilegeTree(UserGroupBrowsing parent, UserGroup aGroup) {
 		super(parent,MessageBundle.getMessage("angal.menu.menuitmebrowser"),true );
@@ -56,7 +59,6 @@ class PrivilegeTree extends JDialog {
 		setBounds(new Rectangle(r.x+50, r.y+50,280, 350));
 		//setSize(DEFAULT_WIDTH, DEFAULT_HEIGHT);
 		
-		UserBrowsingManager manager = new UserBrowsingManager();
         ArrayList<UserMenuItem> myMenu = null;
         try {
             myMenu = manager.getGroupMenu(aGroup);
@@ -202,7 +204,6 @@ class PrivilegeTree extends JDialog {
 					//System.out.println(umi+" "+umi.isActive());
 					if (!umi.getCode().equals("main")) newUserMenu.add(umi);
 				}	
-				UserBrowsingManager manager = new UserBrowsingManager();
                 try {
                     manager.setGroupMenu(aGroup, newUserMenu);
                 } catch (OHServiceException e1) {

--- a/src/org/isf/menu/gui/UserBrowsing.java
+++ b/src/org/isf/menu/gui/UserBrowsing.java
@@ -23,6 +23,7 @@ import javax.swing.event.AncestorListener;
 import javax.swing.table.DefaultTableModel;
 
 import org.isf.generaldata.MessageBundle;
+import org.isf.menu.manager.Context;
 import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.menu.model.User;
 import org.isf.menu.model.UserGroup;
@@ -120,8 +121,8 @@ public class UserBrowsing extends ModalJFrame implements UserEdit.UserListener {
 	private String pSelection;
 	
 	private UserBrowsing myFrame;
-	private UserBrowsingManager manager = new UserBrowsingManager();
-	
+	private UserBrowsingManager manager = Context.getApplicationContext().getBean(UserBrowsingManager.class);
+
 	public UserBrowsing() {
 		
 		setTitle(MessageBundle.getMessage("angal.menu.usersbrowser"));
@@ -288,7 +289,6 @@ public class UserBrowsing extends ModalJFrame implements UserEdit.UserListener {
 	                        JOptionPane.PLAIN_MESSAGE);				
 					return;									
 				}else {
-				UserBrowsingManager manager = new UserBrowsingManager();
 				User m = (User)(((UserBrowserModel) model).getValueAt(table.getSelectedRow(), -1));
 				int n = JOptionPane.showConfirmDialog(
                         null,
@@ -332,7 +332,6 @@ public class UserBrowsing extends ModalJFrame implements UserEdit.UserListener {
 		private static final long serialVersionUID = 1L;
 
 		public UserBrowserModel(String s) {
-			UserBrowsingManager manager = new UserBrowsingManager();
             try {
                 pUser = manager.getUser(s);
             } catch (OHServiceException e) {
@@ -340,7 +339,6 @@ public class UserBrowsing extends ModalJFrame implements UserEdit.UserListener {
             }
         }
 		public UserBrowserModel() {
-			UserBrowsingManager manager = new UserBrowsingManager();
             try {
                 pUser = manager.getUser();
             } catch (OHServiceException e) {

--- a/src/org/isf/menu/gui/UserEdit.java
+++ b/src/org/isf/menu/gui/UserEdit.java
@@ -22,6 +22,7 @@ import javax.swing.JTextField;
 import javax.swing.event.EventListenerList;
 
 import org.isf.generaldata.MessageBundle;
+import org.isf.menu.manager.Context;
 import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.menu.model.User;
 import org.isf.menu.model.UserGroup;
@@ -93,6 +94,8 @@ public class UserEdit extends JDialog {
     
 	private User user = null;
 	private boolean insert = false;
+
+	private UserBrowsingManager manager = Context.getApplicationContext().getBean(UserBrowsingManager.class);
     
 	/**
      * 
@@ -254,7 +257,6 @@ public class UserEdit extends JDialog {
 					}
 					user.setUserName(userName);
 					user.setDesc(descriptionTextField.getText());
-					UserBrowsingManager manager = new UserBrowsingManager();
 					boolean result = false;
 					if (insert) {
 						char[] password = pwdTextField.getPassword();
@@ -361,7 +363,6 @@ public class UserEdit extends JDialog {
 		if (typeComboBox == null) {
 			typeComboBox = new JComboBox();
 			if (insert) {
-				UserBrowsingManager manager = new UserBrowsingManager();
                 ArrayList<UserGroup> group = null;
                 try {
                     group = manager.getUserGroup();

--- a/src/org/isf/menu/gui/UserGroupBrowsing.java
+++ b/src/org/isf/menu/gui/UserGroupBrowsing.java
@@ -18,6 +18,7 @@ import javax.swing.JTable;
 import javax.swing.table.DefaultTableModel;
 
 import org.isf.generaldata.MessageBundle;
+import org.isf.menu.manager.Context;
 import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.menu.model.UserGroup;
 import org.isf.utils.exception.OHServiceException;
@@ -62,10 +63,10 @@ public class UserGroupBrowsing extends ModalJFrame implements GroupEdit.GroupLis
 	private DefaultTableModel model ;
 	private JTable table;
 	
-	
 	private UserGroupBrowsing myFrame;
-	
-	
+
+	private UserBrowsingManager manager = Context.getApplicationContext().getBean(UserBrowsingManager.class);
+
 	public UserGroupBrowsing() {
 		myFrame = this;
 		setTitle(MessageBundle.getMessage("angal.menu.groupsbrowser"));
@@ -159,7 +160,6 @@ public class UserGroupBrowsing extends ModalJFrame implements GroupEdit.GroupLis
 	                        JOptionPane.PLAIN_MESSAGE);				
 					return;									
 				}else {
-				UserBrowsingManager manager = new UserBrowsingManager();
 				UserGroup m = (UserGroup)(((UserGroupBrowserModel) model).getValueAt(table.getSelectedRow(), -1));
 				int n = JOptionPane.showConfirmDialog(
                         null,
@@ -205,7 +205,6 @@ public class UserGroupBrowsing extends ModalJFrame implements GroupEdit.GroupLis
 		private static final long serialVersionUID = 1L;
 
 		public UserGroupBrowserModel() {
-			UserBrowsingManager manager = new UserBrowsingManager();
             try {
                 pGroup = manager.getUserGroup();
             } catch (OHServiceException e) {

--- a/src/org/isf/priceslist/gui/PricesBrowser.java
+++ b/src/org/isf/priceslist/gui/PricesBrowser.java
@@ -81,7 +81,7 @@ public class PricesBrowser extends ModalJFrame {
     private ArrayList<Operation> operArray;
        
     private PriceNode medNodes;
-    private MedicalBrowsingManager mediManager = new MedicalBrowsingManager();
+    private MedicalBrowsingManager mediManager = Context.getApplicationContext().getBean(MedicalBrowsingManager.class);
     private ArrayList<Medical> mediArray;
     
     private PriceNode othNodes;

--- a/src/org/isf/serviceprinting/gui/MedicalPrintSelection.java
+++ b/src/org/isf/serviceprinting/gui/MedicalPrintSelection.java
@@ -54,6 +54,8 @@ public class MedicalPrintSelection extends JDialog implements ActionListener{
 	private String formatSelected="Java";
 	
 	private PrintManager printManager = Context.getApplicationContext().getBean(PrintManager.class);
+	private MedicalBrowsingManager medicalBrowsingManager = Context.getApplicationContext().getBean(MedicalBrowsingManager.class);
+	private MedicalTypeBrowserManager medicalManager = Context.getApplicationContext().getBean(MedicalTypeBrowserManager.class);
 	
 	public MedicalPrintSelection(JFrame owner){
 		super(owner, true);
@@ -152,10 +154,9 @@ public class MedicalPrintSelection extends JDialog implements ActionListener{
 	}
 	private JComboBox getMedicalBox() {
 		medicalBox = new JComboBox();
-		MedicalBrowsingManager medicalManager = new MedicalBrowsingManager();
 		ArrayList<Medical> medical;
 		try {
-			medical = medicalManager.getMedicals();
+			medical = medicalBrowsingManager.getMedicals();
 		} catch (OHServiceException e1) {
 			medical = null;
 			JOptionPane.showMessageDialog(null, e1.getMessage());
@@ -186,7 +187,6 @@ public class MedicalPrintSelection extends JDialog implements ActionListener{
 	}
 	private JComboBox getMedicalTypeBox() {
 		medicalTypeBox = new JComboBox();
-		MedicalTypeBrowserManager medicalManager = new MedicalTypeBrowserManager();
 		ArrayList<MedicalType> medical;
 		
 		medicalTypeBox.addItem("All");
@@ -246,7 +246,6 @@ public class MedicalPrintSelection extends JDialog implements ActionListener{
 				if(!(medicalTypeBox.getSelectedItem() instanceof String)){
 					medicalType=((MedicalType)medicalTypeBox.getSelectedItem()).getCode();
 				}
-                MedicalBrowsingManager medicalBrowsingManager= new MedicalBrowsingManager();
 				int format = 0;
 				if(formatSelected.equalsIgnoreCase("Java")){
 					format=PrintManager.toDisplay;

--- a/src/org/isf/serviceprinting/gui/MedicalStockSelection.java
+++ b/src/org/isf/serviceprinting/gui/MedicalStockSelection.java
@@ -87,6 +87,9 @@ public class MedicalStockSelection extends JDialog implements ActionListener{
 	private String formatSelected="Java";
 	
 	private PrintManager printManager = Context.getApplicationContext().getBean(PrintManager.class);
+	private MedicalBrowsingManager medicalBrowsingManager = Context.getApplicationContext().getBean(MedicalBrowsingManager.class);
+	private MedicalTypeBrowserManager medicalTypeBrowserManager = Context.getApplicationContext().getBean(MedicalTypeBrowserManager.class);
+	private MedicaldsrstockmovTypeBrowserManager medicaldsrstockmovTypeBrowserManager = Context.getApplicationContext().getBean(MedicaldsrstockmovTypeBrowserManager.class);
 
 	public MedicalStockSelection(JFrame owner) {
 		super(owner, true);
@@ -220,10 +223,9 @@ public class MedicalStockSelection extends JDialog implements ActionListener{
 
 	private JComboBox getMedicalBox() {
 		medicalBox = new JComboBox();
-		MedicalBrowsingManager medicalManager = new MedicalBrowsingManager();
 		ArrayList<Medical> medical;
 		try {
-			medical = medicalManager.getMedicals();
+			medical = medicalBrowsingManager.getMedicals();
 		} catch (OHServiceException e1) {
 			medical = null;
 			JOptionPane.showMessageDialog(null, e1.getMessage());
@@ -263,13 +265,12 @@ public class MedicalStockSelection extends JDialog implements ActionListener{
 
 	private JComboBox getMedicalTypeBox() {
 		medicalTypeBox = new JComboBox();
-		MedicalTypeBrowserManager medicalManager = new MedicalTypeBrowserManager();
 		ArrayList<MedicalType> medical;
 		
 		medicalTypeBox.addItem("All");
 		
 		try {
-			medical = medicalManager.getMedicalType();
+			medical = medicalTypeBrowserManager.getMedicalType();
 			
 			for (MedicalType aMedicalType : medical) {
 				medicalTypeBox.addItem(aMedicalType);
@@ -329,10 +330,9 @@ public class MedicalStockSelection extends JDialog implements ActionListener{
 	}
 	private JComboBox getMovementTypeBox() {
 		movTypeBox = new JComboBox();
-		MedicaldsrstockmovTypeBrowserManager typeManager = new MedicaldsrstockmovTypeBrowserManager();
 		ArrayList<MovementType> type;
 		try {
-			type = typeManager.getMedicaldsrstockmovType();
+			type = medicaldsrstockmovTypeBrowserManager.getMedicaldsrstockmovType();
 		} catch (OHServiceException e1) {
 			type = null;
 			JOptionPane.showMessageDialog(null, e1.getMessage());

--- a/src/org/isf/therapy/gui/TherapyEdit.java
+++ b/src/org/isf/therapy/gui/TherapyEdit.java
@@ -130,7 +130,7 @@ public class TherapyEdit extends JDialog {
 
 	private static final long serialVersionUID = 1L;
 
-	private MedicalBrowsingManager medBrowser = new MedicalBrowsingManager();
+	private MedicalBrowsingManager medBrowser = Context.getApplicationContext().getBean(MedicalBrowsingManager.class);
 	private TherapyManager thManager = Context.getApplicationContext().getBean(TherapyManager.class);
 	private VisitManager vstManager = Context.getApplicationContext().getBean(VisitManager.class);
 	private ArrayList<Medical> medArray;

--- a/src/org/isf/therapy/gui/TherapyEntryForm.java
+++ b/src/org/isf/therapy/gui/TherapyEntryForm.java
@@ -71,7 +71,7 @@ public class TherapyEntryForm extends JDialog {
 	/*
 	 * Managers
 	 */
-	private MedicalBrowsingManager medBrowser = new MedicalBrowsingManager();
+	private MedicalBrowsingManager medBrowser = Context.getApplicationContext().getBean(MedicalBrowsingManager.class);
 	private ArrayList<Medical> medArray = null;
 
 	/*

--- a/src/org/isf/utils/jobjects/JTextFieldSearchModel.java
+++ b/src/org/isf/utils/jobjects/JTextFieldSearchModel.java
@@ -30,6 +30,7 @@ import org.isf.generaldata.GeneralData;
 import org.isf.generaldata.MessageBundle;
 import org.isf.medicals.manager.MedicalBrowsingManager;
 import org.isf.medicals.model.Medical;
+import org.isf.menu.manager.Context;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.gui.OHServiceExceptionUtil;
 import org.isf.utils.jobjects.TextPrompt.Show;
@@ -50,7 +51,9 @@ public class JTextFieldSearchModel extends JPanel {
 	private Object selectedObject;
 	private HashMap<String, Medical> medicalMap;
 	private JDialog owner;
-	
+
+	private MedicalBrowsingManager medMan = Context.getApplicationContext().getBean(MedicalBrowsingManager.class);
+
 	/**
 	 * Creates a Dialog containing a JTextField 
 	 * with search capabilities over a certain model class
@@ -70,7 +73,6 @@ public class JTextFieldSearchModel extends JPanel {
 	}
 
 	private void initializeMedical() {
-		MedicalBrowsingManager medMan = new MedicalBrowsingManager();
 		ArrayList<Medical> medicals = null;
 		medicalMap = new HashMap<String, Medical>();
 		try {

--- a/src/org/isf/xmpp/gui/CommunicationFrame.java
+++ b/src/org/isf/xmpp/gui/CommunicationFrame.java
@@ -36,6 +36,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.text.BadLocationException;
 
 import org.isf.generaldata.MessageBundle;
+import org.isf.menu.manager.Context;
 import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.gui.OHServiceExceptionUtil;
@@ -81,7 +82,7 @@ public class CommunicationFrame extends AbstractCommunicationFrame {
 	private JTextPane userInfo;
 	private ChatMessages area;
 
-
+	private UserBrowsingManager userBrowsingManager = Context.getApplicationContext().getBean(UserBrowsingManager.class);
 
 	public CommunicationFrame(){
 		if (frame==null){
@@ -263,11 +264,10 @@ public class CommunicationFrame extends AbstractCommunicationFrame {
 
 			@Override
 			public void actionPerformed(ActionEvent arg0) {
-				UserBrowsingManager user=new UserBrowsingManager();
 				String user_name = (String)((RosterEntry)buddyList.getSelectedValue()).getName();
                 String info = null;
                 try {
-                    info = user.getUsrInfo(user_name);
+                    info = userBrowsingManager.getUsrInfo(user_name);
                 } catch (OHServiceException e) {
                     OHServiceExceptionUtil.showMessages(e);
                 }


### PR DESCRIPTION
The pull request move Manager to Spring bean instead of manually create new instance.

Furthermore, moved Manager declaration as class attribute instead of method scope declaration.
This avoids declaring the same Manager multiple times in different methods of the same Class and easily understanding which Manager the class depends on.
The result is the same beacause in Spring a bean is Singleton by default, so every time we request it we would always have the same instance.