### PR TITLE
Remove note about mvn 3.2.5 now that JDK 8 is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ You need the openhospital-core in order to run the gui.
 * follow the instructions in the related README.md
 
 **How to build with Maven:**
-_(requires Maven 3.2.5 or lesser installed and configured)_
 
     mvn clean install
     


### PR DESCRIPTION
Remove note about `mvn` version 3.2.5 begin required now that JDK 8 is used.

See Maven [release history](https://maven.apache.org/docs/history.html) to see that the most recent version can be used and is only dependent on JDK 7.