### PR TITLE
OP-139: Upgrading to processing core 2.2.1 (#66)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,13 +207,18 @@
   				</exclusion>
   			</exclusions>
 		</dependency>
-  		<!-- dependency>
-			<groupId>jcu.sal</groupId>
-			<artifactId>sal_isf</artifactId>
-			<version>1.0</version>
-			<scope>system</scope>
-			<systemPath>${project.basedir}/lib/sal_isf.jar</systemPath>
-		</dependency -->
+		<dependency>
+          <groupId>jcu.sal</groupId>
+          <artifactId>sal_isf</artifactId>
+          <version>1.0</version>
+          <scope>system</scope>
+          <systemPath>${project.basedir}/lib/sal_isf.jar</systemPath>
+        </dependency>
+		<dependency>
+			<groupId>com.github.sarxos</groupId>
+			<artifactId>webcam-capture</artifactId>
+			<version>0.3.11</version>
+		</dependency>
 		<dependency>
 			<groupId>jasperreports</groupId>
 			<artifactId>jasperreports</artifactId>
@@ -234,11 +239,6 @@
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
 			<version>2.2</version>
-		</dependency>
-		<dependency>
-		    <groupId>org.processing</groupId>
-		    <artifactId>core</artifactId>
-		    <version>1.2.1</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.rxtx</groupId>
@@ -285,6 +285,32 @@
 	  		<artifactId>spring-context</artifactId>
 	  		<version>${spring.framework.version}</version>
 	  	</dependency>
+		<dependency>
+			<groupId>com.jgoodies</groupId>
+			<artifactId>jgoodies-common</artifactId>
+			<version>1.8.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.jgoodies</groupId>
+			<artifactId>jgoodies-binding</artifactId>
+			<version>2.13.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.jgoodies</groupId>
+			<artifactId>jgoodies-forms</artifactId>
+			<version>1.9.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.jgoodies</groupId>
+			<artifactId>jgoodies-looks</artifactId>
+			<version>2.7.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.jgoodies</groupId>
+			<artifactId>jgoodies-validation</artifactId>
+			<version>2.5.1</version>
+		</dependency>
 	  	<!-- <dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
@@ -316,14 +342,6 @@
                 <id>dcm4che</id>
                 <name>Dcm4Che Repository</name>
                 <url>http://www.dcm4che.org/maven2/</url>
-                <snapshots>
-                    <enabled>false</enabled>
-                </snapshots>
-        </repository>
-        <repository>
-                <id>cytoscape</id>
-                <name>Cytoscape Repository</name>
-                <url>http://code.cytoscape.org/nexus/content/repositories/releases/</url>
                 <snapshots>
                     <enabled>false</enabled>
                 </snapshots>

--- a/src/org/isf/gui/BaseComponent.java
+++ b/src/org/isf/gui/BaseComponent.java
@@ -1,0 +1,70 @@
+package org.isf.gui;
+
+import com.jgoodies.binding.PresentationModel;
+
+public abstract class BaseComponent<PM extends PresentationModel> {
+    PM model;
+
+    /**
+     * Build the panel by initialising the components, building the model, binding the
+     * model, and initialising the event handling.
+     *
+     * @see #initComponents()
+     * @see #buildModel()
+     * @see #bind()
+     * @see #initEventHandling()
+     */
+    public final void build() {
+        try {
+            this.model = buildModel();
+            initComponents();
+            bind();
+            initEventHandling();
+            initGUIState();
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("Unable to construct " + getClass().getName(), e);
+        }
+    }
+
+    /**
+     * Build the model for the panel.
+     */
+    protected PM buildModel()
+            throws Exception {
+        return null;
+    }
+
+    public PM presentationModel() {
+        return model;
+    }
+
+    /**
+     * Initialise any GUI state.
+     */
+    protected void initGUIState() throws Exception {
+    }
+
+    /**
+     * Initialise the components - this will be implemented by JFormDesigner generated code.
+     * @throws Exception dude
+     */
+    protected void initComponents()
+            throws Exception {
+    }
+
+    /**
+     * Bind the components to the model.
+     * @throws Exception dude
+     */
+    protected void bind() throws Exception {
+    }
+
+    /**
+     * Register event handlers.
+     * @throws Exception dude
+     */
+    protected void initEventHandling() throws Exception {
+    }
+
+}

--- a/src/org/isf/utils/image/ImageUtil.java
+++ b/src/org/isf/utils/image/ImageUtil.java
@@ -1,0 +1,42 @@
+package org.isf.utils.image;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+
+public final class ImageUtil {
+    private ImageUtil() {
+    }
+
+    public static BufferedImage scaleImage(final BufferedImage src,
+                                           final int boundWidth,
+                                           final int boundHeight){
+        final int originalWidth = src.getWidth();
+        final int originalHeight = src.getHeight();
+        int newWidth = originalWidth;
+        int newHeight = originalHeight;
+
+        // first check if we need to scale width
+        if (originalWidth > boundWidth) {
+            //scale width to fit
+            newWidth = boundWidth;
+            //scale height to maintain aspect ratio
+            newHeight = (newWidth * originalHeight) / originalWidth;
+        }
+
+        // then check if we need to scale even with the new height
+        if (newHeight > boundHeight) {
+            //scale height to fit instead
+            newHeight = boundHeight;
+            //scale width to maintain aspect ratio
+            newWidth = (newHeight * originalWidth) / originalHeight;
+        }
+
+        final BufferedImage resizedImg = new BufferedImage(newWidth, newHeight, BufferedImage.TYPE_INT_RGB);
+        final Graphics2D g2 = resizedImg.createGraphics();
+        g2.setBackground(Color.WHITE);
+        g2.clearRect(0,0,newWidth, newHeight);
+        g2.drawImage(src, 0, 0, newWidth, newHeight, null);
+        g2.dispose();
+        return resizedImg;
+    }
+}

--- a/src/org/isf/video/PhotoboothTester.java
+++ b/src/org/isf/video/PhotoboothTester.java
@@ -1,0 +1,71 @@
+package org.isf.video;
+
+import com.github.sarxos.webcam.Webcam;
+import org.isf.video.gui.PhotoboothDialog;
+import org.isf.video.gui.PhotoboothPanelModel;
+import org.isf.video.gui.PhotoboothPanelPresentationModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.image.BufferedImage;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+public class PhotoboothTester {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PhotoboothTester.class);
+
+    public static void main(final String[] args) {
+        final Webcam webcam = Webcam.getDefault();
+        final Dimension[] resolutions = webcam.getDevice().getResolutions();
+        final PhotoboothPanelPresentationModel presentationModel = new PhotoboothPanelPresentationModel();
+        presentationModel.addBeanPropertyChangeListener(PhotoboothPanelModel.PROPERTY_IMAGE, new PropertyChangeListener() {
+            @Override
+            public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
+                final Object newValue = propertyChangeEvent.getNewValue();
+                if (newValue instanceof BufferedImage) {
+                    final BufferedImage bufferedImage = (BufferedImage) newValue;
+                    LOGGER.info("New image is being set {}x{}", bufferedImage.getWidth(), bufferedImage.getHeight());
+                }
+            }
+        });
+        presentationModel.addBeanPropertyChangeListener(PhotoboothPanelModel.PROPERTY_RESOLUTION, new PropertyChangeListener() {
+            @Override
+            public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
+                Object newValue = propertyChangeEvent.getNewValue();
+                if (newValue instanceof Dimension) {
+                    final Dimension newDimension = (Dimension) newValue;
+                    LOGGER.info("New dimension is {}x{}", newDimension.getWidth(), newDimension.getHeight());
+                }
+            }
+        });
+
+        // initialise to the highest resolution
+        presentationModel.setResolution(resolutions[resolutions.length - 1]);
+
+        final PhotoboothDialog photoboothDialog = new PhotoboothDialog(presentationModel, new JDialog());
+        photoboothDialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
+        photoboothDialog.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent windowEvent) {
+                // invoked when the dialog itself is being closed
+                super.windowClosing(windowEvent);
+                System.exit(0);
+            }
+
+            @Override
+            public void windowClosed(WindowEvent windowEvent) {
+                // invoked when the dialog's "dispose" is called (programmatically)
+                super.windowClosed(windowEvent);
+                System.exit(0);
+            }
+        });
+        photoboothDialog.setVisible(true);
+        photoboothDialog.toFront();
+        photoboothDialog.requestFocus();
+
+    }
+}

