### PR TITLE
OP-158: Prevent GUI freeze when opening some window due to deadlock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,6 +285,11 @@
 	  		<artifactId>spring-context</artifactId>
 	  		<version>${spring.framework.version}</version>
 	  	</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.5</version>
+		</dependency>
 	  	<!-- <dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -285,11 +285,6 @@
 	  		<artifactId>spring-context</artifactId>
 	  		<version>${spring.framework.version}</version>
 	  	</dependency>
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.5</version>
-		</dependency>
 	  	<!-- <dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>

--- a/src/org/isf/menu/gui/Menu.java
+++ b/src/org/isf/menu/gui/Menu.java
@@ -1,10 +1,5 @@
 package org.isf.menu.gui;
 
-import java.awt.Toolkit;
-import java.io.File;
-
-import javax.swing.JFrame;
-
 import org.apache.log4j.PropertyConfigurator;
 import org.isf.generaldata.Version;
 import org.isf.menu.manager.Context;
@@ -13,6 +8,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import javax.swing.*;
+import java.awt.*;
+import java.io.File;
 
 public class Menu {
 
@@ -31,8 +30,10 @@ public class Menu {
 		checkJavaVersion();
 		JFrame.setDefaultLookAndFeelDecorated(false);
 		new SplashWindow3("rsc"+File.separator+"images"+File.separator+"Splash.jpg",null,3000);
-		WaitCursorEventQueue waitQueue = new WaitCursorEventQueue(10);
-		Toolkit.getDefaultToolkit().getSystemEventQueue().push(waitQueue);
+
+		final EventQueue defaultEventQueue = Toolkit.getDefaultToolkit().getSystemEventQueue();
+		final WaitCursorEventQueue waitQueue = new WaitCursorEventQueue(defaultEventQueue, 10);
+		defaultEventQueue.push(waitQueue);
 	}
 	
 	private static void checkOHVersion() {

--- a/src/org/isf/utils/jobjects/WaitCursorEventQueue.java
+++ b/src/org/isf/utils/jobjects/WaitCursorEventQueue.java
@@ -1,7 +1,5 @@
 package org.isf.utils.jobjects;
 
-import org.apache.commons.lang3.reflect.FieldUtils;
-
 import java.awt.*;
 import java.awt.event.InputEvent;
 import java.util.ArrayList;
@@ -10,10 +8,13 @@ import java.util.ArrayList;
 public class WaitCursorEventQueue extends EventQueue implements DelayTimerCallback {
 	private final CursorManager cursorManager;
 	private final DelayTimer waitTimer;
+	private final EventQueue previousEventQueue;
 
-	public WaitCursorEventQueue(int delay) {
+	public WaitCursorEventQueue(final EventQueue previousEventQueue,
+								final int delay) {
 		this.waitTimer = new DelayTimer(this, delay);
 		this.cursorManager = new CursorManager(waitTimer);
+		this.previousEventQueue = previousEventQueue;
 	}
 
 	public void close() {
@@ -32,13 +33,6 @@ public class WaitCursorEventQueue extends EventQueue implements DelayTimerCallba
 		}
 	}
 
-	private EventQueue previousEventQueue() {
-		try {
-			return (EventQueue) FieldUtils.readField(this, "previousQueue", true);
-		} catch (IllegalAccessException e) {
-			throw new RuntimeException(e);
-		}
-	}
 
 	public AWTEvent getNextEvent() throws InterruptedException {
 		waitTimer.stopTimer();
@@ -47,7 +41,7 @@ public class WaitCursorEventQueue extends EventQueue implements DelayTimerCallba
 
 	public java.util.List<AWTEvent> getNonInputEvents() {
 		final java.util.List<AWTEvent> nonInputEvents = new ArrayList<AWTEvent>();
-		synchronized (previousEventQueue()) {
+		synchronized (previousEventQueue) {
 			synchronized (this) {
 				while (peekEvent() != null) {
 					try {


### PR DESCRIPTION
* Thread 1 (looks like it is the EDT): CursorManager was locking the WaitCursorEventQueue, and then attempt to hold lock on underlying EventQueue
* Thread 2: has lock on the underlying EventQueue tried to hold lock on WaitCursorEventQueue
* Tried to fix this by making sure Thread 1 acquire the underlying EventQueue first, before holding lock on WaitCursorEventQueue (in the same order as Thread 2)