--- a/src/org/isf/video/gui/BottomPanel.java
+++ b/src/org/isf/video/gui/BottomPanel.java
@@ -1,27 +1,16 @@
 package org.isf.video.gui;
 
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.GridLayout;
-import java.awt.Toolkit;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.util.ArrayList;
+import org.isf.video.manager.VideoDeviceStreamAppletManager;
+import org.isf.video.manager.VideoManager;
 
-import javax.swing.BorderFactory;
-import javax.swing.BoxLayout;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
+import javax.swing.*;
 import javax.swing.border.Border;
 import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
-
-import org.isf.video.manager.VideoDeviceStreamAppletManager;
-import org.isf.video.manager.VideoDevicesManager;
-import org.isf.video.manager.VideoManager;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
 
 public class BottomPanel extends JPanel {
 
@@ -78,15 +67,10 @@ public class BottomPanel extends JPanel {
 			public void actionPerformed(ActionEvent e) {
 				
 				String path = selectedPreview.path;
-				String device = selectedPreview.device;
-				
-				if (device.length() > 31)	{
-					device = device.substring(0, 30) + "...";
-				}
-				
+
 				String resolution = selectedPreview.resolution;
 				
-				PhotoFrame photoFrame = new PhotoFrame(path, device, resolution);
+				PhotoFrame photoFrame = new PhotoFrame(path, resolution);
 				photoFrame.setResizable(false);
 				photoFrame.setMaximumSize(photoFrame.getPreferredSize());
 				
@@ -137,7 +121,7 @@ public class BottomPanel extends JPanel {
 		buttonsPanel.add(importPhotoButton);
 	}
 	
-	
+
 	public void setSize (int width)	{
 		//this.setPreferredSize(new Dimension(width, 195));
 		//System.out.println(width);
@@ -152,9 +136,7 @@ public class BottomPanel extends JPanel {
 		String currentResolution = VideoDeviceStreamAppletManager.currentStreamApplet.resolutionWidth
 						+	"x"	+ VideoDeviceStreamAppletManager.currentStreamApplet.resolutionHeight;
 		
-		final PhotoPreviewBox box = new PhotoPreviewBox(path, 
-												VideoDevicesManager.currentVideoDevice.productName,
-												currentResolution);
+		final PhotoPreviewBox box = new PhotoPreviewBox(path, currentResolution);
 		
 		box.photoButton.addActionListener(new ActionListener () {
 			public void actionPerformed(ActionEvent e) {

--- a/src/org/isf/video/gui/PatientPhotoPanel.java
+++ b/src/org/isf/video/gui/PatientPhotoPanel.java
@@ -1,44 +1,27 @@
-	package org.isf.video.gui;
+package org.isf.video.gui;
 
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.EventQueue;
-import java.awt.GridBagConstraints;
-import java.awt.Image;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.IOException;
-import java.util.Date;
-
-import javax.imageio.ImageIO;
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.Icon;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JDialog;
-import javax.swing.JFileChooser;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.filechooser.FileFilter;
-import javax.swing.filechooser.FileNameExtensionFilter;
-
+import com.github.sarxos.webcam.Webcam;
 import org.isf.generaldata.GeneralData;
 import org.isf.generaldata.MessageBundle;
 import org.isf.patient.gui.PatientInsertExtended;
+import org.isf.utils.image.ImageUtil;
 import org.isf.utils.jobjects.Cropping;
 import org.isf.utils.jobjects.IconButton;
-import org.isf.video.manager.VideoDeviceStreamAppletManager;
-import org.isf.video.manager.VideoDevicesManager;
-import org.isf.video.manager.VideoManager;
-import org.isf.video.model.Resolution;
-import org.isf.video.model.VideoDevice;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import javax.swing.filechooser.FileFilter;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.image.BufferedImage;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.io.IOException;
 
 public class PatientPhotoPanel extends JPanel {
 	/**
@@ -50,36 +33,22 @@ public class PatientPhotoPanel extends JPanel {
 
 	// Photo Components:
 	private JPanel jPhotoPanel = null;
-	private String photoFileName = ""; //$NON-NLS-1$
-	private VideoFrame videoFrame = null;
 	private PhotoPanel externalPanel = null;
 	private PatientInsertExtended owner = null;
 	
 	private JButton jGetPhotoButton = null;
 	private JButton jAttachPhotoButton = null;
-	private JButton higherResolutionButton = null;
-	private JButton lowerResolutionButton = null;
-	private JButton switchCamButton = null;
-	private JLabel lblResolution = null;
-	
-	private final static int appletMaximumWidth = 200;
-	private final static int appletMaximumHeight = 160;
-	
-	private final static int BUTTONMODE_showStream = 0;
-	private final static int BUTTONMODE_shootPhoto = 1;
-	
-	private static int buttonMode = BUTTONMODE_showStream;
-	
+
+	private final PhotoboothPanelPresentationModel photoboothPanelPresentationModel;
+
 	public PatientPhotoPanel(final PatientInsertExtended patientFrame, final Integer code, final Image patientPhoto) throws IOException {
 		owner = patientFrame;
+		this.photoboothPanelPresentationModel = new PhotoboothPanelPresentationModel();
 		if (jPhotoPanel == null) {
 			jPhotoPanel = new JPanel();
 			jPhotoPanel = setMyBorder(jPhotoPanel, MessageBundle.getMessage("angal.patient.patientphoto")); //$NON-NLS-1$
 			jPhotoPanel.setLayout(new BorderLayout());
 			jPhotoPanel.setBackground(null);
-			// jPhotoPanel.setBorder(BorderFactory.createLineBorder(Color.lightGray));
-
-			int buttonLeftRightMargin = 5;
 
 			final Image nophoto = ImageIO.read(new File("rsc/images/nophoto.png")); //$NON-NLS-1$
 
@@ -118,6 +87,16 @@ public class PatientPhotoPanel extends JPanel {
 			box.add(Box.createHorizontalGlue());
 
 			externalPanel.add(box, BorderLayout.NORTH);
+			photoboothPanelPresentationModel.addBeanPropertyChangeListener(PhotoboothPanelModel.PROPERTY_IMAGE, new PropertyChangeListener() {
+				@Override
+				public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
+					final BufferedImage newImage = (BufferedImage) propertyChangeEvent.getNewValue();
+					if (newImage != null) {
+						externalPanel.updatePhoto(ImageUtil.scaleImage(newImage, 160, 160));
+						patientFrame.setPatientPhoto(newImage);
+					}
+				}
+			});
 
 			box.add(btnDeletePhoto);
 
@@ -129,10 +108,8 @@ public class PatientPhotoPanel extends JPanel {
 			GridBagConstraints gbs = new GridBagConstraints();
 			gbs.anchor = GridBagConstraints.CENTER;
 			
-			Box buttonBox1 = Box.createHorizontalBox();
-			Box buttonBox2 = Box.createHorizontalBox();
-			//jGetPhotoButtonBox.add(Box.createHorizontalStrut(buttonLeftRightMargin));
-			
+			final Box buttonBox1 = Box.createHorizontalBox();
+
 			jAttachPhotoButton = new JButton(MessageBundle.getMessage("angal.patient.file"));
 			jAttachPhotoButton.setMinimumSize(new Dimension(200, (int) jAttachPhotoButton.getPreferredSize().getHeight()));
 			jAttachPhotoButton.setMaximumSize(new Dimension(200, (int) jAttachPhotoButton.getPreferredSize().getHeight()));
@@ -154,229 +131,46 @@ public class PatientPhotoPanel extends JPanel {
                         cropDiag.setLocationRelativeTo(null);
                         cropDiag.setVisible(true);
                         
-                        //JLabel label = new JLabel(new ImageIcon(cropDiag.getCropped()));
-                		//JOptionPane.showMessageDialog(patientFrame, label, "clipped image", JOptionPane.PLAIN_MESSAGE);
-                		
-                        Image photo = cropDiag.getCropped();
-                        if (photo == null) return;
-                        externalPanel.updatePhoto(photo);
-						patientFrame.setPatientPhoto(photo);
+                        final Image croppedImage = cropDiag.getCropped();
+						if (croppedImage != null) {
+							photoboothPanelPresentationModel.setImage(croppedImage);
+						}
 					}
 				}
 			});
 
-			if (GeneralData.VIDEOMODULEENABLED) {
+			final Webcam webcam = Webcam.getDefault();
+
+			if (GeneralData.VIDEOMODULEENABLED && webcam != null) {
 				jGetPhotoButton = new JButton(MessageBundle.getMessage("angal.patient.newphoto")); //$NON-NLS-1$
 				jGetPhotoButton.setMinimumSize(new Dimension(200, (int) jGetPhotoButton.getPreferredSize().getHeight()));
 				jGetPhotoButton.setMaximumSize(new Dimension(200, (int) jGetPhotoButton.getPreferredSize().getHeight()));
 
-				if (GeneralData.DEBUG) {
-					if (videoFrame == null)
-						videoFrame = new VideoFrame(owner);
+				final Dimension[] resolutions = webcam.getDevice().getResolutions();
+				jGetPhotoButton.addActionListener(new ActionListener() {
+					@Override
+					public void actionPerformed(ActionEvent event) {
+						photoboothPanelPresentationModel.setWebcam(webcam);
+						// start with the highest resolution.
+						photoboothPanelPresentationModel.setResolution(resolutions[resolutions.length - 1]);
 
-					videoFrame.addComponentListener(new java.awt.event.ComponentAdapter() {
-						public void componentHidden(java.awt.event.ComponentEvent e) {
+						final PhotoboothDialog photoBoothDialog = new PhotoboothDialog(photoboothPanelPresentationModel, owner);
+						photoBoothDialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
+						photoBoothDialog.setVisible(true);
+						photoBoothDialog.toFront();
+						photoBoothDialog.requestFocus();
+					}
+				});
 
-							final String filename = videoFrame.selectedPhotoFileName;
-
-							// System.out.println(filename);
-							if (filename != null && !filename.equals("")) { //$NON-NLS-1$
-								photoFileName = filename;
-
-								new Thread(new Runnable() {
-									public void run() {
-										btnDeletePhoto.setVisible(true);
-
-										EventQueue.invokeLater(new Runnable() {
-											public void run() {
-												try {
-													Image photo = ImageIO.read(new File(filename));
-													
-													externalPanel.updatePhoto(photo);
-												} catch (IOException ioe) {
-													ioe.printStackTrace();
-												}
-											}
-										});
-									}
-								}).start();
-							}
-						}
-					});
-					
-					jGetPhotoButton.addActionListener(new ActionListener() {
-						public void actionPerformed(ActionEvent e) {
-							// Updating the devices list
-							int videoDevicesCount = VideoManager.updateDeviceList();
-	
-							// This reset is need in Linux in order to stop the daemon
-							VideoManager.reset(false);
-	
-							// If devices are found, we show the frame
-							// We show only a dialog otherwise
-							if (videoDevicesCount > 0) {
-								new Thread(new Runnable() {
-									public void run() {
-										videoFrame.init(false);
-									}
-								}).start();
-							} else {
-								JOptionPane.showMessageDialog(owner, MessageBundle.getMessage("angal.patient.nowebcamfound")); //$NON-NLS-1$
-							}
-						}
-					});
-					
-					buttonBox1.add(jGetPhotoButton);
-					buttonBox1.add(jAttachPhotoButton);
-				} else {
-					VideoManager.init();
-					
-					Icon switchCamIcon = new ImageIcon("rsc/icons/switchcam.png"); //$NON-NLS-1$
-					switchCamButton = new JButton();
-					switchCamButton.setIcon(switchCamIcon);
-					switchCamButton.addActionListener(new ActionListener(){
-						
-						public void actionPerformed(ActionEvent e) {
-							
-							// Update the devices list
-							VideoManager.reset(true);
-							int videoDevicesCount = VideoManager.updateDeviceList();
-							
-							if (videoDevicesCount > 0)	{
-								logger.debug("idCurrent: " + VideoDevicesManager.idCurrentVideoDevice);
-								
-								VideoDevice device = VideoManager.getNextVideoDevice(VideoDevicesManager.idCurrentVideoDevice);
-								
-								if (device != null)	{
-									showVideoDeviceStream(device);
-								}
-							}
-						}
-					});
-					
-					jGetPhotoButton.addActionListener(new ActionListener() {
-						public void actionPerformed(ActionEvent e) {
-							jAttachPhotoButton.setEnabled(false);
-							switch (buttonMode) {
-								case BUTTONMODE_showStream:
-									// The videomanager reset is needed on Linux in order to stop the daemon for
-									// devices plugin events
-									VideoManager.reset(true);
-									final int videoDevicesCount = VideoManager.updateDeviceList();
-									if (videoDevicesCount > 0)	{
-										VideoDevice device = VideoDevicesManager.currentVideoDevice;
-										if (device == null)	{
-											device = VideoManager.getFirstVideoDevice();
-										} 
-										showVideoDeviceStream(device);
-									}
-									setMode(BUTTONMODE_shootPhoto);
-									break;
-								
-								case BUTTONMODE_shootPhoto:
-									String filename = String.valueOf((new Date()).getTime());
-									photoFileName = VideoManager.savePhoto(externalPanel.applet, filename);
-									String tempDir = VideoManager.shotPhotosTempDir;
-									String extension = VideoManager.shotPhotosExtension;
-									
-									String path = tempDir + photoFileName + extension;
-									
-									CroppingDialog cropDiag = new CroppingDialog(patientFrame, new File(path));
-									cropDiag.pack();
-									cropDiag.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
-									cropDiag.setLocationRelativeTo(null);
-									cropDiag.setVisible(true);
-									    
-									//Image photo = ImageIO.read(new File(path));
-									Image photo = cropDiag.getCropped();
-									if (photo == null) return;
-	
-									externalPanel.updatePhoto(photo);
-									patientFrame.setPatientPhoto(photo);
-									setMode(BUTTONMODE_showStream);
-									jAttachPhotoButton.setEnabled(true);
-									break;
-							}
-						}
-					});
-					
-					
-					higherResolutionButton = new JButton("+"); //$NON-NLS-1$
-					higherResolutionButton.setSize(12, 12);
-					
-					higherResolutionButton.addActionListener(new ActionListener(){
-						
-						public void actionPerformed(ActionEvent e) {
-							VideoDevice device;
-							
-							if ((device = VideoDevicesManager.currentVideoDevice) != null)
-							{
-								Resolution resolution = device.getNextResolution(externalPanel.applet.resolutionWidth,
-										externalPanel.applet.resolutionHeight);
-								
-								if (resolution != null)
-								{
-									VideoManager.setCurrentResolutionAsDefault(resolution.width, resolution.height, 
-											device.deviceIdentificationString);
-									
-									showVideoDeviceStream(device);
-									
-									buttonMode = BUTTONMODE_shootPhoto;
-								}
-							}
-						}
-					});
-					
-					lowerResolutionButton = new JButton("-"); //$NON-NLS-1$
-					lowerResolutionButton.setSize(12, 12);
-					lowerResolutionButton.addActionListener(new ActionListener(){
-						
-						public void actionPerformed(ActionEvent e) {
-							VideoDevice device;
-							
-							if ((device = VideoDevicesManager.currentVideoDevice) != null)
-							{
-								Resolution resolution = device.getPreviousResolution(externalPanel.applet.resolutionWidth,
-										externalPanel.applet.resolutionHeight);
-								
-								if (resolution != null)
-								{
-									VideoManager.setCurrentResolutionAsDefault(resolution.width, resolution.height, 
-											device.deviceIdentificationString);
-									
-									showVideoDeviceStream(device);
-									
-									buttonMode = BUTTONMODE_shootPhoto;
-								}
-							}
-						}
-					});
-					
-					buttonBox1.add(jGetPhotoButton);
-					buttonBox1.add(jAttachPhotoButton);
-					//buttonBox1.add(switchCamButton);
-					
-					lblResolution = new JLabel(MessageBundle.getMessage("angal.patient.quality")+":"); //$NON-NLS-1$
-					buttonBox2.add(Box.createGlue());
-					buttonBox2.add(lblResolution);
-					buttonBox2.add(lowerResolutionButton);
-					buttonBox2.add(higherResolutionButton);
-					buttonBox2.add(switchCamButton);
-					buttonBox2.add(Box.createGlue());
-					
-					setMode(BUTTONMODE_showStream);
-				}
-				
-				buttonBox2.add(Box.createHorizontalStrut(buttonLeftRightMargin));
+				buttonBox1.add(jGetPhotoButton);
+				buttonBox1.add(jAttachPhotoButton);
 			} else {
 				jAttachPhotoButton.setText(MessageBundle.getMessage("angal.patient.loadfile"));
 				buttonBox1.add(jAttachPhotoButton);
 			}
-			
 
 			jPhotoPanel.add(externalPanel, BorderLayout.NORTH);
 			jPhotoPanel.add(buttonBox1, java.awt.BorderLayout.CENTER);
-			jPhotoPanel.add(buttonBox2, java.awt.BorderLayout.SOUTH);
 
 			jPhotoPanel.setMinimumSize(new Dimension((int) getPreferredSize().getWidth(), 100));
 		}
@@ -395,132 +189,6 @@ public class PatientPhotoPanel extends JPanel {
 
 		c.setBorder(b2);
 		return c;
-	}
-	
-	
-	public String getPhotoFilePath()
-	{
-		String tempDir = VideoManager.shotPhotosTempDir;
-		String extension = VideoManager.shotPhotosExtension;
-		
-		StringBuilder path = new StringBuilder(tempDir).append(photoFileName).append(extension);
-		
-		if (GeneralData.DEBUG) return photoFileName;
-		else return path.toString();
-	}
-	
-	
-	// creates an applet with the given id and dimensions 
-	public void showVideoDeviceStream(final VideoDevice device)
-	{
-		/*
-		 * If another videoDevice stream (or the stream of the selected videoDevice at a different resolution)
-		 * is currently being shown, then its applet have to be removed.
-		 */
-		if ((VideoDeviceStreamAppletManager.currentStreamApplet != null) && (VideoDevicesManager.currentVideoDevice != null))	{
-			removeApplet();
-		}
-		
-		device.checkResolutions(false);
-		
-		final int resolutionWidth;
-		final int resolutionHeight;
-		
-		int defResIndex = device.getDefaultResolutionIndex();
-		if (defResIndex != -1)	{
-			resolutionWidth = device.getResolutionWidth(defResIndex);
-			resolutionHeight = device.getResolutionHeight(defResIndex);
-		}
-		else	{
-			resolutionWidth = device.getResolutionWidth(0);
-			resolutionHeight = device.getResolutionHeight(0);
-		}
-		
-		final Dimension appletDimension = calculateAppletDimension(resolutionWidth, resolutionHeight);
-		
-		//updateStatus(id, "wait", resolutionWidth, resolutionHeight, appletWidth, appletHeight);
-		
-		/* Switches the two applets in a different thread */
-		new Thread (new Runnable() {
-			public void run() {
-				enableInteraction(false);
-				
-				final boolean switchOk = VideoDeviceStreamAppletManager
-							.switchApplets(device, resolutionWidth, resolutionHeight, 
-									appletDimension.width, appletDimension.height);
-				
-				EventQueue.invokeLater(new Runnable() {
-					public void run() {
-						if (switchOk)	{
-							externalPanel.addApplet(VideoDeviceStreamAppletManager.currentStreamApplet);
-							
-							//updateCurrentStreamInfo();
-						}
-						enableInteraction(true);
-					}
-				});
-			}
-		}).start();
-	}
-	
-	
-	private void removeApplet()	{
-		//updateStatus(VideoDevicesManager.idCurrentVideoDevice, "stop", -1, -1, -1, -1);
-		
-		externalPanel.removeApplet();
-	}
-	
-	
-	private Dimension calculateAppletDimension(int resolutionWidth, int resolutionHeight)
-	{
-		int appletW, appletH;
-		
-		appletW = appletMaximumWidth;
-		appletH = appletMaximumWidth * resolutionHeight / resolutionWidth;
-		
-		if (appletH > appletMaximumHeight)
-		{
-			appletH = appletMaximumHeight;
-			appletW = appletMaximumHeight * resolutionWidth / resolutionHeight;
-		}
-		
-		System.out.println("Applet dim: " + appletW + "x" + appletH); //$NON-NLS-1$ //$NON-NLS-2$
-		
-		return (new Dimension(appletW, appletH));
-	}
-	
-	
-	private void enableInteraction (boolean enabled)
-	{
-		jGetPhotoButton.setEnabled(enabled);
-		switchCamButton.setEnabled(enabled);
-		lowerResolutionButton.setEnabled(enabled);
-		higherResolutionButton.setEnabled(enabled);
-	}
-	
-	
-	private void setMode (int mode)
-	{
-		buttonMode = mode;
-		
-		switch(mode)
-		{
-			case BUTTONMODE_shootPhoto:
-				switchCamButton.setVisible(true);
-				lowerResolutionButton.setVisible(true);
-				higherResolutionButton.setVisible(true);
-				lblResolution.setVisible(true);
-				repaint();
-				break;
-				
-			case BUTTONMODE_showStream:
-				switchCamButton.setVisible(false);
-				lowerResolutionButton.setVisible(false);
-				higherResolutionButton.setVisible(false);
-				lblResolution.setVisible(false);
-				repaint();
-				break;
-		}
 	}
 }
 
@@ -580,10 +248,6 @@ class CroppingDialog extends JDialog {
 	 * @return the cropped
 	 */
 	public Image getCropped() {
-		if (cropped != null) {
-			return cropped.getScaledInstance(160, 160, Image.SCALE_DEFAULT);
-		} else {
-			return null;
-		}
+		return cropped;
 	}
 }

--- a/src/org/isf/video/gui/PhotoFrame.java
+++ b/src/org/isf/video/gui/PhotoFrame.java
@@ -14,7 +14,7 @@ public class PhotoFrame extends JFrame{
 	 */
 	private static final long serialVersionUID = 1L;
 
-	public PhotoFrame (String path, String device, String resolution)	{
+	public PhotoFrame(String path, String resolution)	{
 		super("Photo preview");
 		
 		Container contentPane = getContentPane();
@@ -27,7 +27,7 @@ public class PhotoFrame extends JFrame{
 		
 		contentPane.add(centerPanel, BorderLayout.CENTER);
 		
-		JLabel photoInfo = new JLabel("<html><center><br>Shoot with: " + device
+		JLabel photoInfo = new JLabel("<html><center> "
 									+ "<br><br>Original picture resolution: " + resolution 
 									+ "<br><br></center></html>");		
 		

--- a/src/org/isf/video/gui/PhotoPanel.java
+++ b/src/org/isf/video/gui/PhotoPanel.java
@@ -1,13 +1,9 @@
 package org.isf.video.gui;
 
-import java.awt.Dimension;
-import java.awt.Graphics;
-import java.awt.Image;
-
-import javax.swing.ImageIcon;
-import javax.swing.JPanel;
-
 import org.isf.video.manager.VideoDeviceStreamApplet;
+
+import javax.swing.*;
+import java.awt.*;
 
 class PhotoPanel extends JPanel {
 
@@ -17,12 +13,7 @@ class PhotoPanel extends JPanel {
 	public VideoDeviceStreamApplet applet;
 	private Dimension dimension;
 
-	public PhotoPanel(String img) {
-		setLayout(null);
-		updatePhoto(new ImageIcon(img).getImage());
-	}
-
-	public PhotoPanel(Image img) {
+	public PhotoPanel(final Image img) {
 		setLayout(null);
 		updatePhoto(img);
 	}
@@ -35,16 +26,7 @@ class PhotoPanel extends JPanel {
 
 		repaint();
 	}
-	
-	public void addApplet (VideoDeviceStreamApplet applet) {
-		this.applet = applet;
-		this.img = null;
-		
-		Dimension dimension = new Dimension(applet.appletWidth, applet.appletHeight);
-		refreshPanel(dimension);
-		add(applet);
-	}
-	
+
 	public void removeApplet () {
 		if (this.applet != null)
 		{

--- a/src/org/isf/video/gui/PhotoPreviewBox.java
+++ b/src/org/isf/video/gui/PhotoPreviewBox.java
@@ -1,16 +1,10 @@
 package org.isf.video.gui;
 
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Image;
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import java.awt.*;
 import java.io.File;
 import java.io.IOException;
-
-import javax.imageio.ImageIO;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
 
 public class PhotoPreviewBox extends Box {
 
@@ -26,14 +20,12 @@ public class PhotoPreviewBox extends Box {
 	
 	public String path;
 	public String resolution;
-	public String device;
-	
-	public PhotoPreviewBox(String path, String device, String resolution)	{
+
+	public PhotoPreviewBox(String path, String resolution)	{
 		//lstPhotoPaths.add(path);
 		super(BoxLayout.Y_AXIS) ;
 		
 		this.path = path;
-		this.device = device;
 		this.resolution = resolution;
 		
 		Box.createVerticalBox();

--- a/src/org/isf/video/gui/PhotoboothComponent.java
+++ b/src/org/isf/video/gui/PhotoboothComponent.java
@@ -1,0 +1,162 @@
+package org.isf.video.gui;
+
+import java.awt.*;
+import com.jgoodies.forms.factories.CC;
+import com.jgoodies.forms.layout.FormLayout;
+import org.isf.gui.BaseComponent;
+
+import javax.swing.*;
+/*
+ * Created by JFormDesigner on Mon Mar 09 21:10:41 AEDT 2020
+ */
+
+
+
+/**
+ * @author User #1
+ */
+public class PhotoboothComponent extends BaseComponent<PhotoboothPanelPresentationModel> {
+
+	public JPanel getPhotoBoothPanel() {
+		return photoBoothPanel;
+	}
+
+	public JPanel getPhotoContainer() {
+		return photoContainer;
+	}
+
+	public JPanel getStreamingPanel() {
+		return streamingPanel;
+	}
+
+	public JPanel getSnapshotPanel() {
+		return snapshotPanel;
+	}
+
+	public JButton getCaptureButton() {
+		return captureButton;
+	}
+
+	public JButton getOkButton() {
+		return okButton;
+	}
+
+	public JButton getCancelButton() {
+		return cancelButton;
+	}
+
+	public JPanel getButtonContainer() {
+		return buttonContainer;
+	}
+
+	public void initComponents() {
+		// JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
+		photoBoothPanel = new JPanel();
+		photoContainer = new JPanel();
+		streamingPanel = new JPanel();
+		snapshotPanel = new JPanel();
+		resolutionPanel = new JPanel();
+		webcamLabel = new JLabel();
+		webcamComboBox = new JComboBox();
+		resolutionLabel = new JLabel();
+		resolutionComboBox = new JComboBox();
+		captureButton = new JButton();
+		buttonContainer = new JPanel();
+		okButton = new JButton();
+		cancelButton = new JButton();
+
+		//======== photoBoothPanel ========
+		{
+			photoBoothPanel.setLayout(new FormLayout(
+				"$ugap, $lcgap, default:grow, $lcgap, $ugap",
+				"$ugap, $lgap, fill:default:grow, 2*($lgap, default), $lgap, $ugap"));
+
+			//======== photoContainer ========
+			{
+				photoContainer.setLayout(new FormLayout(
+					"default:grow, $lcgap, default:grow",
+					"fill:default:grow"));
+				((FormLayout)photoContainer.getLayout()).setColumnGroups(new int[][] {{1, 3}});
+
+				//======== streamingPanel ========
+				{
+					streamingPanel.setPreferredSize(new Dimension(300, 200));
+					streamingPanel.setMinimumSize(new Dimension(300, 200));
+					streamingPanel.setLayout(new FormLayout(
+						"default:grow",
+						"default:grow"));
+				}
+				photoContainer.add(streamingPanel, CC.xy(1, 1));
+
+				//======== snapshotPanel ========
+				{
+					snapshotPanel.setMinimumSize(new Dimension(300, 200));
+					snapshotPanel.setPreferredSize(new Dimension(300, 200));
+					snapshotPanel.setLayout(new FormLayout(
+						"default:grow",
+						"default:grow"));
+				}
+				photoContainer.add(snapshotPanel, CC.xy(3, 1));
+			}
+			photoBoothPanel.add(photoContainer, CC.xy(3, 3, CC.FILL, CC.FILL));
+
+			//======== resolutionPanel ========
+			{
+				resolutionPanel.setLayout(new FormLayout(
+					"default, 3*($lcgap), default, $lcgap, $rgap, $lcgap, default, 3*($lcgap), default, $lcgap, $button",
+					"default"));
+
+				//---- webcamLabel ----
+				webcamLabel.setText("Webcam");
+				resolutionPanel.add(webcamLabel, CC.xy(1, 1));
+				resolutionPanel.add(webcamComboBox, CC.xy(5, 1));
+
+				//---- resolutionLabel ----
+				resolutionLabel.setText("Resolution");
+				resolutionPanel.add(resolutionLabel, CC.xy(9, 1));
+				resolutionPanel.add(resolutionComboBox, CC.xy(13, 1));
+
+				//---- captureButton ----
+				captureButton.setText("Capture");
+				resolutionPanel.add(captureButton, CC.xy(15, 1));
+			}
+			photoBoothPanel.add(resolutionPanel, CC.xy(3, 5, CC.CENTER, CC.DEFAULT));
+
+			//======== buttonContainer ========
+			{
+				buttonContainer.setLayout(new FormLayout(
+					"$button, $lcgap, $button",
+					"default"));
+
+				//---- okButton ----
+				okButton.setText("OK");
+				buttonContainer.add(okButton, CC.xy(1, 1));
+
+				//---- cancelButton ----
+				cancelButton.setText("Cancel");
+				buttonContainer.add(cancelButton, CC.xy(3, 1));
+			}
+			photoBoothPanel.add(buttonContainer, CC.xy(3, 7, CC.RIGHT, CC.DEFAULT));
+		}
+		// JFormDesigner - End of component initialization  //GEN-END:initComponents
+	}
+
+	// JFormDesigner - Variables declaration - DO NOT MODIFY  //GEN-BEGIN:variables
+	private JPanel photoBoothPanel;
+	private JPanel photoContainer;
+	private JPanel streamingPanel;
+	private JPanel snapshotPanel;
+	private JPanel resolutionPanel;
+	private JLabel webcamLabel;
+	protected JComboBox webcamComboBox;
+	private JLabel resolutionLabel;
+	protected JComboBox resolutionComboBox;
+	private JButton captureButton;
+	private JPanel buttonContainer;
+	private JButton okButton;
+	private JButton cancelButton;
+	// JFormDesigner - End of variables declaration  //GEN-END:variables
+
+
+
+}

--- a/src/org/isf/video/gui/PhotoboothComponent.jfd
+++ b/src/org/isf/video/gui/PhotoboothComponent.jfd
@@ -1,0 +1,140 @@
+JFDML JFormDesigner: "5.2.5.0.333" Java: "1.8.0_242" encoding: "UTF-8"
+
+new FormModel {
+	contentType: "form/swing"
+	root: new FormRoot {
+		add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class com.jgoodies.forms.layout.FormLayout ) {
+			"$columnSpecs": "unrelgap, labelcompgap, default:grow, labelcompgap, unrelgap"
+			"$rowSpecs": "unrelgap, linegap, fill:default:grow, linegap, default, linegap, default, linegap, unrelgap"
+		} ) {
+			name: "photoBoothPanel"
+			auxiliary() {
+				"JavaCodeGenerator.variableGetter": true
+			}
+			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class com.jgoodies.forms.layout.FormLayout ) {
+				"$columnSpecs": "default:grow, labelcompgap, default:grow"
+				"$rowSpecs": "fill:default:grow"
+				"$columnGroupIds": "1, 0, 1"
+			} ) {
+				name: "photoContainer"
+				auxiliary() {
+					"JavaCodeGenerator.variableGetter": true
+				}
+				add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class com.jgoodies.forms.layout.FormLayout ) {
+					"$columnSpecs": "default:grow"
+					"$rowSpecs": "default:grow"
+				} ) {
+					name: "streamingPanel"
+					"preferredSize": new java.awt.Dimension( 300, 200 )
+					"minimumSize": new java.awt.Dimension( 300, 200 )
+					auxiliary() {
+						"JavaCodeGenerator.variableGetter": true
+					}
+				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) )
+				add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class com.jgoodies.forms.layout.FormLayout ) {
+					"$columnSpecs": "default:grow"
+					"$rowSpecs": "default:grow"
+				} ) {
+					name: "snapshotPanel"
+					"minimumSize": new java.awt.Dimension( 300, 200 )
+					"preferredSize": new java.awt.Dimension( 300, 200 )
+					auxiliary() {
+						"JavaCodeGenerator.variableGetter": true
+					}
+				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
+					"gridX": 3
+					"gridY": 1
+				} )
+			}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
+				"gridX": 3
+				"gridY": 3
+				"hAlign": sfield com.jgoodies.forms.layout.CellConstraints FILL
+				"vAlign": sfield com.jgoodies.forms.layout.CellConstraints FILL
+			} )
+			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class com.jgoodies.forms.layout.FormLayout ) {
+				"$columnSpecs": "default, labelcompgap, labelcompgap, labelcompgap, default, labelcompgap, relgap, labelcompgap, default, labelcompgap, labelcompgap, labelcompgap, default, labelcompgap, button"
+				"$rowSpecs": "default"
+			} ) {
+				name: "resolutionPanel"
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "webcamLabel"
+					"text": "Webcam"
+				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
+					"gridX": 1
+					"gridY": 1
+				} )
+				add( new FormComponent( "javax.swing.JComboBox" ) {
+					name: "webcamComboBox"
+					auxiliary() {
+						"JavaCodeGenerator.variableModifiers": 4
+					}
+				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
+					"gridX": 5
+					"gridY": 1
+				} )
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "resolutionLabel"
+					"text": "Resolution"
+				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
+					"gridX": 9
+					"gridY": 1
+				} )
+				add( new FormComponent( "javax.swing.JComboBox" ) {
+					name: "resolutionComboBox"
+					auxiliary() {
+						"JavaCodeGenerator.variableModifiers": 4
+					}
+				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
+					"gridX": 13
+				} )
+				add( new FormComponent( "javax.swing.JButton" ) {
+					name: "captureButton"
+					"text": "Capture"
+					auxiliary() {
+						"JavaCodeGenerator.variableGetter": true
+					}
+				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
+					"gridX": 15
+				} )
+			}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
+				"gridX": 3
+				"gridY": 5
+				"hAlign": sfield com.jgoodies.forms.layout.CellConstraints CENTER
+			} )
+			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class com.jgoodies.forms.layout.FormLayout ) {
+				"$columnSpecs": "button, labelcompgap, button"
+				"$rowSpecs": "default"
+			} ) {
+				name: "buttonContainer"
+				auxiliary() {
+					"JavaCodeGenerator.variableGetter": true
+				}
+				add( new FormComponent( "javax.swing.JButton" ) {
+					name: "okButton"
+					"text": "OK"
+					auxiliary() {
+						"JavaCodeGenerator.variableGetter": true
+					}
+				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
+					"gridX": 1
+				} )
+				add( new FormComponent( "javax.swing.JButton" ) {
+					name: "cancelButton"
+					"text": "Cancel"
+					auxiliary() {
+						"JavaCodeGenerator.variableGetter": true
+					}
+				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
+					"gridX": 3
+				} )
+			}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
+				"gridX": 3
+				"gridY": 7
+				"hAlign": sfield com.jgoodies.forms.layout.CellConstraints RIGHT
+			} )
+		}, new FormLayoutConstraints( null ) {
+			"location": new java.awt.Point( 0, 0 )
+			"size": new java.awt.Dimension( 1345, 610 )
+		} )
+	}
+}

--- a/src/org/isf/video/gui/PhotoboothComponentImpl.java
+++ b/src/org/isf/video/gui/PhotoboothComponentImpl.java
@@ -1,0 +1,247 @@
+package org.isf.video.gui;
+
+import com.github.sarxos.webcam.Webcam;
+import com.github.sarxos.webcam.WebcamPanel;
+import com.jgoodies.binding.adapter.ComboBoxAdapter;
+import com.jgoodies.binding.list.SelectionInList;
+import com.jgoodies.forms.factories.CC;
+import org.isf.utils.image.ImageUtil;
+import org.isf.utils.jobjects.Cropping;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.image.BufferedImage;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class PhotoboothComponentImpl extends PhotoboothComponent {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PhotoboothComponentImpl.class);
+    private static final DefaultListCellRenderer RESOLUTION_DROPDOWN_OPTION_RENDERER = new DefaultListCellRenderer() {
+        @Override
+        public Component getListCellRendererComponent(final JList list,
+                                                      final Object value,
+                                                      final int index,
+                                                      final boolean isSelected,
+                                                      final boolean cellHasFocus) {
+            final Component component = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            if (value != null && value instanceof Dimension) {
+                final Dimension valueAsDimension = (Dimension) value;
+                setText(String.format("%d x %d", (int) valueAsDimension.getWidth(), (int) valueAsDimension.getHeight()));
+            }
+            return component;
+        }
+    };
+    private static final DefaultListCellRenderer WEBCAM_DROPDOWN_OPTION_RENDERER = new DefaultListCellRenderer() {
+        @Override
+        public Component getListCellRendererComponent(final JList list,
+                                                      final Object value,
+                                                      final int index,
+                                                      final boolean isSelected,
+                                                      final boolean cellHasFocus) {
+            final Component component = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            if (value != null && value instanceof Webcam) {
+                final Webcam webcam = (Webcam) value;
+                setText(webcam.getName());
+            }
+            return component;
+        }
+    };
+
+    private Webcam webcam;
+    private final List<Dimension> supportedResolutions;
+    private WebcamPanel webcamPanel;
+    private final PhotoboothPanelPresentationModel photoboothPanelPresentationModel;
+    private final JDialog owner;
+    private Cropping cropping;
+    private Action okAction;
+    private PropertyChangeListener webcamResolutionChangeListener;
+    private final List<Webcam> allWebcams;
+    private ComboBoxAdapter<Dimension> resolutionModel;
+    private final SelectionInList<Dimension> dimensionSelectionInList;
+    private PropertyChangeListener webcamChangeListener;
+
+
+    public PhotoboothComponentImpl(final PhotoboothPanelPresentationModel model,
+                                   final JDialog owner) {
+        this.photoboothPanelPresentationModel = model;
+        this.owner = owner;
+
+        this.allWebcams = Webcam.getWebcams();
+        this.webcam = Webcam.getDefault();
+
+        this.supportedResolutions = new ArrayList<Dimension>();
+        Collections.addAll(supportedResolutions, webcam.getDevice().getResolutions());
+        dimensionSelectionInList = new SelectionInList<Dimension>(supportedResolutions);
+    }
+
+    @Override
+    public void initComponents() {
+        super.initComponents();
+
+        // set initial size of all photo panels to use the resolution defined on the model
+        getStreamingPanel().setPreferredSize(photoboothPanelPresentationModel.getResolution());
+        getStreamingPanel().setMinimumSize(photoboothPanelPresentationModel.getResolution());
+        getSnapshotPanel().setPreferredSize(photoboothPanelPresentationModel.getResolution());
+        getSnapshotPanel().setMinimumSize(photoboothPanelPresentationModel.getResolution());
+        this.resolutionComboBox.setRenderer(RESOLUTION_DROPDOWN_OPTION_RENDERER);
+        this.webcamComboBox.setRenderer(WEBCAM_DROPDOWN_OPTION_RENDERER);
+
+        this.webcam.setViewSize(photoboothPanelPresentationModel.getResolution());
+        this.webcamPanel = new WebcamPanel(webcam, false);
+        getStreamingPanel().add(webcamPanel, CC.xy(1, 1));
+    }
+
+    @Override
+    protected void initGUIState() throws Exception {
+        super.initGUIState();
+        this.okAction.setEnabled(false);
+        this.webcamPanel.start();
+    }
+
+    @Override
+    protected void bind() throws Exception {
+        super.bind();
+        this.resolutionModel = new ComboBoxAdapter(
+                dimensionSelectionInList,
+                photoboothPanelPresentationModel.getModel(PhotoboothPanelModel.PROPERTY_RESOLUTION)
+        );
+        this.resolutionComboBox.setModel(resolutionModel);
+
+        this.webcamComboBox.setModel(new ComboBoxAdapter(
+                allWebcams,
+                photoboothPanelPresentationModel.getModel(PhotoboothPanelModel.PROPERTY_WEBCAM)
+        ));
+
+        webcamResolutionChangeListener = new PropertyChangeListener() {
+            @Override
+            public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
+                final Object newValue = propertyChangeEvent.getNewValue();
+                if (newValue != null && newValue instanceof Dimension) {
+                    PhotoboothComponentImpl.this.stopWebcam();
+
+                    LOGGER.info("Changing webcam dimension to {}", newValue);
+                    webcam.setViewSize((Dimension) newValue);
+                    PhotoboothComponentImpl.this.getStreamingPanel().setPreferredSize((Dimension) newValue);
+                    PhotoboothComponentImpl.this.getStreamingPanel().setMinimumSize((Dimension) newValue);
+                    PhotoboothComponentImpl.this.getSnapshotPanel().setPreferredSize((Dimension) newValue);
+                    PhotoboothComponentImpl.this.getSnapshotPanel().setMinimumSize((Dimension) newValue);
+
+                    webcamPanel = new WebcamPanel(webcam);
+                    PhotoboothComponentImpl.this.getStreamingPanel().add(webcamPanel, CC.xy(1, 1));
+                    owner.pack();
+                    owner.repaint();
+                    owner.validate();
+                }
+            }
+        };
+        photoboothPanelPresentationModel.addBeanPropertyChangeListener(PhotoboothPanelModel.PROPERTY_RESOLUTION, webcamResolutionChangeListener);
+
+        webcamChangeListener = new PropertyChangeListener() {
+            @Override
+            public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
+                final Object newValue = propertyChangeEvent.getNewValue();
+                if (newValue != null && newValue instanceof Webcam) {
+                    PhotoboothComponentImpl.this.stopWebcam();
+
+                    webcam = (Webcam) newValue;
+                    LOGGER.info("Webcam changed to {}", webcam.getName());
+
+                    supportedResolutions.clear();
+                    final Dimension[] allResolutions = webcam.getDevice().getResolutions();
+                    Collections.addAll(supportedResolutions, allResolutions);
+                    dimensionSelectionInList.fireContentsChanged(0, supportedResolutions.size() - 1);
+
+                    // set to highest resolution
+                    photoboothPanelPresentationModel.setResolution(allResolutions[allResolutions.length - 1]);
+                    webcam.setViewSize(photoboothPanelPresentationModel.getResolution());
+                    PhotoboothComponentImpl.this.getStreamingPanel().setPreferredSize(photoboothPanelPresentationModel.getResolution());
+                    PhotoboothComponentImpl.this.getStreamingPanel().setMinimumSize(photoboothPanelPresentationModel.getResolution());
+                    PhotoboothComponentImpl.this.getSnapshotPanel().setPreferredSize(photoboothPanelPresentationModel.getResolution());
+                    PhotoboothComponentImpl.this.getSnapshotPanel().setMinimumSize(photoboothPanelPresentationModel.getResolution());
+
+                    webcamPanel = new WebcamPanel(webcam);
+                    PhotoboothComponentImpl.this.getStreamingPanel().add(webcamPanel, CC.xy(1, 1));
+                    owner.pack();
+                    owner.repaint();
+                    owner.validate();
+
+                }
+            }
+        };
+        photoboothPanelPresentationModel.addBeanPropertyChangeListener(PhotoboothPanelModel.PROPERTY_WEBCAM, webcamChangeListener);
+    }
+
+    private void stopWebcam() {
+        webcamPanel.stop();
+        webcam.close();
+        getStreamingPanel().remove(webcamPanel);
+    }
+
+    @Override
+    protected PhotoboothPanelPresentationModel buildModel()  {
+        return photoboothPanelPresentationModel;
+    }
+
+    @Override
+    protected void initEventHandling() throws Exception {
+        super.initEventHandling();
+
+        this.okAction = new AbstractAction("OK") {
+            @Override
+            public void actionPerformed(final ActionEvent actionEvent) {
+                // change image on the model, based on the cropped image
+                presentationModel().setImage(cropping.clipImage());
+                cleanup();
+                owner.dispose();
+            }
+        };
+        getOkButton().setAction(okAction);
+
+        getCancelButton().addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent actionEvent) {
+                PhotoboothComponentImpl.this.presentationModel().triggerFlush();
+                PhotoboothComponentImpl.this.cleanup();
+                owner.dispose();
+            }
+        });
+
+        getCaptureButton().addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent actionEvent) {
+                final Dimension currentResolution = photoboothPanelPresentationModel.getResolution();
+                // resize the image to match the current selected resolution. This is because under some circumstances, the
+                // webcam's viewSize seems to be different from the currently selected resolution. Weird. i know..
+                final BufferedImage resizedImage = ImageUtil.scaleImage(webcam.getImage(), (int) currentResolution.getWidth(), (int) currentResolution.getHeight());
+
+                // set image on the cropping panel.
+                cropping = new Cropping(resizedImage);
+                okAction.setEnabled(true);
+                SwingUtilities.invokeLater(new Runnable() {
+                    @Override
+                    public void run() {
+                        PhotoboothComponentImpl.this.getSnapshotPanel().removeAll();
+                        PhotoboothComponentImpl.this.getSnapshotPanel().add(cropping, CC.xy(1, 1));
+                        PhotoboothComponentImpl.this.getPhotoBoothPanel().repaint();
+                        PhotoboothComponentImpl.this.getPhotoBoothPanel().revalidate();
+                    }
+                });
+            }
+        });
+    }
+
+    public void cleanup() {
+        stopWebcam();
+
+        // need to remove listener here, to prevent memory leak the next time we open the photo frame again.
+        photoboothPanelPresentationModel.removeBeanPropertyChangeListener(PhotoboothPanelModel.PROPERTY_RESOLUTION, webcamResolutionChangeListener);
+        photoboothPanelPresentationModel.removeBeanPropertyChangeListener(PhotoboothPanelModel.PROPERTY_WEBCAM, webcamChangeListener);
+    }
+}

--- a/src/org/isf/video/gui/PhotoboothComponentImpl.java
+++ b/src/org/isf/video/gui/PhotoboothComponentImpl.java
@@ -133,6 +133,8 @@ public final class PhotoboothComponentImpl extends PhotoboothComponent {
                     PhotoboothComponentImpl.this.getSnapshotPanel().setPreferredSize((Dimension) newValue);
                     PhotoboothComponentImpl.this.getSnapshotPanel().setMinimumSize((Dimension) newValue);
 
+                    LOGGER.info("Closing webcam before attaching to panel.");
+                    webcam.close();
                     webcamPanel = new WebcamPanel(webcam);
                     PhotoboothComponentImpl.this.getStreamingPanel().add(webcamPanel, CC.xy(1, 1));
                     owner.pack();
@@ -160,12 +162,18 @@ public final class PhotoboothComponentImpl extends PhotoboothComponent {
 
                     // set to highest resolution
                     photoboothPanelPresentationModel.setResolution(allResolutions[allResolutions.length - 1]);
+                    LOGGER.info("Closing webcam {} before changing resolution", webcam.getName());
+                    webcam.close();
+
+                    LOGGER.info("Changing resolution to {}", photoboothPanelPresentationModel.getResolution());
                     webcam.setViewSize(photoboothPanelPresentationModel.getResolution());
+
                     PhotoboothComponentImpl.this.getStreamingPanel().setPreferredSize(photoboothPanelPresentationModel.getResolution());
                     PhotoboothComponentImpl.this.getStreamingPanel().setMinimumSize(photoboothPanelPresentationModel.getResolution());
                     PhotoboothComponentImpl.this.getSnapshotPanel().setPreferredSize(photoboothPanelPresentationModel.getResolution());
                     PhotoboothComponentImpl.this.getSnapshotPanel().setMinimumSize(photoboothPanelPresentationModel.getResolution());
 
+                    LOGGER.info("Attaching webcam {} to panel", webcam.getName());
                     webcamPanel = new WebcamPanel(webcam);
                     PhotoboothComponentImpl.this.getStreamingPanel().add(webcamPanel, CC.xy(1, 1));
                     owner.pack();

--- a/src/org/isf/video/gui/PhotoboothDialog.java
+++ b/src/org/isf/video/gui/PhotoboothDialog.java
@@ -1,0 +1,28 @@
+package org.isf.video.gui;
+
+import javax.swing.*;
+import java.awt.*;
+
+public final class PhotoboothDialog extends JDialog {
+
+    private final PhotoboothComponentImpl photoboothComponent;
+
+    public PhotoboothDialog(final PhotoboothPanelPresentationModel model,
+                            final Dialog owner) {
+        super(owner, true);
+        photoboothComponent = new PhotoboothComponentImpl(model, this);
+        photoboothComponent.build();
+
+        this.add(photoboothComponent.getPhotoBoothPanel());
+        pack();
+        setResizable(false);
+        setLocationRelativeTo(null);
+    }
+
+    @Override
+    public void dispose() {
+        photoboothComponent.cleanup();
+        super.dispose();
+    }
+
+}

--- a/src/org/isf/video/gui/PhotoboothPanelModel.java
+++ b/src/org/isf/video/gui/PhotoboothPanelModel.java
@@ -1,0 +1,45 @@
+package org.isf.video.gui;
+
+import com.github.sarxos.webcam.Webcam;
+import com.jgoodies.binding.beans.Model;
+
+import java.awt.*;
+
+public final class PhotoboothPanelModel extends Model {
+    public static final String PROPERTY_IMAGE = "image";
+    public static final String PROPERTY_RESOLUTION = "resolution";
+    public static final String PROPERTY_WEBCAM = "webcam";
+    private Image image;
+    private Dimension resolution;
+    private Webcam webcam;
+
+    public Image getImage() {
+        return image;
+    }
+
+    public void setImage(final Image newValue) {
+        final Image oldValue = this.image;
+        this.image = newValue;
+        this.firePropertyChange(PROPERTY_IMAGE, oldValue, newValue);
+    }
+
+    public Dimension getResolution() {
+        return resolution;
+    }
+
+    public void setResolution(final Dimension resolution) {
+        Dimension oldValue = this.resolution;
+        this.resolution = resolution;
+        this.firePropertyChange(PROPERTY_RESOLUTION, oldValue, resolution);
+    }
+
+    public Webcam getWebcam() {
+        return webcam;
+    }
+
+    public void setWebcam(final Webcam webcam) {
+        Webcam oldValue = this.webcam;
+        this.webcam = webcam;
+        this.firePropertyChange(PROPERTY_WEBCAM, oldValue, webcam);
+    }
+}

--- a/src/org/isf/video/gui/PhotoboothPanelPresentationModel.java
+++ b/src/org/isf/video/gui/PhotoboothPanelPresentationModel.java
@@ -1,0 +1,29 @@
+package org.isf.video.gui;
+
+import com.github.sarxos.webcam.Webcam;
+import com.jgoodies.binding.PresentationModel;
+
+import java.awt.*;
+
+public final class PhotoboothPanelPresentationModel extends PresentationModel<PhotoboothPanelModel> {
+
+    public PhotoboothPanelPresentationModel() {
+        super(new PhotoboothPanelModel());
+    }
+
+    public void setImage(final Image image) {
+        getBean().setImage(image);
+    }
+
+    public Dimension getResolution() {
+        return getBean().getResolution();
+    }
+
+    public void setResolution(final Dimension resolution) {
+        getBean().setResolution(resolution);
+    }
+
+    public void setWebcam(final Webcam webcam) {
+        getBean().setWebcam(webcam);
+    }
+}


### PR DESCRIPTION
* OP-139: Upgrading to processing core 2.2.1
Version 1.2.1 cant be accessed from cytoscape repo anymore
* OP-139: Using webcam-capture library to capture image from webcam
* The old library (processing-core, etc) is not working as expected. So switching to this new library which seems to work
* OP-139: Added resolution selector on the photobooth frame
* OP-139: Fixing image resolution change implementation
* OP-139: Minor UI restructure
* Also get rid of 'discard' image button. Quite frankly, it is useless.
* OP-139: Fixing memory leak bug
* Need to make sure that the resolution property change listener is removed when closing photo dialog.
* This also fix the issue where there can be multiple listener listening to the change in resolution combo box, and hence causing issue where the webcam library reporting error 'please close webcam before changing resolution'
* OP-139: Adding simple PhotoboothTester
* OP-139: Adding webcam selection
* so that user can choose webcam, when there is more than one available
* OP-139: Select default webcam
* upon opening photo dialog, choose default webcam
* OP-139: Reverting back to Java 6.