### PR TITLE
Replace concatenation with parameterized log message

### DIFF
--- a/src/main/java/org/isf/medicals/gui/MedicalBrowser.java
+++ b/src/main/java/org/isf/medicals/gui/MedicalBrowser.java
@@ -1,7 +1,3 @@
-/**
- * 11-dic-2005
- * author bob
- */
 package org.isf.medicals.gui;
 
 import java.awt.AWTEvent;
@@ -70,41 +66,41 @@ import org.isf.utils.jobjects.CustomJDateChooser;
  * supplies-sundries, diagnostic kits -reagents, laboratory chemicals. It is
  * possible to filter data with a selection combo box
  * and edit-insert-delete records
- * 
+ *
  * @author bob
- * 		   modified by alex:
- * 			- product code
- * 			- pieces per packet
- * 
+ * 11-dic-2005
+ * modified by alex:
+ * - product code
+ * - pieces per packet
  */
 public class MedicalBrowser extends ModalJFrame implements MedicalListener { // implements RowSorterListener{
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 1L;
-	
+
 	private static Logger logger = LoggerFactory.getLogger(MedicalBrowser.class);
 
 	public void medicalInserted(Medical medical) {
-		pMedicals.add(0,medical);
-		((MedicalBrowsingModel)table.getModel()).fireTableDataChanged();
+		pMedicals.add(0, medical);
+		((MedicalBrowsingModel) table.getModel()).fireTableDataChanged();
 		table.updateUI();
 		if (table.getRowCount() > 0)
 			table.setRowSelectionInterval(0, 0);
 		repaint();
 	}
-	
+
 	public void medicalUpdated(AWTEvent e) {
-		pMedicals.set(selectedrow,medical);
-		((MedicalBrowsingModel)table.getModel()).fireTableDataChanged();
+		pMedicals.set(selectedrow, medical);
+		((MedicalBrowsingModel) table.getModel()).fireTableDataChanged();
 		table.updateUI();
-		if ((table.getRowCount() > 0) && selectedrow >-1)
-			table.setRowSelectionInterval(selectedrow,selectedrow);
+		if ((table.getRowCount() > 0) && selectedrow > -1)
+			table.setRowSelectionInterval(selectedrow, selectedrow);
 		repaint();
-	
+
 	}
-	
+
 	private static final int DEFAULT_WIDTH = 500;
 	private static final int DEFAULT_HEIGHT = 400;
 	private int pfrmWidth;
@@ -121,15 +117,15 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 			MessageBundle.getMessage("angal.medicals.critlevelm"),
 			MessageBundle.getMessage("angal.medicals.outofstockm")
 	};
-	private String[] pColumsSorter = {"MDSRT_DESC", "MDSR_CODE", "MDSR_DESC", null, "STOCK", "MDSR_MIN_STOCK_QTI", "STOCK"};
-	private boolean[] pColumsNormalSorting = {true, true, true, true, true, true, false};
-	private int[] pColumwidth = {100,100,400,60,60,80,100};
-	private boolean[] pColumResizable = {true,true,true,true,true,true,true};
+	private String[] pColumsSorter = { "MDSRT_DESC", "MDSR_CODE", "MDSR_DESC", null, "STOCK", "MDSR_MIN_STOCK_QTI", "STOCK" };
+	private boolean[] pColumsNormalSorting = { true, true, true, true, true, true, false };
+	private int[] pColumwidth = { 100, 100, 400, 60, 60, 80, 100 };
+	private boolean[] pColumResizable = { true, true, true, true, true, true, true };
 	private Medical medical;
-	private DefaultTableModel model ;
+	private DefaultTableModel model;
 	private JTable table;
 	private final JFrame me;
-	
+
 	private String pSelection;
 	private JTextField searchString = null;
 	protected boolean altKeyReleased = true;
@@ -144,9 +140,9 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 		table.setModel(model);
 		searchString.requestFocus();
 	}
-	
+
 	public MedicalBrowser() {
-		me=this;
+		me = this;
 		setTitle(MessageBundle.getMessage("angal.medicals.pharmaceuticalbrowsing"));
 		setSize(DEFAULT_WIDTH, DEFAULT_HEIGHT);
 		Toolkit kit = Toolkit.getDefaultToolkit();
@@ -161,7 +157,7 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 		setLocationRelativeTo(null);
 		searchString.requestFocus();
 	}
-	
+
 	private JPanel getContentpane() {
 		JPanel contentPane = new JPanel();
 		contentPane.setLayout(new BorderLayout());
@@ -169,7 +165,7 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 		contentPane.add(getJButtonPanel(), BorderLayout.SOUTH);
 		return contentPane;
 	}
-	
+
 	private JScrollPane getScrollPane() {
 		JScrollPane scrollPane = new JScrollPane(getJTable());
 		int totWidth = 0;
@@ -179,29 +175,33 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 		scrollPane.setPreferredSize(new Dimension(totWidth, 450));
 		return scrollPane;
 	}
-	
+
 	private JTable getJTable() {
 		if (table == null) {
 			model = new MedicalBrowsingModel();
 			table = new JTable(model);
 			table.setAutoCreateRowSorter(true);
-			table.setDefaultRenderer(Object.class,new ColorTableCellRenderer());
-			for (int i=0;i<pColumwidth.length; i++){
+			table.setDefaultRenderer(Object.class, new ColorTableCellRenderer());
+			for (int i = 0; i < pColumwidth.length; i++) {
 				table.getColumnModel().getColumn(i).setMinWidth(pColumwidth[i]);
-				if (!pColumResizable[i]) table.getColumnModel().getColumn(i).setMaxWidth(pColumwidth[i]);
+				if (!pColumResizable[i])
+					table.getColumnModel().getColumn(i).setMaxWidth(pColumwidth[i]);
 			}
 		}
 		return table;
 	}
-	
+
 	private JPanel getJButtonPanel() {
 		JPanel buttonPanel = new JPanel();
 		buttonPanel.add(new JLabel(MessageBundle.getMessage("angal.medicals.selecttype")));
 		buttonPanel.add(getComboBoxMedicalType());
 		buttonPanel.add(getSearchBox());
-		if (MainMenu.checkUserGrants("btnpharmaceuticalnew")) buttonPanel.add(getJButtonNew());
-		if (MainMenu.checkUserGrants("btnpharmaceuticaledit")) buttonPanel.add(getJButtonEdit());
-		if (MainMenu.checkUserGrants("btnpharmaceuticaldel")) buttonPanel.add(getJButtonDelete());
+		if (MainMenu.checkUserGrants("btnpharmaceuticalnew"))
+			buttonPanel.add(getJButtonNew());
+		if (MainMenu.checkUserGrants("btnpharmaceuticaledit"))
+			buttonPanel.add(getJButtonEdit());
+		if (MainMenu.checkUserGrants("btnpharmaceuticaldel"))
+			buttonPanel.add(getJButtonDelete());
 		buttonPanel.add(getJButtonReport());
 		buttonPanel.add(getJButtonStock());
 		buttonPanel.add(getJButtonStockCard());
@@ -216,20 +216,23 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 		if (buttonAMC == null) {
 			buttonAMC = new JButton(MessageBundle.getMessage("angal.medicals.averagemonthlyconsumption.abbr"));
 			buttonAMC.setMnemonic(KeyEvent.VK_M);
-			buttonAMC.addActionListener(new ActionListener(){
-				public void actionPerformed(ActionEvent event){
+			buttonAMC.addActionListener(new ActionListener() {
+
+				public void actionPerformed(ActionEvent event) {
 					new GenericReportPharmaceuticalOrder(GeneralData.PHARMACEUTICALAMC);
-					
+
 				}
 			});
 		}
 		return buttonAMC;
 	}
+
 	private JTextField getSearchBox() {
 		if (searchString == null) {
 			searchString = new JTextField();
 			searchString.setColumns(15);
 			searchString.addKeyListener(new KeyListener() {
+
 				public void keyTyped(KeyEvent e) {
 					if (altKeyReleased) {
 						lastKey = "";
@@ -254,10 +257,12 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 		}
 		return searchString;
 	}
+
 	private JButton getJButtonClose() {
 		JButton buttonClose = new JButton(MessageBundle.getMessage("angal.common.close"));
 		buttonClose.setMnemonic(KeyEvent.VK_C);
 		buttonClose.addActionListener(new ActionListener() {
+
 			public void actionPerformed(ActionEvent arg0) {
 				dispose();
 			}
@@ -268,10 +273,11 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 	private JButton getJButtonExpiring() {
 		JButton buttonExpiring = new JButton(MessageBundle.getMessage("angal.medicals.expiring"));
 		buttonExpiring.setMnemonic(KeyEvent.VK_X);
-		buttonExpiring.addActionListener(new ActionListener(){
-			public void actionPerformed(ActionEvent event){
+		buttonExpiring.addActionListener(new ActionListener() {
+
+			public void actionPerformed(ActionEvent event) {
 				launchExpiringReport();
-				
+
 			}
 		});
 		return buttonExpiring;
@@ -280,8 +286,9 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 	private JButton getJButtonOrderList() {
 		JButton buttonOrderList = new JButton(MessageBundle.getMessage("angal.medicals.orderlist"));
 		buttonOrderList.setMnemonic(KeyEvent.VK_O);
-		buttonOrderList.addActionListener(new ActionListener(){
-			public void actionPerformed(ActionEvent event){
+		buttonOrderList.addActionListener(new ActionListener() {
+
+			public void actionPerformed(ActionEvent event) {
 				new GenericReportPharmaceuticalOrder(GeneralData.PHARMACEUTICALORDER);
 			}
 		});
@@ -291,49 +298,51 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 	private JButton getJButtonStock() {
 		JButton buttonStock = new JButton(MessageBundle.getMessage("angal.medicals.stock"));
 		buttonStock.setMnemonic(KeyEvent.VK_S);
-		buttonStock.addActionListener(new ActionListener(){
-			public void actionPerformed(ActionEvent event){
-				
+		buttonStock.addActionListener(new ActionListener() {
+
+			public void actionPerformed(ActionEvent event) {
+
 				ArrayList<String> dateOptions = new ArrayList<String>();
 				dateOptions.add(MessageBundle.getMessage("angal.medicals.today"));
 				dateOptions.add(MessageBundle.getMessage("angal.common.date"));
-				
+
 				Icon icon = new ImageIcon("rsc/icons/calendar_dialog.png"); //$NON-NLS-1$
-				String dateOption = (String) JOptionPane.showInputDialog(MedicalBrowser.this, 
-						MessageBundle.getMessage("angal.medicals.pleaseselectareport"), 
-						MessageBundle.getMessage("angal.medicals.report"), 
-						JOptionPane.INFORMATION_MESSAGE, 
-						icon, 
-						dateOptions.toArray(), 
+				String dateOption = (String) JOptionPane.showInputDialog(MedicalBrowser.this,
+						MessageBundle.getMessage("angal.medicals.pleaseselectareport"),
+						MessageBundle.getMessage("angal.medicals.report"),
+						JOptionPane.INFORMATION_MESSAGE,
+						icon,
+						dateOptions.toArray(),
 						dateOptions.get(0));
-				
+
 				if (dateOption == null)
 					return;
-				
+
 				ArrayList<String> lotOptions = new ArrayList<String>();
 				lotOptions.add(MessageBundle.getMessage("angal.medicals.onlyquantity"));
 				lotOptions.add(MessageBundle.getMessage("angal.medicals.withlot"));
-				
-				String lotOption = (String) JOptionPane.showInputDialog(MedicalBrowser.this, 
-						MessageBundle.getMessage("angal.medicals.pleaseselectareport"), 
-						MessageBundle.getMessage("angal.medicals.report"), 
-						JOptionPane.INFORMATION_MESSAGE, 
-						icon, 
-						lotOptions.toArray(), 
+
+				String lotOption = (String) JOptionPane.showInputDialog(MedicalBrowser.this,
+						MessageBundle.getMessage("angal.medicals.pleaseselectareport"),
+						MessageBundle.getMessage("angal.medicals.report"),
+						JOptionPane.INFORMATION_MESSAGE,
+						icon,
+						lotOptions.toArray(),
 						lotOptions.get(0));
-				
-				
+
+
 				/* Getting Report parameters */
 				String sortBy = null;
 				String groupBy = null;
 				String filter = "%" + searchString.getText() + "%";
-				if (pbox.getSelectedItem() instanceof MedicalType) groupBy = ((MedicalType) pbox.getSelectedItem()).getDescription();
+				if (pbox.getSelectedItem() instanceof MedicalType)
+					groupBy = ((MedicalType) pbox.getSelectedItem()).getDescription();
 				//System.out.println("==> GROUPING : " + groupBy);
 				List<?> sortedKeys = table.getRowSorter().getSortKeys();
 				if (!sortedKeys.isEmpty()) {
 					int sortedColumn = ((SortKey) sortedKeys.get(0)).getColumn();
 					SortOrder sortedOrder = ((SortKey) sortedKeys.get(0)).getSortOrder();
-					
+
 					String columnName = pColumsSorter[sortedColumn];
 					String columnOrder = sortedOrder.toString().equals("ASCENDING") ? "ASC" : "DESC";
 					if (!pColumsNormalSorting[sortedColumn])
@@ -343,14 +352,14 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 						sortBy = "MDSRT_DESC, " + columnName + " " + columnOrder;
 					} else
 						sortBy = columnName + " " + columnOrder;
-					
+
 				} else { //default values
 					groupBy = "%%";
 					sortBy = "MDSRT_DESC, MDSR_DESC";
 				}
-				
+
 				String report = "";
-				
+
 				int i = 0;
 				if (lotOptions.indexOf(lotOption) == i) {
 					report = GeneralData.PHARMACEUTICALSTOCK;
@@ -365,58 +374,59 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 					return;
 				}
 				if (dateOptions.indexOf(dateOption) == ++i) {
-					
+
 					icon = new ImageIcon("rsc/icons/calendar_dialog.png"); //$NON-NLS-1$
-					
+
 					CustomJDateChooser dateChooser = new CustomJDateChooser();
 					dateChooser.setLocale(new Locale(GeneralData.LANGUAGE));
-					
-			        int r = JOptionPane.showConfirmDialog(MedicalBrowser.this, 
-			        		dateChooser, 
-			        		MessageBundle.getMessage("angal.common.date"), 
-			        		JOptionPane.OK_CANCEL_OPTION, 
-			        		JOptionPane.PLAIN_MESSAGE,
-			        		icon);
 
-			        if (r == JOptionPane.OK_OPTION) {
-			        	new GenericReportPharmaceuticalStock(dateChooser.getDate(), report, filter, groupBy, sortBy, false);
-			        	new GenericReportPharmaceuticalStock(dateChooser.getDate(), report, filter, groupBy, sortBy, true);
-			        	return;
-						
-			        } else {
-			            return;
-			        }
+					int r = JOptionPane.showConfirmDialog(MedicalBrowser.this,
+							dateChooser,
+							MessageBundle.getMessage("angal.common.date"),
+							JOptionPane.OK_CANCEL_OPTION,
+							JOptionPane.PLAIN_MESSAGE,
+							icon);
+
+					if (r == JOptionPane.OK_OPTION) {
+						new GenericReportPharmaceuticalStock(dateChooser.getDate(), report, filter, groupBy, sortBy, false);
+						new GenericReportPharmaceuticalStock(dateChooser.getDate(), report, filter, groupBy, sortBy, true);
+						return;
+
+					} else {
+						return;
+					}
 				}
 			}
 		});
 		return buttonStock;
 	}
-	
+
 	private JButton getJButtonStockCard() {
 		JButton buttonStockCard = new JButton(MessageBundle.getMessage("angal.medicals.stockcard"));
 		buttonStockCard.setMnemonic(KeyEvent.VK_K);
-		buttonStockCard.addActionListener(new ActionListener(){
-			public void actionPerformed(ActionEvent event){
+		buttonStockCard.addActionListener(new ActionListener() {
+
+			public void actionPerformed(ActionEvent event) {
 				if (table.getSelectedRow() < 0) {
-					JOptionPane.showMessageDialog(				
+					JOptionPane.showMessageDialog(
 							MedicalBrowser.this,
-	                        MessageBundle.getMessage("angal.common.pleaseselectarow"),
-	                        MessageBundle.getMessage("angal.hospital"),
-	                        JOptionPane.PLAIN_MESSAGE);				
-					return;									
-				}else {
+							MessageBundle.getMessage("angal.common.pleaseselectarow"),
+							MessageBundle.getMessage("angal.hospital"),
+							JOptionPane.PLAIN_MESSAGE);
+					return;
+				} else {
 					selectedrow = table.convertRowIndexToModel(table.getSelectedRow());
-					Medical medical = (Medical)(((MedicalBrowsingModel) model).getValueAt(selectedrow, -1));
-					
+					Medical medical = (Medical) (((MedicalBrowsingModel) model).getValueAt(selectedrow, -1));
+
 					// Select Dates
 					JFromDateToDateChooserDialog dataRange = new JFromDateToDateChooserDialog(MedicalBrowser.this);
 					dataRange.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
 					dataRange.setVisible(true);
-					
+
 					Date dateFrom = dataRange.getDateFrom();
 					Date dateTo = dataRange.getDateTo();
 					boolean toExcel = dataRange.isExcel();
-					
+
 					if (!dataRange.isCancel()) {
 						new GenericReportPharmaceuticalStockCard("ProductLedger", dateFrom, dateTo, medical, null, toExcel);
 						return;
@@ -430,29 +440,28 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 	private JButton getJButtonReport() {
 		JButton buttonExport = new JButton(MessageBundle.getMessage("angal.medicals.export"));
 		buttonExport.setMnemonic(KeyEvent.VK_X);
-		buttonExport.addActionListener(new ActionListener(){
-			public void actionPerformed(ActionEvent event){
-				
+		buttonExport.addActionListener(new ActionListener() {
+
+			public void actionPerformed(ActionEvent event) {
+
 				String fileName = compileFileName();
 				File defaultFileName = new File(fileName);
 				JFileChooser fcExcel = ExcelExporter.getJFileChooserExcel(defaultFileName);
-				
+
 				int iRetVal = fcExcel.showSaveDialog(MedicalBrowser.this);
-				if(iRetVal == JFileChooser.APPROVE_OPTION)
-				{
+				if (iRetVal == JFileChooser.APPROVE_OPTION) {
 					File exportFile = fcExcel.getSelectedFile();
-					if (!exportFile.getName().endsWith("xls")) exportFile = new File(exportFile.getAbsoluteFile() + ".xls");
+					if (!exportFile.getName().endsWith("xls"))
+						exportFile = new File(exportFile.getAbsoluteFile() + ".xls");
 					ExcelExporter xlsExport = new ExcelExporter();
-					try
-					{
+					try {
 						xlsExport.exportTableToExcel(table, exportFile);
-					} catch(IOException exc)
-					{
+					} catch (IOException exc) {
 						JOptionPane.showMessageDialog(MedicalBrowser.this,
 								exc.getMessage(),
-		                        MessageBundle.getMessage("angal.hospital"),
-		                        JOptionPane.PLAIN_MESSAGE);	
-						logger.error("Export to excel error : "+ exc.getMessage());
+								MessageBundle.getMessage("angal.hospital"),
+								JOptionPane.PLAIN_MESSAGE);
+						logger.error("Export to excel error : {}", exc.getMessage());
 					}
 				}
 			}
@@ -462,27 +471,28 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 
 	private String compileFileName() {
 		StringBuilder filename = new StringBuilder("Stock");
-		if (pbox.isEnabled() 
+		if (pbox.isEnabled()
 				&& !pbox.getSelectedItem().equals(
-						MessageBundle.getMessage("angal.medicals.allm"))) {
-			
+				MessageBundle.getMessage("angal.medicals.allm"))) {
+
 			filename.append("_").append(pbox.getSelectedItem());
 		}
 		return filename.toString();
 	}
-	
+
 	private JButton getJButtonDelete() {
 		JButton buttonDelete = new JButton(MessageBundle.getMessage("angal.common.delete"));
 		buttonDelete.setMnemonic(KeyEvent.VK_D);
 		buttonDelete.addActionListener(new ActionListener() {
+
 			public void actionPerformed(ActionEvent event) {
 				if (table.getSelectedRow() < 0) {
-					JOptionPane.showMessageDialog(				
+					JOptionPane.showMessageDialog(
 							MedicalBrowser.this,
-	                        MessageBundle.getMessage("angal.common.pleaseselectarow"),
-	                        MessageBundle.getMessage("angal.hospital"),
-	                        JOptionPane.PLAIN_MESSAGE);				
-					return;									
+							MessageBundle.getMessage("angal.common.pleaseselectarow"),
+							MessageBundle.getMessage("angal.hospital"),
+							JOptionPane.PLAIN_MESSAGE);
+					return;
 				} else {
 					selectedrow = table.convertRowIndexToModel(table.getSelectedRow());
 					Medical med = (Medical) (((MedicalBrowsingModel) model).getValueAt(selectedrow, -1));
@@ -492,10 +502,10 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 							.append(med.getDescription())
 							.append("\" ?");
 					int n = JOptionPane.showConfirmDialog(
-									MedicalBrowser.this,
-									deleteMessage.toString(),
-									MessageBundle.getMessage("angal.hospital"), 
-									JOptionPane.YES_NO_OPTION);
+							MedicalBrowser.this,
+							deleteMessage.toString(),
+							MessageBundle.getMessage("angal.hospital"),
+							JOptionPane.YES_NO_OPTION);
 					boolean deleted;
 					try {
 						deleted = medicalBrowsingManager.deleteMedical(med);
@@ -521,19 +531,19 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 
 			public void actionPerformed(ActionEvent event) {
 				if (table.getSelectedRow() < 0) {
-					JOptionPane.showMessageDialog(				
-	                        MedicalBrowser.this,
-	                        MessageBundle.getMessage("angal.common.pleaseselectarow"),
-	                        MessageBundle.getMessage("angal.hospital"),
-	                        JOptionPane.PLAIN_MESSAGE);				
-					return;									
-				}else {		
+					JOptionPane.showMessageDialog(
+							MedicalBrowser.this,
+							MessageBundle.getMessage("angal.common.pleaseselectarow"),
+							MessageBundle.getMessage("angal.hospital"),
+							JOptionPane.PLAIN_MESSAGE);
+					return;
+				} else {
 					selectedrow = table.convertRowIndexToModel(table.getSelectedRow());
-					medical = (Medical)(((MedicalBrowsingModel) model).getValueAt(selectedrow, -1));
-					MedicalEdit editrecord = new MedicalEdit(medical,false,me);
+					medical = (Medical) (((MedicalBrowsingModel) model).getValueAt(selectedrow, -1));
+					MedicalEdit editrecord = new MedicalEdit(medical, false, me);
 					editrecord.addMedicalListener(MedicalBrowser.this);
 					editrecord.setVisible(true);
-				}	 				
+				}
 			}
 		});
 		return buttonEdit;
@@ -544,8 +554,7 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 		buttonNew.setMnemonic(KeyEvent.VK_N);
 		buttonNew.addActionListener(new ActionListener() {
 
-			public void actionPerformed(ActionEvent event) 
-			{
+			public void actionPerformed(ActionEvent event) {
 				// medical will reference the new record
 				medical = new Medical(null, new MedicalType("", ""), "", "", 0, 0, 0, 0, 0);
 				MedicalEdit newrecord = new MedicalEdit(medical, true, me);
@@ -568,9 +577,10 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 				}
 			} catch (OHServiceException e) {
 				OHServiceExceptionUtil.showMessages(e);
-			}	
+			}
 		}
 		pbox.addActionListener(new ActionListener() {
+
 			public void actionPerformed(ActionEvent arg0) {
 				pSelection = pbox.getSelectedItem().toString();
 				if (pSelection.compareTo(MessageBundle.getMessage("angal.medicals.allm")) == 0) {
@@ -588,7 +598,7 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 	}
 
 	protected void launchExpiringReport() {
-		
+
 		ArrayList<String> options = new ArrayList<String>();
 		options.add(MessageBundle.getMessage("angal.medicals.today"));
 		options.add(MessageBundle.getMessage("angal.medicals.thismonth"));
@@ -596,26 +606,27 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 		options.add(MessageBundle.getMessage("angal.medicals.nexttwomonths"));
 		options.add(MessageBundle.getMessage("angal.medicals.nextthreemonths"));
 		options.add(MessageBundle.getMessage("angal.medicals.othermonth"));
-		
+
 		Icon icon = new ImageIcon("rsc/icons/calendar_dialog.png"); //$NON-NLS-1$
-		String option = (String) JOptionPane.showInputDialog(MedicalBrowser.this, 
-				MessageBundle.getMessage("angal.medicals.pleaseselectperiod"), 
-				MessageBundle.getMessage("angal.medicals.expiringreport"), 
-				JOptionPane.INFORMATION_MESSAGE, 
-				icon, 
-				options.toArray(), 
+		String option = (String) JOptionPane.showInputDialog(MedicalBrowser.this,
+				MessageBundle.getMessage("angal.medicals.pleaseselectperiod"),
+				MessageBundle.getMessage("angal.medicals.expiringreport"),
+				JOptionPane.INFORMATION_MESSAGE,
+				icon,
+				options.toArray(),
 				options.get(0));
-		
-		if (option == null) return;
-		
+
+		if (option == null)
+			return;
+
 		String from = null;
 		String to = null;
-		
+
 		int i = 0;
-		
+
 		if (options.indexOf(option) == i) {
 			GregorianCalendar gc = new GregorianCalendar();
-			
+
 			from = TimeTools.formatDateTimeReport(gc);
 			to = from;
 		}
@@ -623,7 +634,7 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 			GregorianCalendar gc = new GregorianCalendar();
 			gc.set(GregorianCalendar.DAY_OF_MONTH, 1);
 			from = TimeTools.formatDateTimeReport(gc);
-			
+
 			gc.set(GregorianCalendar.DAY_OF_MONTH, gc.getActualMaximum(GregorianCalendar.DAY_OF_MONTH));
 			to = TimeTools.formatDateTimeReport(gc);
 		}
@@ -631,7 +642,7 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 			GregorianCalendar gc = new GregorianCalendar();
 			gc.set(GregorianCalendar.DAY_OF_MONTH, 1);
 			from = TimeTools.formatDateTimeReport(gc);
-			
+
 			gc.add(GregorianCalendar.MONTH, 1);
 			gc.set(GregorianCalendar.DAY_OF_MONTH, gc.getActualMaximum(GregorianCalendar.DAY_OF_MONTH));
 			to = TimeTools.formatDateTimeReport(gc);
@@ -640,7 +651,7 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 			GregorianCalendar gc = new GregorianCalendar();
 			gc.set(GregorianCalendar.DAY_OF_MONTH, 1);
 			from = TimeTools.formatDateTimeReport(gc);
-			
+
 			gc.add(GregorianCalendar.MONTH, 2);
 			gc.set(GregorianCalendar.DAY_OF_MONTH, gc.getActualMaximum(GregorianCalendar.DAY_OF_MONTH));
 			to = TimeTools.formatDateTimeReport(gc);
@@ -649,7 +660,7 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 			GregorianCalendar gc = new GregorianCalendar();
 			gc.set(GregorianCalendar.DAY_OF_MONTH, 1);
 			from = TimeTools.formatDateTimeReport(gc);
-			
+
 			gc.add(GregorianCalendar.MONTH, 3);
 			gc.set(GregorianCalendar.DAY_OF_MONTH, gc.getActualMaximum(GregorianCalendar.DAY_OF_MONTH));
 			to = TimeTools.formatDateTimeReport(gc);
@@ -658,40 +669,40 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 			GregorianCalendar monthYear;
 			icon = new ImageIcon("rsc/icons/calendar_dialog.png"); //$NON-NLS-1$
 			JMonthYearChooser monthYearChooser = new JMonthYearChooser();
-	        int r = JOptionPane.showConfirmDialog(MedicalBrowser.this, 
-	        		monthYearChooser, 
-	        		MessageBundle.getMessage("angal.billbrowser.month"), 
-	        		JOptionPane.OK_CANCEL_OPTION, 
-	        		JOptionPane.PLAIN_MESSAGE,
-	        		icon);
+			int r = JOptionPane.showConfirmDialog(MedicalBrowser.this,
+					monthYearChooser,
+					MessageBundle.getMessage("angal.billbrowser.month"),
+					JOptionPane.OK_CANCEL_OPTION,
+					JOptionPane.PLAIN_MESSAGE,
+					icon);
 
-	        if (r == JOptionPane.OK_OPTION) {
-	        	monthYear = monthYearChooser.getDate();
-	        } else {
-	            return;
-	        }
-	        
-	        GregorianCalendar gc = new GregorianCalendar();
+			if (r == JOptionPane.OK_OPTION) {
+				monthYear = monthYearChooser.getDate();
+			} else {
+				return;
+			}
+
+			GregorianCalendar gc = new GregorianCalendar();
 			gc.set(GregorianCalendar.DAY_OF_MONTH, 1);
 			from = TimeTools.formatDateTimeReport(gc);
-			
+
 			gc.set(GregorianCalendar.MONTH, monthYear.get(GregorianCalendar.MONTH));
 			gc.set(GregorianCalendar.YEAR, monthYear.get(GregorianCalendar.YEAR));
 			gc.set(GregorianCalendar.DAY_OF_MONTH, gc.getActualMaximum(GregorianCalendar.DAY_OF_MONTH));
 			to = TimeTools.formatDateTimeReport(gc);
 		}
 		new GenericReportFromDateToDate(
-				from, 
-				to, 
-				"PharmaceuticalExpiration", 
-				MessageBundle.getMessage("angal.medicals.expiringreport"), 
+				from,
+				to,
+				"PharmaceuticalExpiration",
+				MessageBundle.getMessage("angal.medicals.expiringreport"),
 				false);
 	}
-	
+
 	class MedicalBrowsingModel extends DefaultTableModel {
-		
+
 		/**
-		 * 
+		 *
 		 */
 		private static final long serialVersionUID = 1L;
 
@@ -708,7 +719,7 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 			} else {
 				for (Medical med : pMedicals) {
 					if (key != null) {
-						
+
 						String s = key + lastKey;
 						s.trim();
 						String[] tokens = s.split(" ");
@@ -716,18 +727,22 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 						if (!s.equals("")) {
 							String description = med.getProd_code() + med.getDescription();
 							int a = 0;
-							for (int j = 0; j < tokens.length ; j++) {
+							for (int j = 0; j < tokens.length; j++) {
 								String token = tokens[j].toLowerCase();
 								if (description.toLowerCase().contains(token)) {
 									a++;
 								}
 							}
-							if (a == tokens.length) medicalList.add(med);
-						} else medicalList.add(med);
-					} else medicalList.add(med);
+							if (a == tokens.length)
+								medicalList.add(med);
+						} else
+							medicalList.add(med);
+					} else
+						medicalList.add(med);
 				}
 			}
 		}
+
 		public MedicalBrowsingModel() {
 			try {
 				medicalList = pMedicals = medicalBrowsingManager.getMedicals(null, false);
@@ -736,8 +751,8 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 				OHServiceExceptionUtil.showMessages(e);
 			}
 		}
-		
-		public Class<?> getColumnClass(int c) { 
+
+		public Class<?> getColumnClass(int c) {
 			if (c == 0) {
 				return String.class;
 			} else if (c == 1) {
@@ -752,16 +767,16 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 				return Double.class;
 			} else if (c == 6) {
 				return Boolean.class;
-			} 
+			}
 			return null;
 		}
-		
+
 		public int getRowCount() {
 			if (medicalList == null)
 				return 0;
 			return medicalList.size();
 		}
-		
+
 		public String getColumnName(int c) {
 			return pColums[c];
 		}
@@ -772,7 +787,7 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 
 		public Object getValueAt(int r, int c) {
 			Medical med = medicalList.get(r);
-			double actualQty = med.getInitialqty()+med.getInqty()-med.getOutqty();
+			double actualQty = med.getInitialqty() + med.getInqty() - med.getOutqty();
 			double minQuantity = med.getMinqty();
 			if (c == -1) {
 				return med;
@@ -788,41 +803,42 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener { // 
 				return actualQty;
 			} else if (c == 5) {
 				return minQuantity;
-			} else if(c == 6){
+			} else if (c == 6) {
 				//if(actualQty<=minQuantity)return true;
-				if(actualQty == 0)return true;
-				else return false;
+				if (actualQty == 0)
+					return true;
+				else
+					return false;
 			}
 			return null;
 		}
-		
+
 		@Override
 		public boolean isCellEditable(int arg0, int arg1) {
 			return false;
 		}
-		
+
 	}
-	
-	class ColorTableCellRenderer extends DefaultTableCellRenderer
-	{  
-	   /**
-		 * 
+
+	class ColorTableCellRenderer extends DefaultTableCellRenderer {
+
+		/**
+		 *
 		 */
 		private static final long serialVersionUID = 1L;
 
-	public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, 
-	      boolean hasFocus, int row, int column)
-	   {  
-		   Component cell=super.getTableCellRendererComponent(table,value,isSelected,hasFocus,row,column);
-		   cell.setForeground(Color.BLACK);
-		   Medical med = pMedicals.get(row);
-		   double actualQty = med.getInitialqty()+med.getInqty()-med.getOutqty();
+		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
+				boolean hasFocus, int row, int column) {
+			Component cell = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+			cell.setForeground(Color.BLACK);
+			Medical med = pMedicals.get(row);
+			double actualQty = med.getInitialqty() + med.getInqty() - med.getOutqty();
 			if (((Boolean) table.getValueAt(row, 6)).booleanValue())
 				cell.setForeground(Color.GRAY); // out of stock
 			if (med.getMinqty() != 0 && actualQty <= med.getMinqty())
 				cell.setForeground(Color.RED); // under critical level
-	      return cell;
-	   }
+			return cell;
+		}
 	}
 
 }

--- a/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
@@ -1,4 +1,3 @@
-
 package org.isf.medicalstock.gui;
 
 /*------------------------------------------
@@ -9,7 +8,7 @@ package org.isf.medicalstock.gui;
  * 30/03/2006 - Theo - first beta version
  * 03/11/2006 - ross - changed title, removed delete all button
  *                   - corrected an error in datetextfield class (the month displayed in the filter was -1
- * 			         - version is now  1.0 
+ * 			         - version is now  1.0
  *------------------------------------------*/
 
 import java.awt.BorderLayout;
@@ -87,10 +86,10 @@ import org.slf4j.LoggerFactory;
 public class MovStockBrowser extends ModalJFrame {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 1L;
-	
+
 	private static Logger logger = LoggerFactory.getLogger(MovStockBrowser.class);
 
 	private final JFrame myFrame;
@@ -102,7 +101,7 @@ public class MovStockBrowser extends ModalJFrame {
 	private JButton dischargeButton;
 	private JButton filterButton;
 	private JButton exportToExcel;
-//	private JButton importFromExcel;
+	//	private JButton importFromExcel;
 	private JButton stockCardButton;
 	private JButton stockLedgerButton;
 	private JPanel filterPanel;
@@ -124,43 +123,46 @@ public class MovStockBrowser extends ModalJFrame {
 	private MovBrowserModel model;
 	private ArrayList<Movement> moves;
 	private String[] pColums = {
-			MessageBundle.getMessage("angal.medicalstock.refno"), 
-			MessageBundle.getMessage("angal.common.datem"), 				//1 
-			MessageBundle.getMessage("angal.medicalstock.typem"), 			//2
-			MessageBundle.getMessage("angal.medicalstock.wardm"),			//3
-			MessageBundle.getMessage("angal.medicalstock.qtym"), 			//4
-			MessageBundle.getMessage("angal.medicalstock.pharmaceuticalm"),	//5
-			MessageBundle.getMessage("angal.medicalstock.medtypem"),		//6
-			MessageBundle.getMessage("angal.medicalstock.lotm"),			//7
-			MessageBundle.getMessage("angal.medicalstock.prepdatem"),		//8
-			MessageBundle.getMessage("angal.medicalstock.duedatem"),		//9
-			MessageBundle.getMessage("angal.medicalstock.originm"),			//10
-			MessageBundle.getMessage("angal.medicalstock.costm"),			//11
-			MessageBundle.getMessage("angal.medicalstock.totalm")			//12
+			MessageBundle.getMessage("angal.medicalstock.refno"),
+			MessageBundle.getMessage("angal.common.datem"),                //1
+			MessageBundle.getMessage("angal.medicalstock.typem"),            //2
+			MessageBundle.getMessage("angal.medicalstock.wardm"),            //3
+			MessageBundle.getMessage("angal.medicalstock.qtym"),            //4
+			MessageBundle.getMessage("angal.medicalstock.pharmaceuticalm"),    //5
+			MessageBundle.getMessage("angal.medicalstock.medtypem"),        //6
+			MessageBundle.getMessage("angal.medicalstock.lotm"),            //7
+			MessageBundle.getMessage("angal.medicalstock.prepdatem"),        //8
+			MessageBundle.getMessage("angal.medicalstock.duedatem"),        //9
+			MessageBundle.getMessage("angal.medicalstock.originm"),            //10
+			MessageBundle.getMessage("angal.medicalstock.costm"),            //11
+			MessageBundle.getMessage("angal.medicalstock.totalm")            //12
 	};
-	private boolean[] pColumnBold = {true,false,false,false,false,false,false,false,false,false,false,false,false};
-	private int[] columnAlignment = {SwingConstants.LEFT, SwingConstants.CENTER, SwingConstants.CENTER, SwingConstants.CENTER, SwingConstants.CENTER, SwingConstants.LEFT, SwingConstants.LEFT, SwingConstants.CENTER,
-			SwingConstants.CENTER, SwingConstants.CENTER, SwingConstants.CENTER, SwingConstants.RIGHT, SwingConstants.RIGHT};
-	private boolean[] pColumnVisible = {true,true,true,true,true,true,true,!GeneralData.AUTOMATICLOT_IN,!GeneralData.AUTOMATICLOT_IN,true,true,GeneralData.LOTWITHCOST,GeneralData.LOTWITHCOST,true};
- 	
-	private int[] pColumwidth = {50, 80, 45, 130, 50, 150, 70, 70, 80, 65, 50, 50, 70};
+	private boolean[] pColumnBold = { true, false, false, false, false, false, false, false, false, false, false, false, false };
+	private int[] columnAlignment = { SwingConstants.LEFT, SwingConstants.CENTER, SwingConstants.CENTER, SwingConstants.CENTER, SwingConstants.CENTER,
+			SwingConstants.LEFT, SwingConstants.LEFT, SwingConstants.CENTER,
+			SwingConstants.CENTER, SwingConstants.CENTER, SwingConstants.CENTER, SwingConstants.RIGHT, SwingConstants.RIGHT };
+	private boolean[] pColumnVisible = { true, true, true, true, true, true, true, !GeneralData.AUTOMATICLOT_IN, !GeneralData.AUTOMATICLOT_IN, true, true,
+			GeneralData.LOTWITHCOST, GeneralData.LOTWITHCOST, true };
+
+	private int[] pColumwidth = { 50, 80, 45, 130, 50, 150, 70, 70, 80, 65, 50, 50, 70 };
 	private static final String DATE_FORMAT_DD_MM_YY = "dd/MM/yy";
 	private static final String DATE_FORMAT_DD_MM_YY_HH_MM = "dd/MM/yy HH:mm";
-	
+
 	private String currencyCod;
-        
-    /*
-     *Adds to facilitate the selection of products 
-     */
-    private JPanel searchPanel;
-    private JTextField searchTextField;
-    private JButton searchButton;
-	
+
+	/*
+	 *Adds to facilitate the selection of products
+	 */
+	private JPanel searchPanel;
+	private JTextField searchTextField;
+	private JButton searchButton;
+
 	private HashMap<Integer, String> supMap = new HashMap<Integer, String>();
 
 	private MedicalBrowsingManager medicalManager = Context.getApplicationContext().getBean(MedicalBrowsingManager.class);
 	private MedicalTypeBrowserManager medicalTypeBrowserManager = Context.getApplicationContext().getBean(MedicalTypeBrowserManager.class);
-	private MedicaldsrstockmovTypeBrowserManager medicaldsrstockmovTypeBrowserManager = Context.getApplicationContext().getBean(MedicaldsrstockmovTypeBrowserManager.class);
+	private MedicaldsrstockmovTypeBrowserManager medicaldsrstockmovTypeBrowserManager = Context.getApplicationContext()
+			.getBean(MedicaldsrstockmovTypeBrowserManager.class);
 	private MovBrowserManager movBrowserManager = Context.getApplicationContext().getBean(MovBrowserManager.class);
 	private HospitalBrowsingManager hospitalManager = Context.getApplicationContext().getBean(HospitalBrowsingManager.class);
 	private SupplierBrowserManager supplierBrowserManager = Context.getApplicationContext().getBean(SupplierBrowserManager.class);
@@ -201,26 +203,29 @@ public class MovStockBrowser extends ModalJFrame {
 		contentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		return contentPane;
 	}
-	
+
 	/**
 	 * this method controls if the automaticlot option is on
-	 * 
+	 *
 	 * @return
 	 */
 	private boolean isAutomaticLot() {
 		return GeneralData.AUTOMATICLOT_IN;
 	}
+
 	private JPanel getButtonPanel() {
 		buttonPanel = new JPanel();
-		if (MainMenu.checkUserGrants("btnpharmstockcharge")) buttonPanel.add(getChargeButton());
-		if (MainMenu.checkUserGrants("btnpharmstockdischarge")) buttonPanel.add(getDishargeButton());
+		if (MainMenu.checkUserGrants("btnpharmstockcharge"))
+			buttonPanel.add(getChargeButton());
+		if (MainMenu.checkUserGrants("btnpharmstockdischarge"))
+			buttonPanel.add(getDishargeButton());
 		buttonPanel.add(getExportToExcelButton());
 		buttonPanel.add(getStockCardButton());
 		buttonPanel.add(getStockLedgerButton());
 		buttonPanel.add(getCloseButton());
 		return buttonPanel;
 	}
-	
+
 	private JButton getStockCardButton() {
 		stockCardButton = new JButton(MessageBundle.getMessage("angal.medicalstock.stockcard"));
 		stockCardButton.setMnemonic(KeyEvent.VK_K);
@@ -228,20 +233,20 @@ public class MovStockBrowser extends ModalJFrame {
 
 			public void actionPerformed(ActionEvent e) {
 				Medical medical = null;
-				if (movTable.getSelectedRow()>-1) { 
-					Movement movement = (Movement)(((MovBrowserModel) model).getValueAt(movTable.getSelectedRow(), -1));
+				if (movTable.getSelectedRow() > -1) {
+					Movement movement = (Movement) (((MovBrowserModel) model).getValueAt(movTable.getSelectedRow(), -1));
 					medical = movement.getMedical();
 				}
-				
-				StockCardDialog stockCardDialog = new StockCardDialog(MovStockBrowser.this, 
-						medical, 
-						movDateFrom.getCompleteDate().getTime(), 
+
+				StockCardDialog stockCardDialog = new StockCardDialog(MovStockBrowser.this,
+						medical,
+						movDateFrom.getCompleteDate().getTime(),
 						movDateTo.getCompleteDate().getTime());
 				medical = stockCardDialog.getMedical();
 				Date dateFrom = stockCardDialog.getDateFrom();
 				Date dateTo = stockCardDialog.getDateTo();
 				boolean toExcel = stockCardDialog.isExcel();
-				
+
 				if (!stockCardDialog.isCancel()) {
 					if (medical == null) {
 						JOptionPane.showMessageDialog(MovStockBrowser.this,
@@ -255,18 +260,19 @@ public class MovStockBrowser extends ModalJFrame {
 		});
 		return stockCardButton;
 	}
-	
+
 	private JButton getStockLedgerButton() {
 		stockLedgerButton = new JButton(MessageBundle.getMessage("angal.medicalstock.stockledger"));
 		stockLedgerButton.setMnemonic(KeyEvent.VK_L);
 		stockLedgerButton.addActionListener(new ActionListener() {
 
 			public void actionPerformed(ActionEvent e) {
-				
-				StockLedgerDialog stockCardDialog = new StockLedgerDialog(MovStockBrowser.this, movDateFrom.getCompleteDate().getTime(), movDateTo.getCompleteDate().getTime());
+
+				StockLedgerDialog stockCardDialog = new StockLedgerDialog(MovStockBrowser.this, movDateFrom.getCompleteDate().getTime(),
+						movDateTo.getCompleteDate().getTime());
 				Date dateFrom = stockCardDialog.getDateFrom();
 				Date dateTo = stockCardDialog.getDateTo();
-				
+
 				if (!stockCardDialog.isCancel()) {
 					new GenericReportPharmaceuticalStockCard("ProductLedger_multi", dateFrom, dateTo, null, null, false);
 					return;
@@ -283,7 +289,7 @@ public class MovStockBrowser extends ModalJFrame {
 		tablePanel.add(getTableTotal(), BorderLayout.SOUTH);
 		return tablePanel;
 	}
-	
+
 	private JScrollPane getTable() {
 		JScrollPane scrollPane = new JScrollPane(getMovTable());
 		int totWidth = 0;
@@ -293,7 +299,7 @@ public class MovStockBrowser extends ModalJFrame {
 		scrollPane.setPreferredSize(new Dimension(totWidth, 450));
 		return scrollPane;
 	}
-	
+
 	private JScrollPane getTableTotal() {
 		JScrollPane scrollPane = new JScrollPane(getJTableTotal());
 		int totWidth = 0;
@@ -305,12 +311,13 @@ public class MovStockBrowser extends ModalJFrame {
 		scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_NEVER);
 		return scrollPane;
 	}
-	
+
 	public void updateTotals() {
-		if (jTableTotal == null) return;
+		if (jTableTotal == null)
+			return;
 		totalQti = 0;
 		totalAmount = new BigDecimal(0);
-		
+
 		// quantity
 		if (!medicalBox.getSelectedItem().equals(MessageBundle.getMessage("angal.medicalstock.all"))) {
 			for (Movement mov : moves) {
@@ -324,7 +331,7 @@ public class MovStockBrowser extends ModalJFrame {
 		} else {
 			jTableTotal.getModel().setValueAt(MessageBundle.getMessage("angal.common.notapplicable"), 0, 4);
 		}
-		
+
 		// amount
 		for (Movement mov : moves) {
 			BigDecimal itemAmount = new BigDecimal(mov.getQuantity());
@@ -375,7 +382,7 @@ public class MovStockBrowser extends ModalJFrame {
 		JPanel label1Panel = new JPanel(new FlowLayout(FlowLayout.CENTER));
 		label1Panel.add(new JLabel(MessageBundle.getMessage("angal.common.description")));
 		medicalPanel.add(label1Panel);
-                medicalPanel.add(getMedicalSearchPanel());
+		medicalPanel.add(getMedicalSearchPanel());
 		JPanel medicalDescPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
 		medicalDescPanel.add(getMedicalBox());
 		medicalPanel.add(medicalDescPanel);
@@ -468,12 +475,12 @@ public class MovStockBrowser extends ModalJFrame {
 	private JComboBox getWardBox() {
 		WardBrowserManager wbm = Context.getApplicationContext().getBean(WardBrowserManager.class);
 		wardBox = new JComboBox();
-		wardBox.setPreferredSize(new Dimension(130,25));
+		wardBox.setPreferredSize(new Dimension(130, 25));
 		wardBox.addItem(MessageBundle.getMessage("angal.medicalstock.all"));
 		ArrayList<Ward> wardList;
 		try {
 			wardList = wbm.getWards();
-		}catch(OHServiceException e){
+		} catch (OHServiceException e) {
 			wardList = new ArrayList<Ward>();
 			OHServiceExceptionUtil.showMessages(e);
 		}
@@ -484,59 +491,66 @@ public class MovStockBrowser extends ModalJFrame {
 		return wardBox;
 	}
 
-        private JPanel getMedicalSearchPanel() {
-            searchButton = new JButton();
-            searchButton.setPreferredSize(new Dimension(20, 20));
-            searchButton.setIcon(new ImageIcon("rsc/icons/zoom_r_button.png"));
-            searchButton.addActionListener(new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent ae) {
-                    medicalBox.removeAllItems();
-                    ArrayList<Medical> medicals;
-                    try {
-                            medicals = medicalManager.getMedicals();
-                    } catch (OHServiceException e1) {
-                            medicals = null;
-                            OHServiceExceptionUtil.showMessages(e1);
-                    }
-                    if (null != medicals) {
-                        ArrayList<Medical> results = getSearchMedicalsResults(searchTextField.getText(), medicals);
-                        int originalSize = medicals.size();
-                        int resultsSize = results.size();
-                        if(originalSize == resultsSize) {
-                            medicalBox.addItem(MessageBundle.getMessage("angal.medicalstock.all"));
-                        }
-                        for (Medical aMedical: results) {
-                            medicalBox.addItem(aMedical);
-                        }
-                    }
-                }
-            });
-            
-            searchTextField = new JTextField(10);
-            searchTextField.setToolTipText(MessageBundle.getMessage("angal.medicalstock.pharmaceutical"));
-            searchTextField.addKeyListener(new KeyListener() {
-                @Override
-                public void keyPressed(KeyEvent e) {
-                    int key = e.getKeyCode();
-                    if (key == KeyEvent.VK_ENTER) {
-                        searchButton.doClick();
-                    }
-                }
-                @Override
-                public void keyReleased(KeyEvent e) {}
-                @Override
-                public void keyTyped(KeyEvent e) {}
-            });
-            
-            searchPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
-            searchPanel.add(searchTextField);
-            searchPanel.add(searchButton);
-            searchPanel.setMaximumSize(new Dimension(150, 25));
-            searchPanel.setMinimumSize(new Dimension(150, 25));
-            searchPanel.setPreferredSize(new Dimension(150, 25));
-            return searchPanel;
-        }
+	private JPanel getMedicalSearchPanel() {
+		searchButton = new JButton();
+		searchButton.setPreferredSize(new Dimension(20, 20));
+		searchButton.setIcon(new ImageIcon("rsc/icons/zoom_r_button.png"));
+		searchButton.addActionListener(new ActionListener() {
+
+			@Override
+			public void actionPerformed(ActionEvent ae) {
+				medicalBox.removeAllItems();
+				ArrayList<Medical> medicals;
+				try {
+					medicals = medicalManager.getMedicals();
+				} catch (OHServiceException e1) {
+					medicals = null;
+					OHServiceExceptionUtil.showMessages(e1);
+				}
+				if (null != medicals) {
+					ArrayList<Medical> results = getSearchMedicalsResults(searchTextField.getText(), medicals);
+					int originalSize = medicals.size();
+					int resultsSize = results.size();
+					if (originalSize == resultsSize) {
+						medicalBox.addItem(MessageBundle.getMessage("angal.medicalstock.all"));
+					}
+					for (Medical aMedical : results) {
+						medicalBox.addItem(aMedical);
+					}
+				}
+			}
+		});
+
+		searchTextField = new JTextField(10);
+		searchTextField.setToolTipText(MessageBundle.getMessage("angal.medicalstock.pharmaceutical"));
+		searchTextField.addKeyListener(new KeyListener() {
+
+			@Override
+			public void keyPressed(KeyEvent e) {
+				int key = e.getKeyCode();
+				if (key == KeyEvent.VK_ENTER) {
+					searchButton.doClick();
+				}
+			}
+
+			@Override
+			public void keyReleased(KeyEvent e) {
+			}
+
+			@Override
+			public void keyTyped(KeyEvent e) {
+			}
+		});
+
+		searchPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
+		searchPanel.add(searchTextField);
+		searchPanel.add(searchButton);
+		searchPanel.setMaximumSize(new Dimension(150, 25));
+		searchPanel.setMinimumSize(new Dimension(150, 25));
+		searchPanel.setPreferredSize(new Dimension(150, 25));
+		return searchPanel;
+	}
+
 	private JComboBox getMedicalBox() {
 		medicalBox = new JComboBox();
 		medicalBox.setMaximumSize(new Dimension(150, 25));
@@ -556,6 +570,7 @@ public class MovStockBrowser extends ModalJFrame {
 			}
 		}
 		medicalBox.addMouseListener(new MouseListener() {
+
 			public void mouseExited(MouseEvent e) {
 			}
 
@@ -580,22 +595,23 @@ public class MovStockBrowser extends ModalJFrame {
 
 	private JComboBox getMedicalTypeBox() {
 		medicalTypeBox = new JComboBox();
-		medicalTypeBox.setPreferredSize(new Dimension(130,25));
+		medicalTypeBox.setPreferredSize(new Dimension(130, 25));
 		ArrayList<MedicalType> medical;
-		
+
 		medicalTypeBox.addItem(MessageBundle.getMessage("angal.medicalstock.all"));
-		
+
 		try {
 			medical = medicalTypeBrowserManager.getMedicalType();
-			
+
 			for (MedicalType aMedicalType : medical) {
 				medicalTypeBox.addItem(aMedicalType);
 			}
 		} catch (OHServiceException e1) {
 			OHServiceExceptionUtil.showMessages(e1);
 		}
-		
+
 		medicalTypeBox.addMouseListener(new MouseListener() {
+
 			public void mouseExited(MouseEvent e) {
 			}
 
@@ -620,7 +636,7 @@ public class MovStockBrowser extends ModalJFrame {
 
 	private JComboBox getMovementTypeBox() {
 		typeBox = new JComboBox();
-		typeBox.setPreferredSize(new Dimension(130,25));
+		typeBox.setPreferredSize(new Dimension(130, 25));
 		ArrayList<MovementType> type;
 		try {
 			type = medicaldsrstockmovTypeBrowserManager.getMedicaldsrstockmovType();
@@ -635,6 +651,7 @@ public class MovStockBrowser extends ModalJFrame {
 			}
 		}
 		typeBox.addActionListener(new ActionListener() {
+
 			public void actionPerformed(ActionEvent e) {
 				if (!(typeBox.getSelectedItem() instanceof String)) {
 					MovementType selected = (MovementType) typeBox
@@ -655,40 +672,40 @@ public class MovStockBrowser extends ModalJFrame {
 	}
 
 	private JTable getMovTable() {
-		GregorianCalendar now=new GregorianCalendar();
-		GregorianCalendar old=new GregorianCalendar();
-		old.add(GregorianCalendar.WEEK_OF_YEAR,-1);
-		
-		model = new MovBrowserModel(null,null,null,null,old,now,null,null,null,null);
+		GregorianCalendar now = new GregorianCalendar();
+		GregorianCalendar old = new GregorianCalendar();
+		old.add(GregorianCalendar.WEEK_OF_YEAR, -1);
+
+		model = new MovBrowserModel(null, null, null, null, old, now, null, null, null, null);
 		movTable = new JTable(model);
-		
+
 		for (int i = 0; i < pColums.length; i++) {
 			movTable.getColumnModel().getColumn(i).setCellRenderer(new EnabledTableCellRenderer());
 			movTable.getColumnModel().getColumn(i).setPreferredWidth(pColumwidth[i]);
-//			if (!pColumnResizable[i]) {
-//				movTable.getColumnModel().getColumn(i).setResizable(pColumnResizable[i]);
-//				movTable.getColumnModel().getColumn(i).setMaxWidth(pColumwidth[i]);
-//			}
+			//			if (!pColumnResizable[i]) {
+			//				movTable.getColumnModel().getColumn(i).setResizable(pColumnResizable[i]);
+			//				movTable.getColumnModel().getColumn(i).setMaxWidth(pColumwidth[i]);
+			//			}
 			if (!pColumnVisible[i]) {
 				movTable.getColumnModel().getColumn(i).setMinWidth(0);
 				movTable.getColumnModel().getColumn(i).setMaxWidth(0);
 				movTable.getColumnModel().getColumn(i).setWidth(0);
 			}
 		}
-		
+
 		TableColumn costColumn = movTable.getColumnModel().getColumn(11);
 		costColumn.setCellRenderer(new DecimalFormatRenderer());
-		
+
 		TableColumn totalColumn = movTable.getColumnModel().getColumn(12);
 		totalColumn.setCellRenderer(new DecimalFormatRenderer());
-		
+
 		return movTable;
 	}
-	
+
 	private JTable getJTableTotal() {
 		if (jTableTotal == null) {
 			jTableTotal = new JTable();
-			
+
 			String currencyCod;
 			try {
 				currencyCod = hospitalManager.getHospitalCurrencyCod();
@@ -696,13 +713,15 @@ public class MovStockBrowser extends ModalJFrame {
 				currencyCod = null;
 				OHServiceExceptionUtil.showMessages(e);
 			}
-			
+
 			jTableTotal.setModel(new DefaultTableModel(
 					new Object[][] {
-							{"", "", "", "<html><b>Total Qty: </b></html>", totalQti, "", "", "", "", "", "<html><b>Total: </b></html>", currencyCod, totalAmount}
-							}, new String[pColums.length]) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+							{ "", "", "", "<html><b>Total Qty: </b></html>", totalQti, "", "", "", "", "", "<html><b>Total: </b></html>", currencyCod,
+									totalAmount }
+					}, new String[pColums.length]) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
 				private static final long serialVersionUID = 1L;
-	
+
 				public boolean isCellEditable(int row, int column) {
 					return false;
 				}
@@ -713,7 +732,7 @@ public class MovStockBrowser extends ModalJFrame {
 			jTableTotal.setRowSelectionAllowed(false);
 			jTableTotal.setCellSelectionEnabled(false);
 			jTableTotal.setColumnSelectionAllowed(false);
-			
+
 			for (int i = 0; i < pColums.length; i++) {
 				jTableTotal.getColumnModel().getColumn(i).setCellRenderer(new EnabledTableCellRenderer());
 				jTableTotal.getColumnModel().getColumn(i).setPreferredWidth(pColumwidth[i]);
@@ -723,11 +742,11 @@ public class MovStockBrowser extends ModalJFrame {
 					jTableTotal.getColumnModel().getColumn(i).setWidth(0);
 				}
 			}
-			
+
 			jTableTotal.getColumnModel().getColumn(3).setCellRenderer(new RightAlignCellRenderer());
 			TableColumn totalColumn = jTableTotal.getColumnModel().getColumn(4);
 			totalColumn.setCellRenderer(new DecimalFormatRenderer());
-			
+
 			jTableTotal.getColumnModel().getColumn(11).setCellRenderer(new RightAlignCellRenderer());
 			TableColumn totalAmountColumn = jTableTotal.getColumnModel().getColumn(12);
 			totalAmountColumn.setCellRenderer(new DecimalFormatRenderer());
@@ -770,7 +789,7 @@ public class MovStockBrowser extends ModalJFrame {
 
 	/**
 	 * this method creates the button that filters the data
-	 * 
+	 *
 	 * @return
 	 */
 
@@ -785,52 +804,52 @@ public class MovStockBrowser extends ModalJFrame {
 				String typeSelected = null;
 				String wardSelected = null;
 				boolean dateOk = true;
-				
-				GregorianCalendar movFrom=movDateFrom.getCompleteDate();
-				GregorianCalendar movTo=movDateTo.getCompleteDate();
-				if((movFrom==null)||(movTo==null)){
-					if(!((movFrom==null)&&(movTo==null))){
-						JOptionPane.showMessageDialog(null,MessageBundle.getMessage("angal.medicalstock.chooseavalidmovementdate"));
-						dateOk=false;
+
+				GregorianCalendar movFrom = movDateFrom.getCompleteDate();
+				GregorianCalendar movTo = movDateTo.getCompleteDate();
+				if ((movFrom == null) || (movTo == null)) {
+					if (!((movFrom == null) && (movTo == null))) {
+						JOptionPane.showMessageDialog(null, MessageBundle.getMessage("angal.medicalstock.chooseavalidmovementdate"));
+						dateOk = false;
 					}
-				}else if(movFrom.compareTo(
+				} else if (movFrom.compareTo(
 						movTo) > 0) {
-						JOptionPane
-								.showMessageDialog(null,
-										MessageBundle.getMessage("angal.medicalstock.movementdatefromcannotbelaterthanmovementdateto"));
-						dateOk = false;
-					}
-					
+					JOptionPane
+							.showMessageDialog(null,
+									MessageBundle.getMessage("angal.medicalstock.movementdatefromcannotbelaterthanmovementdateto"));
+					dateOk = false;
+				}
+
 				if (!isAutomaticLot()) {
-					GregorianCalendar prepFrom=lotPrepFrom.getCompleteDate();
-					GregorianCalendar prepTo=lotPrepTo.getCompleteDate();
-					if((prepFrom==null)||(prepTo==null)){
-						if(!((prepFrom==null)&&(prepTo==null))){
-							JOptionPane.showMessageDialog(null,MessageBundle.getMessage("angal.medicalstock.chooseavalidpreparationdate"));
-							dateOk=false;
-						}
-					}else if (prepFrom.compareTo(
-							prepTo) > 0) {
-							JOptionPane.showMessageDialog(null,
-									MessageBundle.getMessage("angal.medicalstock.preparationdatefromcannotbelaterpreparationdateto"));
+					GregorianCalendar prepFrom = lotPrepFrom.getCompleteDate();
+					GregorianCalendar prepTo = lotPrepTo.getCompleteDate();
+					if ((prepFrom == null) || (prepTo == null)) {
+						if (!((prepFrom == null) && (prepTo == null))) {
+							JOptionPane.showMessageDialog(null, MessageBundle.getMessage("angal.medicalstock.chooseavalidpreparationdate"));
 							dateOk = false;
-					}
-				}
-				
-				GregorianCalendar dueFrom=lotDueFrom.getCompleteDate();
-				GregorianCalendar dueTo=lotDueTo.getCompleteDate();
-				if((dueFrom==null)||(dueTo==null)){
-					if(!((dueFrom==null)&&(dueTo==null))){
-						JOptionPane.showMessageDialog(null,MessageBundle.getMessage("angal.medicalstock.chooseavalidduedate"));
-						dateOk=false;
-					}
-				}else if (dueFrom.compareTo(
-						dueTo) > 0) {
+						}
+					} else if (prepFrom.compareTo(
+							prepTo) > 0) {
 						JOptionPane.showMessageDialog(null,
-								MessageBundle.getMessage("angal.medicalstock.duedatefromcannotbelaterthanduedateto"));
+								MessageBundle.getMessage("angal.medicalstock.preparationdatefromcannotbelaterpreparationdateto"));
 						dateOk = false;
+					}
 				}
-				
+
+				GregorianCalendar dueFrom = lotDueFrom.getCompleteDate();
+				GregorianCalendar dueTo = lotDueTo.getCompleteDate();
+				if ((dueFrom == null) || (dueTo == null)) {
+					if (!((dueFrom == null) && (dueTo == null))) {
+						JOptionPane.showMessageDialog(null, MessageBundle.getMessage("angal.medicalstock.chooseavalidduedate"));
+						dateOk = false;
+					}
+				} else if (dueFrom.compareTo(
+						dueTo) > 0) {
+					JOptionPane.showMessageDialog(null,
+							MessageBundle.getMessage("angal.medicalstock.duedatefromcannotbelaterthanduedateto"));
+					dateOk = false;
+				}
+
 				if (dateOk) {
 					if (medicalBox.isEnabled()) {
 						if (!(medicalBox.getSelectedItem() instanceof String)) {
@@ -854,23 +873,23 @@ public class MovStockBrowser extends ModalJFrame {
 					if (!isAutomaticLot()) {
 						model = new MovBrowserModel(medicalSelected,
 								medicalTypeSelected, wardSelected, typeSelected,
-								movDateFrom.getCompleteDate(), 
-								movDateTo.getCompleteDate(), 
-								lotPrepFrom.getCompleteDate(), 
-								lotPrepTo.getCompleteDate(), 
-								lotDueFrom.getCompleteDate(), 
+								movDateFrom.getCompleteDate(),
+								movDateTo.getCompleteDate(),
+								lotPrepFrom.getCompleteDate(),
+								lotPrepTo.getCompleteDate(),
+								lotDueFrom.getCompleteDate(),
 								lotDueTo.getCompleteDate());
 					} else {
 						model = new MovBrowserModel(medicalSelected,
 								medicalTypeSelected, wardSelected, typeSelected,
-								movDateFrom.getCompleteDate(), 
-								movDateTo.getCompleteDate(), 
-								null, 
-								null, 
-								lotDueFrom.getCompleteDate(), 
+								movDateFrom.getCompleteDate(),
+								movDateTo.getCompleteDate(),
+								null,
+								null,
+								lotDueFrom.getCompleteDate(),
 								lotDueTo.getCompleteDate());
 					}
-					
+
 					if (moves != null) {
 						model.fireTableDataChanged();
 						movTable.updateUI();
@@ -885,13 +904,14 @@ public class MovStockBrowser extends ModalJFrame {
 
 	/**
 	 * this method creates the button that close the mask
-	 * 
+	 *
 	 * @return
 	 */
 	private JButton getCloseButton() {
 		closeButton = new JButton(MessageBundle.getMessage("angal.common.close"));
 		closeButton.setMnemonic(KeyEvent.VK_C);
 		closeButton.addActionListener(new ActionListener() {
+
 			public void actionPerformed(ActionEvent e) {
 				dispose();
 			}
@@ -904,7 +924,7 @@ public class MovStockBrowser extends ModalJFrame {
 	 * this method creates the button that deletes all the records in
 	 * medicaldsrstockmov and lot it is for training pourposes only to be
 	 * deleted in production environment
-	 * 
+	 *
 	 * @return
 	 */
 	/*private JButton getdeleteAllButton() {
@@ -938,30 +958,30 @@ public class MovStockBrowser extends ModalJFrame {
 		return deleteAllButton;
 	}*/
 
-//	/**
-//	 * this method creates the button that load the insert movement mask
-//	 * 
-//	 * @return
-//	 */
-//	private JButton getInsertButton() {
-//		insertButton = new JButton(MessageBundle.getMessage("angal.medicalstock.insert"));
-//		insertButton.setMnemonic(KeyEvent.VK_I);
-//		insertButton.addActionListener(new ActionListener() {
-//
-//			public void actionPerformed(ActionEvent e) {
-//				new MovStockInserting(myFrame);
-//				model = new MovBrowserModel();
-//				//model.fireTableDataChanged();
-//				movTable.updateUI();
-//				if (jCheckBoxKeepFilter.isSelected()) filterButton.doClick();
-//			}
-//		});
-//		return insertButton;
-//	}
-	
+	//	/**
+	//	 * this method creates the button that load the insert movement mask
+	//	 *
+	//	 * @return
+	//	 */
+	//	private JButton getInsertButton() {
+	//		insertButton = new JButton(MessageBundle.getMessage("angal.medicalstock.insert"));
+	//		insertButton.setMnemonic(KeyEvent.VK_I);
+	//		insertButton.addActionListener(new ActionListener() {
+	//
+	//			public void actionPerformed(ActionEvent e) {
+	//				new MovStockInserting(myFrame);
+	//				model = new MovBrowserModel();
+	//				//model.fireTableDataChanged();
+	//				movTable.updateUI();
+	//				if (jCheckBoxKeepFilter.isSelected()) filterButton.doClick();
+	//			}
+	//		});
+	//		return insertButton;
+	//	}
+
 	/**
 	 * this method creates the button that load the charging movement mask
-	 * 
+	 *
 	 * @return
 	 */
 	private JButton getChargeButton() {
@@ -975,15 +995,16 @@ public class MovStockBrowser extends ModalJFrame {
 				//model.fireTableDataChanged();
 				movTable.updateUI();
 				updateTotals();
-				if (jCheckBoxKeepFilter.isSelected()) filterButton.doClick();
+				if (jCheckBoxKeepFilter.isSelected())
+					filterButton.doClick();
 			}
 		});
 		return chargeButton;
 	}
-	
+
 	/**
 	 * this method creates the button that load the discharging movement mask
-	 * 
+	 *
 	 * @return
 	 */
 	private JButton getDishargeButton() {
@@ -997,70 +1018,68 @@ public class MovStockBrowser extends ModalJFrame {
 				//model.fireTableDataChanged();
 				movTable.updateUI();
 				updateTotals();
-				if (jCheckBoxKeepFilter.isSelected()) filterButton.doClick();
+				if (jCheckBoxKeepFilter.isSelected())
+					filterButton.doClick();
 			}
 		});
 		return dischargeButton;
 	}
-	
-//	private JButton getImportFromExcelButton()
-//	{
-//		importFromExcel = new JButton(MessageBundle.getMessage("angal.medicalstock.import"));
-//		importFromExcel.setMnemonic(KeyEvent.VK_I);
-//		importFromExcel.addActionListener(new ActionListener()
-//		{
-//			public void actionPerformed(ActionEvent e) {
-//				
-//				JFileChooser fcExcel = new JFileChooser();
-//				FileNameExtensionFilter excelFilter = new FileNameExtensionFilter("Excel (*.xls)","xls");
-//				fcExcel.setFileFilter(excelFilter);
-//				
-//				int iRetVal = fcExcel.showOpenDialog(MovStockBrowser.this);
-//				if(iRetVal == JFileChooser.APPROVE_OPTION)
-//				{
-//					ExcelImporter xlsImport = new ExcelImporter();
-//					try
-//					{
-//						xlsImport.OpenInTable(movTable, fcExcel.getSelectedFile());
-//						movTable.updateUI();
-//					} catch(IOException exc)
-//					{
-//						System.out.println("Import to excel error : "+exc.getMessage());
-//					}
-//				}
-//			}
-//		});
-//		return importFromExcel;
-//	}
-	
-	private JButton getExportToExcelButton()
-	{
+
+	//	private JButton getImportFromExcelButton()
+	//	{
+	//		importFromExcel = new JButton(MessageBundle.getMessage("angal.medicalstock.import"));
+	//		importFromExcel.setMnemonic(KeyEvent.VK_I);
+	//		importFromExcel.addActionListener(new ActionListener()
+	//		{
+	//			public void actionPerformed(ActionEvent e) {
+	//
+	//				JFileChooser fcExcel = new JFileChooser();
+	//				FileNameExtensionFilter excelFilter = new FileNameExtensionFilter("Excel (*.xls)","xls");
+	//				fcExcel.setFileFilter(excelFilter);
+	//
+	//				int iRetVal = fcExcel.showOpenDialog(MovStockBrowser.this);
+	//				if(iRetVal == JFileChooser.APPROVE_OPTION)
+	//				{
+	//					ExcelImporter xlsImport = new ExcelImporter();
+	//					try
+	//					{
+	//						xlsImport.OpenInTable(movTable, fcExcel.getSelectedFile());
+	//						movTable.updateUI();
+	//					} catch(IOException exc)
+	//					{
+	//						System.out.println("Import to excel error : "+exc.getMessage());
+	//					}
+	//				}
+	//			}
+	//		});
+	//		return importFromExcel;
+	//	}
+
+	private JButton getExportToExcelButton() {
 		exportToExcel = new JButton(MessageBundle.getMessage("angal.medicalstock.export"));
 		exportToExcel.setMnemonic(KeyEvent.VK_E);
-		exportToExcel.addActionListener(new ActionListener()
-		{
+		exportToExcel.addActionListener(new ActionListener() {
+
 			public void actionPerformed(ActionEvent e) {
 
 				String fileName = compileFileName();
 				File defaultFileName = new File(fileName);
 				JFileChooser fcExcel = ExcelExporter.getJFileChooserExcel(defaultFileName);
-				
+
 				int iRetVal = fcExcel.showSaveDialog(MovStockBrowser.this);
-				if(iRetVal == JFileChooser.APPROVE_OPTION)
-				{
+				if (iRetVal == JFileChooser.APPROVE_OPTION) {
 					File exportFile = fcExcel.getSelectedFile();
-					if (!exportFile.getName().endsWith("xls")) exportFile = new File(exportFile.getAbsoluteFile() + ".xls");
+					if (!exportFile.getName().endsWith("xls"))
+						exportFile = new File(exportFile.getAbsoluteFile() + ".xls");
 					ExcelExporter xlsExport = new ExcelExporter();
-					try
-					{
+					try {
 						xlsExport.exportTableToExcel(movTable, exportFile);
-					} catch(IOException exc)
-					{
+					} catch (IOException exc) {
 						JOptionPane.showMessageDialog(MovStockBrowser.this,
 								exc.getMessage(),
-		                        MessageBundle.getMessage("angal.hospital"),
-		                        JOptionPane.PLAIN_MESSAGE);	
-						logger.info("Export to excel error : "+ exc.getMessage());
+								MessageBundle.getMessage("angal.hospital"),
+								JOptionPane.PLAIN_MESSAGE);
+						logger.info("Export to excel error : {}", exc.getMessage());
 					}
 				}
 			}
@@ -1068,31 +1087,30 @@ public class MovStockBrowser extends ModalJFrame {
 		return exportToExcel;
 	}
 
-
 	private String compileFileName() {
 		StringBuilder filename = new StringBuilder("Stock Ledger");
-		if (medicalBox.isEnabled() 
+		if (medicalBox.isEnabled()
 				&& !medicalBox.getSelectedItem().equals(
-						MessageBundle.getMessage("angal.medicalstock.all"))) {
-			
+				MessageBundle.getMessage("angal.medicalstock.all"))) {
+
 			filename.append("_").append(medicalBox.getSelectedItem());
 		}
 		if (medicalTypeBox.isEnabled()
 				&& !medicalTypeBox.getSelectedItem().equals(
-						MessageBundle.getMessage("angal.medicalstock.all"))) {
-			
+				MessageBundle.getMessage("angal.medicalstock.all"))) {
+
 			filename.append("_").append(medicalTypeBox.getSelectedItem());
 		}
 		if (typeBox.isEnabled() &&
 				!typeBox.getSelectedItem().equals(
 						MessageBundle.getMessage("angal.medicalstock.all"))) {
-			
+
 			filename.append("_").append(typeBox.getSelectedItem());
 		}
 		if (wardBox.isEnabled() &&
 				!wardBox.getSelectedItem().equals(
 						MessageBundle.getMessage("angal.medicalstock.all"))) {
-			
+
 			filename.append("_").append(wardBox.getSelectedItem());
 		}
 		filename.append("_").append(TimeTools.formatDateTime(movDateFrom.getCompleteDate(), "yyyyMMdd"))
@@ -1100,49 +1118,48 @@ public class MovStockBrowser extends ModalJFrame {
 		return filename.toString();
 	}
 
-        private ArrayList<Medical> getSearchMedicalsResults(String s, ArrayList<Medical> medicalsList) {
-            String query = s.trim();
-            ArrayList<Medical> results = new ArrayList<Medical>();
-            for (Medical medoc : medicalsList) {
-                if(!query.equals("")) {
-                    String[] patterns = query.split(" ");
-                    String code = medoc.getProd_code().toLowerCase();
-                    String description = medoc.getDescription().toLowerCase();
-                    boolean patternFound = false;
-                    for (String pattern : patterns) {
-                        if (code.contains(pattern.toLowerCase()) || description.contains(pattern.toLowerCase())) {
-                            patternFound = true;
-                            //It is sufficient that only one pattern matches the query
-                            break;
-                        }
-                    }
-                    if (patternFound){
-                        results.add(medoc);
-                    }
-                } else {
-                    results.add(medoc);
-                }
-            }		
-            return results;
-        }    
+	private ArrayList<Medical> getSearchMedicalsResults(String s, ArrayList<Medical> medicalsList) {
+		String query = s.trim();
+		ArrayList<Medical> results = new ArrayList<Medical>();
+		for (Medical medoc : medicalsList) {
+			if (!query.equals("")) {
+				String[] patterns = query.split(" ");
+				String code = medoc.getProd_code().toLowerCase();
+				String description = medoc.getDescription().toLowerCase();
+				boolean patternFound = false;
+				for (String pattern : patterns) {
+					if (code.contains(pattern.toLowerCase()) || description.contains(pattern.toLowerCase())) {
+						patternFound = true;
+						//It is sufficient that only one pattern matches the query
+						break;
+					}
+				}
+				if (patternFound) {
+					results.add(medoc);
+				}
+			} else {
+				results.add(medoc);
+			}
+		}
+		return results;
+	}
 
 	/**
 	 * This is the table model
-	 * 
 	 */
 	class MovBrowserModel extends DefaultTableModel {
 
 		/**
-		 * 
+		 *
 		 */
 		private static final long serialVersionUID = 1L;
 
 		public MovBrowserModel() {
-			GregorianCalendar now=new GregorianCalendar();
-			GregorianCalendar old=new GregorianCalendar();
-			old.add(GregorianCalendar.WEEK_OF_YEAR,-1);
-			
-			new MovBrowserModel(null,null,null,null,old,now,null,null,null,null);
+			GregorianCalendar now = new GregorianCalendar();
+			GregorianCalendar old = new GregorianCalendar();
+			old.add(GregorianCalendar.WEEK_OF_YEAR, -1);
+
+			new MovBrowserModel(null, null, null, null, old, now, null, null, null, null);
 			updateTotals();
 		}
 
@@ -1177,7 +1194,7 @@ public class MovStockBrowser extends ModalJFrame {
 
 		/**
 		 * Note: We must get the objects in a reversed way because of the query
-		 * 
+		 *
 		 * @see org.isf.medicalstock.service.MedicalStockIoOperations
 		 */
 		public Object getValueAt(int r, int c) {
@@ -1207,19 +1224,20 @@ public class MovStockBrowser extends ModalJFrame {
 			} else if (c == ++col) {
 				return movement.getMedical().getType().getDescription();
 			} else if (c == ++col) {
-				if(isAutomaticLot())
+				if (isAutomaticLot())
 					return MessageBundle.getMessage("angal.medicalstock.generated");
-				else return lot;
+				else
+					return lot;
 			} else if (c == ++col) {
 				return formatDate(lot.getPreparationDate());
 			} else if (c == ++col) {
 				return formatDate(lot.getDueDate());
-			} else if (c == ++col){
+			} else if (c == ++col) {
 				Supplier origin = movement.getOrigin();
 				return origin != null ? supMap.get(new Integer(origin.getSupId())) : "";
-			} else if (c == ++col){
+			} else if (c == ++col) {
 				return cost;
-			} else if (c == ++col && cost != null){
+			} else if (c == ++col && cost != null) {
 				return cost.multiply(new BigDecimal(qty));
 			}
 			return null;
@@ -1237,33 +1255,35 @@ public class MovStockBrowser extends ModalJFrame {
 		SimpleDateFormat sdf = new SimpleDateFormat(DATE_FORMAT_DD_MM_YY);
 		return sdf.format(time.getTime());
 	}
-	
+
 	private String formatDateTime(GregorianCalendar time) {
 		if (time == null)
 			return MessageBundle.getMessage("angal.medicalstock.nodate");
 		SimpleDateFormat sdf = new SimpleDateFormat(DATE_FORMAT_DD_MM_YY_HH_MM);
 		return sdf.format(time.getTime());
 	}
-	
+
 	class EnabledTableCellRenderer extends DefaultTableCellRenderer {
+
 		/**
-		 * 
+		 *
 		 */
 		private static final long serialVersionUID = 1L;
 
 		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
 			Component cell = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
 			setHorizontalAlignment(columnAlignment[column]);
-			if (pColumnBold[column]) { 
+			if (pColumnBold[column]) {
 				cell.setFont(new Font(null, Font.BOLD, 12));
 			}
 			return cell;
 		}
 	}
-	
+
 	class RightAlignCellRenderer extends DefaultTableCellRenderer {
+
 		/**
-		 * 
+		 *
 		 */
 		private static final long serialVersionUID = 1L;
 
@@ -1273,10 +1293,11 @@ public class MovStockBrowser extends ModalJFrame {
 			return cell;
 		}
 	}
-	
+
 	class DecimalFormatRenderer extends DefaultTableCellRenderer {
+
 		/**
-		 * 
+		 *
 		 */
 		private static final long serialVersionUID = 1L;
 		private final DecimalFormat formatter100 = new DecimalFormat("#,##0.000");
@@ -1286,9 +1307,12 @@ public class MovStockBrowser extends ModalJFrame {
 		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
 			Component cell = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
 			setHorizontalAlignment(columnAlignment[column]);
-			if (column == 4 && value instanceof Number) value = formatter1.format((Number) value);
-			if (column == 11 && value instanceof Number) value = formatter100.format((Number) value);
-			if (column == 12 && value instanceof Number) value = formatter10.format((Number) value);
+			if (column == 4 && value instanceof Number)
+				value = formatter1.format((Number) value);
+			if (column == 11 && value instanceof Number)
+				value = formatter100.format((Number) value);
+			if (column == 12 && value instanceof Number)
+				value = formatter10.format((Number) value);
 			return super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
 		}
 	}

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
@@ -84,10 +84,10 @@ import org.isf.ward.model.Ward;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class WardPharmacy extends ModalJFrame implements 
-	WardPharmacyEdit.MovementWardListeners, 
-	WardPharmacyNew.MovementWardListeners, 
-	WardPharmacyRectify.MovementWardListeners {
+public class WardPharmacy extends ModalJFrame implements
+		WardPharmacyEdit.MovementWardListeners,
+		WardPharmacyNew.MovementWardListeners,
+		WardPharmacyRectify.MovementWardListeners {
 
 	public void movementInserted(AWTEvent e) {
 		jTableOutcomes.setModel(new OutcomesModel());
@@ -102,9 +102,9 @@ public class WardPharmacy extends ModalJFrame implements
 	}
 	
 	private static final long serialVersionUID = 1L;
-	
+
 	private static Logger logger = LoggerFactory.getLogger(WardPharmacy.class);
-	
+
 	private JComboBox jComboBoxWard;
 	private JLabel jLabelWard;
 	private JLabel jLabelFrom;
@@ -153,7 +153,7 @@ public class WardPharmacy extends ModalJFrame implements
 	// private Medical drugSelected;
 	private MovementWard movSelected;
 	private boolean added = false;
-	private String[] columsIncomes = { 
+	private String[] columsIncomes = {
 			MessageBundle.getMessage("angal.common.date"), //$NON-NLS-1$
 			MessageBundle.getMessage("angal.common.from"), //$NON-NLS-1$
 			MessageBundle.getMessage("angal.medicalstockward.medical"), //$NON-NLS-1$
@@ -163,8 +163,8 @@ public class WardPharmacy extends ModalJFrame implements
 			MessageBundle.getMessage("angal.medicalstock.lotduedate") //$NON-NLS-1$
 	};
 	private boolean[] columsResizableIncomes = { true, true, true, true, true, true, true };
-	private int[] columWidthIncomes = { 80, 50, 50, 50, 50 , 50, 50};
-	private String[] columsOutcomes = { 
+	private int[] columWidthIncomes = { 80, 50, 50, 50, 50, 50, 50 };
+	private String[] columsOutcomes = {
 			MessageBundle.getMessage("angal.common.date"),  //$NON-NLS-1$
 			MessageBundle.getMessage("angal.medicalstockward.purpose"), //$NON-NLS-1$
 			MessageBundle.getMessage("angal.medicalstockward.age"),  //$NON-NLS-1$
@@ -178,14 +178,14 @@ public class WardPharmacy extends ModalJFrame implements
 	};
 	private boolean[] columsResizableOutcomes = { false, true, false, false, false, true, false, false, true };
 	private int[] columWidthOutcomes = { 150, 150, 50, 50, 50, 170, 50, 50, 50 };
-	private String[] columsDrugs = { 
+	private String[] columsDrugs = {
 			MessageBundle.getMessage("angal.medicalstockward.medical"), //$NON-NLS-1$
 			MessageBundle.getMessage("angal.common.quantity"), //$NON-NLS-1$
 			MessageBundle.getMessage("angal.medicalstockward.units"), //$NON-NLS-1$
 			"" //$NON-NLS-1$
 	};
-	private boolean[] columsResizableDrugs = { true, true, true, true};
-	private int[] columWidthDrugs = { 150, 50, 50, 50};
+	private boolean[] columsResizableDrugs = { true, true, true, true };
+	private int[] columWidthDrugs = { 150, 50, 50, 50 };
 	private final int filterWidth = 250;
 	private final int filterSpacing = 5;
 	private String rowCounterText = MessageBundle.getMessage("angal.medicalstockward.count") + ": "; //$NON-NLS-1$ //$NON-NLS-2$
@@ -212,16 +212,16 @@ public class WardPharmacy extends ModalJFrame implements
 	private ArrayList<MedicalWard> wardDrugs;
 	private ArrayList<MovementWard> wardOutcomes;
 	private ArrayList<Movement> wardIncomes;
-	
+
 	//private static final String PREFERRED_LOOK_AND_FEEL = "javax.swing.plaf.metal.MetalLookAndFeel"; //$NON-NLS-1$
 
-        /*
-         *Adds to facilitate the selection of products 
-         */
-        private JPanel searchPanel;
-        private JTextField searchTextField;
-        private JButton searchButton;
-        
+	/*
+	 *Adds to facilitate the selection of products
+	 */
+	private JPanel searchPanel;
+	private JTextField searchTextField;
+	private JButton searchButton;
+
 	public WardPharmacy() {
 		if (MainMenu.checkUserGrants("btnmedicalswardedit")) //$NON-NLS-1$
 			editAllowed = true;
@@ -272,43 +272,40 @@ public class WardPharmacy extends ModalJFrame implements
 		}
 		return jPanelButtons;
 	}
-	
+
 	private JButton getJButtonStockCard() {
 		if (jButtonStockCard == null) {
 			jButtonStockCard = new JButton(MessageBundle.getMessage("angal.medicalstockward.stockcard"));
 			jButtonStockCard.setMnemonic(KeyEvent.VK_K);
 			jButtonStockCard.setVisible(false);
-			jButtonStockCard.addActionListener(new ActionListener(){
-				public void actionPerformed(ActionEvent event){
+			jButtonStockCard.addActionListener(new ActionListener() {
+
+				public void actionPerformed(ActionEvent event) {
 
 					Medical medical = null;
-					if (jTabbedPaneWard.getSelectedIndex() == 0) 
-					{
+					if (jTabbedPaneWard.getSelectedIndex() == 0) {
 						if (jTableOutcomes.getSelectedRow() >= 0) {
 							MovementWard movWard = (MovementWard) ((jTableOutcomes.getModel()).getValueAt(jTableOutcomes.getSelectedRow(), -1));
 							medical = movWard.getMedical();
 						}
-					} 
-					else if (jTabbedPaneWard.getSelectedIndex() == 1) 
-					{
+					} else if (jTabbedPaneWard.getSelectedIndex() == 1) {
 						if (jTableIncomes.getSelectedRow() >= 0) {
 							Movement mov = (Movement) ((jTableIncomes.getModel()).getValueAt(jTableIncomes.getSelectedRow(), -1));
 							medical = mov.getMedical();
 						}
-					} 
-					else if (jTabbedPaneWard.getSelectedIndex() == 2) {
+					} else if (jTabbedPaneWard.getSelectedIndex() == 2) {
 						if (jTableDrugs.getSelectedRow() >= 0) {
 							MedicalWard medicalWard = (MedicalWard) ((jTableDrugs.getModel()).getValueAt(jTableDrugs.getSelectedRow(), -1));
 							medical = medicalWard.getMedical();
 						}
 					}
-					
+
 					StockCardDialog stockCardDialog = new StockCardDialog(WardPharmacy.this, medical, dateFrom.getTime(), dateTo.getTime());
 					medical = stockCardDialog.getMedical();
 					Date dateFrom = stockCardDialog.getDateFrom();
 					Date dateTo = stockCardDialog.getDateTo();
 					boolean toExcel = stockCardDialog.isExcel();
-					
+
 					if (!stockCardDialog.isCancel()) {
 						new GenericReportPharmaceuticalStockCard("ProductLedgerWard", dateFrom, dateTo, medical, wardSelected, toExcel);
 						return;
@@ -348,7 +345,7 @@ public class WardPharmacy extends ModalJFrame implements
 				public void actionPerformed(ActionEvent e) {
 
 					if (jTableOutcomes.getSelectedRow() < 0 || !jScrollPaneOutcomes.isShowing()) {
-						JOptionPane.showMessageDialog(WardPharmacy.this, 
+						JOptionPane.showMessageDialog(WardPharmacy.this,
 								MessageBundle.getMessage("angal.medicalstockward.pleaseselectanoutcomesmovementfirst"), //$NON-NLS-1$  
 								MessageBundle.getMessage("angal.hospital"), //$NON-NLS-1$
 								JOptionPane.PLAIN_MESSAGE);
@@ -425,13 +422,13 @@ public class WardPharmacy extends ModalJFrame implements
 			jCalendarTo.setDateFormatString("dd/MM/yy"); //$NON-NLS-1$
 			jCalendarTo.addPropertyChangeListener("date", new PropertyChangeListener() { //$NON-NLS-1$
 
-						public void propertyChange(PropertyChangeEvent evt) {
-							dateTo.setTime((Date) evt.getNewValue());
-							jTableOutcomes.setModel(new OutcomesModel());
-							jTableIncomes.setModel(new IncomesModel());
-							rowCounter.setText(rowCounterText + jTableOutcomes.getRowCount());
-						}
-					});
+				public void propertyChange(PropertyChangeEvent evt) {
+					dateTo.setTime((Date) evt.getNewValue());
+					jTableOutcomes.setModel(new OutcomesModel());
+					jTableIncomes.setModel(new IncomesModel());
+					rowCounter.setText(rowCounterText + jTableOutcomes.getRowCount());
+				}
+			});
 			jCalendarTo.setEnabled(false);
 		}
 		return jCalendarTo;
@@ -447,13 +444,13 @@ public class WardPharmacy extends ModalJFrame implements
 			jCalendarFrom.setDateFormatString("dd/MM/yy"); //$NON-NLS-1$
 			jCalendarFrom.addPropertyChangeListener("date", new PropertyChangeListener() { //$NON-NLS-1$
 
-						public void propertyChange(PropertyChangeEvent evt) {
-							dateFrom.setTime((Date) evt.getNewValue());
-							jTableOutcomes.setModel(new OutcomesModel());
-							jTableIncomes.setModel(new IncomesModel());
-							rowCounter.setText(rowCounterText + jTableOutcomes.getRowCount());
-						}
-					});
+				public void propertyChange(PropertyChangeEvent evt) {
+					dateFrom.setTime((Date) evt.getNewValue());
+					jTableOutcomes.setModel(new OutcomesModel());
+					jTableIncomes.setModel(new IncomesModel());
+					rowCounter.setText(rowCounterText + jTableOutcomes.getRowCount());
+				}
+			});
 			jCalendarFrom.setEnabled(false);
 		}
 		return jCalendarFrom;
@@ -480,14 +477,14 @@ public class WardPharmacy extends ModalJFrame implements
 		}
 		return jTableIncomes;
 	}
-    
+
 	private JScrollPane getJScrollPaneDrugs() {
 		if (jScrollPaneDrugs == null) {
 			jScrollPaneDrugs = new JScrollPane();
-			jScrollPaneDrugs.setBorder (BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder (),
+			jScrollPaneDrugs.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
 					MessageBundle.getMessage("angal.medicalstock.clickdrugs"),
-                    TitledBorder.LEFT,
-                    TitledBorder.TOP));
+					TitledBorder.LEFT,
+					TitledBorder.TOP));
 			jScrollPaneDrugs.setViewportView(getJTableDrugs());
 		}
 		return jScrollPaneDrugs;
@@ -497,82 +494,84 @@ public class WardPharmacy extends ModalJFrame implements
 		if (jTableDrugs == null) {
 			modelDrugs = new DrugsModel();
 			jTableDrugs = new JTable(modelDrugs);
-			 TableCellRenderer buttonRenderer = new JTableButtonRenderer();
-			 jTableDrugs.getColumn("").setCellRenderer(buttonRenderer);
+			TableCellRenderer buttonRenderer = new JTableButtonRenderer();
+			jTableDrugs.getColumn("").setCellRenderer(buttonRenderer);
 			for (int i = 0; i < columWidthDrugs.length; i++) {
 				jTableDrugs.getColumnModel().getColumn(i).setMinWidth(columWidthDrugs[i]);
 				if (!columsResizableDrugs[i])
 					jTableDrugs.getColumnModel().getColumn(i).setMaxWidth(columWidthDrugs[i]);
 			}
-			
+
 			jTableDrugs.addMouseListener(new MouseAdapter() {
-				
-		         public void mouseClicked(MouseEvent me) {
-		        	  int column = jTableDrugs.getColumnModel().getColumnIndexAtX(me.getX()); // get the coloum of the button
-		        	  JTable target = (JTable)me.getSource();
-		        	  int row = target.getSelectedRow(); // select a row
 
-		                      /*Checking the row or column is valid or not*/
-		              if (row < jTableDrugs.getRowCount() && row >= 0 && column < jTableDrugs.getColumnCount() && column >= 0) {
-		                  Object value = jTableDrugs.getValueAt(row, column);
-		                  if (value instanceof JButton) {
-		                      /*perform a click event*/
-		                      ((JButton)value).doClick();
-		                  }
-		              }
-		        	 
-		             if (me.getClickCount() == 2) {     // to detect double click events
+				public void mouseClicked(MouseEvent me) {
+					int column = jTableDrugs.getColumnModel().getColumnIndexAtX(me.getX()); // get the coloum of the button
+					JTable target = (JTable) me.getSource();
+					int row = target.getSelectedRow(); // select a row
 
-		                showLotDetail(wardDrugs, (String) jTableDrugs.getValueAt(row, 0));// get the value of a row and column.
-		             }
-		          }
-		       });
+					/*Checking the row or column is valid or not*/
+					if (row < jTableDrugs.getRowCount() && row >= 0 && column < jTableDrugs.getColumnCount() && column >= 0) {
+						Object value = jTableDrugs.getValueAt(row, column);
+						if (value instanceof JButton) {
+							/*perform a click event*/
+							((JButton) value).doClick();
+						}
+					}
+
+					if (me.getClickCount() == 2) {     // to detect double click events
+
+						showLotDetail(wardDrugs, (String) jTableDrugs.getValueAt(row, 0));// get the value of a row and column.
+					}
+				}
+			});
 		}
 		return jTableDrugs;
 	}
 
-	private static class JTableButtonRenderer implements TableCellRenderer {        
-        @Override public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
-            JButton button = (JButton)value;
-            return button;  
-        }
-    }
+	private static class JTableButtonRenderer implements TableCellRenderer {
+
+		@Override
+		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+			JButton button = (JButton) value;
+			return button;
+		}
+	}
+
 	private MedicalWard showLotDetail(ArrayList<MedicalWard> drug, String me) {
 		ArrayList<MedicalWard> dr = new ArrayList<MedicalWard>();
-		MedicalWard medWard =null;
+		MedicalWard medWard = null;
 		for (MedicalWard elem : drug) {
-			if(elem.getMedical().getDescription().equals(me)) {
-				if(elem.getQty() != 0.0) {
+			if (elem.getMedical().getDescription().equals(me)) {
+				if (elem.getQty() != 0.0) {
 					MedicalWard e = elem;
-				 	dr.add(e);		
+					dr.add(e);
 				}
 			}
-			
+
 		}
-	
-			
-			JTable lotTable = new JTable(new StockMovModel(dr));
-			lotTable.getSelectionModel().setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-			JPanel panel = new JPanel(new BorderLayout());
-			panel.add(new JScrollPane(lotTable), BorderLayout.CENTER);
-			
-			do {
-				int ok = JOptionPane.showConfirmDialog(WardPharmacy.this, 
-						panel, 
-						MessageBundle.getMessage("angal.medicalstock.multipledischarging.lotinformations"), //$NON-NLS-1$ 
-						JOptionPane.CLOSED_OPTION);
-	
-			
-				
-			} while (dr == null);
-		 
+
+		JTable lotTable = new JTable(new StockMovModel(dr));
+		lotTable.getSelectionModel().setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+		JPanel panel = new JPanel(new BorderLayout());
+		panel.add(new JScrollPane(lotTable), BorderLayout.CENTER);
+
+		do {
+			int ok = JOptionPane.showConfirmDialog(WardPharmacy.this,
+					panel,
+					MessageBundle.getMessage("angal.medicalstock.multipledischarging.lotinformations"), //$NON-NLS-1$ 
+					JOptionPane.CLOSED_OPTION);
+
+		} while (dr == null);
+
 		return medWard;
 	}
+
 	private static final String DATE_FORMAT_DD_MM_YYYY = "dd/MM/yyyy"; //$NON-NLS-1$
-	
+
 	class StockMovModel extends DefaultTableModel {
+
 		/**
-		 * 
+		 *
 		 */
 		private static final long serialVersionUID = 1L;
 		private ArrayList<MedicalWard> druglist;
@@ -591,7 +590,7 @@ public class WardPharmacy extends ModalJFrame implements
 			if (c == 0) {
 				return MessageBundle.getMessage("angal.medicalstock.lotid"); //$NON-NLS-1$
 			}
-			
+
 			if (c == 1) {
 				return MessageBundle.getMessage("angal.medicalstock.duedate"); //$NON-NLS-1$
 			}
@@ -607,14 +606,14 @@ public class WardPharmacy extends ModalJFrame implements
 
 		public Object getValueAt(int r, int c) {
 			MedicalWard medicalWard = druglist.get(r);
-			
+
 			if (c == -1) {
 				return medicalWard;
 			} else if (c == 0) {
 				return medicalWard.getId().getLot();
 			} else if (c == 1) {
 				return TimeTools.formatDateTime(medicalWard.getId().getLot().getDueDate(), DATE_FORMAT_DD_MM_YYYY);
-			}  else if (c == 2) {
+			} else if (c == 2) {
 				return medicalWard.getQty();
 			}
 			return null;
@@ -646,7 +645,7 @@ public class WardPharmacy extends ModalJFrame implements
 			jPanelFilter.add(Box.createVerticalStrut(filterSpacing));
 			jPanelFilter.add(getJComboBoxTypes());
 			jPanelFilter.add(Box.createVerticalStrut(filterSpacing));
-                        jPanelFilter.add(getJPanelMedicalsSearch());
+			jPanelFilter.add(getJPanelMedicalsSearch());
 			jPanelFilter.add(Box.createVerticalStrut(filterSpacing));
 			jPanelFilter.add(getJComboBoxMedicals());
 			jPanelFilter.add(Box.createVerticalStrut(filterSpacing));
@@ -685,13 +684,15 @@ public class WardPharmacy extends ModalJFrame implements
 
 				public void actionPerformed(ActionEvent e) {
 					if (ageFrom > ageTo) {
-						JOptionPane.showMessageDialog(WardPharmacy.this, MessageBundle.getMessage("angal.medicalstockward.agefrommustbelowerthanageto")); //$NON-NLS-1$
+						JOptionPane.showMessageDialog(WardPharmacy.this,
+								MessageBundle.getMessage("angal.medicalstockward.agefrommustbelowerthanageto")); //$NON-NLS-1$
 						jAgeFromTextField.setText(String.valueOf(ageTo));
 						ageFrom = ageTo;
 						return;
 					}
 					if (weightFrom > weightTo) {
-						JOptionPane.showMessageDialog(WardPharmacy.this, MessageBundle.getMessage("angal.medicalstockward.weightfrommustbelowerthanweightto")); //$NON-NLS-1$
+						JOptionPane.showMessageDialog(WardPharmacy.this,
+								MessageBundle.getMessage("angal.medicalstockward.weightfrommustbelowerthanweightto")); //$NON-NLS-1$
 						jWeightFromTextField.setText(String.valueOf(weightTo));
 						weightFrom = weightTo;
 						return;
@@ -704,7 +705,7 @@ public class WardPharmacy extends ModalJFrame implements
 		}
 		return filterButton;
 	}
-	
+
 	private JButton getResetButton() {
 		if (resetButton == null) {
 			resetButton = new JButton(MessageBundle.getMessage("angal.medicalstockward.reset")); //$NON-NLS-1$
@@ -749,13 +750,15 @@ public class WardPharmacy extends ModalJFrame implements
 			jWeightToTextField.setText("0"); //$NON-NLS-1$
 			jWeightToTextField.setMaximumSize(new Dimension(100, 50));
 			jWeightToTextField.addFocusListener(new FocusListener() {
+
 				public void focusLost(FocusEvent e) {
 					try {
 						weightTo = Integer.parseInt(jWeightToTextField.getText());
 						weightFrom = Integer.parseInt(jWeightFromTextField.getText());
 						if ((weightTo < 0) || (weightTo > 200)) {
 							jWeightToTextField.setText(""); //$NON-NLS-1$
-							JOptionPane.showMessageDialog(WardPharmacy.this, MessageBundle.getMessage("angal.medicalstockward.insertavalidweight")); //$NON-NLS-1$
+							JOptionPane
+									.showMessageDialog(WardPharmacy.this, MessageBundle.getMessage("angal.medicalstockward.insertavalidweight")); //$NON-NLS-1$
 						}
 					} catch (NumberFormatException ex) {
 						jWeightToTextField.setText("0"); //$NON-NLS-1$
@@ -775,13 +778,15 @@ public class WardPharmacy extends ModalJFrame implements
 			jWeightFromTextField.setText("0"); //$NON-NLS-1$
 			jWeightFromTextField.setMinimumSize(new Dimension(100, 50));
 			jWeightFromTextField.addFocusListener(new FocusListener() {
+
 				public void focusLost(FocusEvent e) {
 					try {
 						weightFrom = Integer.parseInt(jWeightFromTextField.getText());
 						weightTo = Integer.parseInt(jWeightToTextField.getText());
 						if ((weightFrom < 0)) {
 							jWeightFromTextField.setText(""); //$NON-NLS-1$
-							JOptionPane.showMessageDialog(WardPharmacy.this, MessageBundle.getMessage("angal.medicalstockward.insertvalidweight")); //$NON-NLS-1$
+							JOptionPane
+									.showMessageDialog(WardPharmacy.this, MessageBundle.getMessage("angal.medicalstockward.insertvalidweight")); //$NON-NLS-1$
 						}
 					} catch (NumberFormatException ex) {
 						jWeightFromTextField.setText("0"); //$NON-NLS-1$
@@ -836,6 +841,7 @@ public class WardPharmacy extends ModalJFrame implements
 			jAgeToTextField.setText("0"); //$NON-NLS-1$
 			jAgeToTextField.setMaximumSize(new Dimension(100, 50));
 			jAgeToTextField.addFocusListener(new FocusListener() {
+
 				public void focusLost(FocusEvent e) {
 					try {
 						ageTo = Integer.parseInt(jAgeToTextField.getText());
@@ -858,7 +864,7 @@ public class WardPharmacy extends ModalJFrame implements
 
 	/**
 	 * This method initializes jAgeFromTextField
-	 * 
+	 *
 	 * @return javax.swing.JTextField
 	 */
 	private VoLimitedTextField getJAgeFromTextField() {
@@ -867,6 +873,7 @@ public class WardPharmacy extends ModalJFrame implements
 			jAgeFromTextField.setText("0"); //$NON-NLS-1$
 			jAgeFromTextField.setMinimumSize(new Dimension(100, 50));
 			jAgeFromTextField.addFocusListener(new FocusListener() {
+
 				public void focusLost(FocusEvent e) {
 					try {
 						ageFrom = Integer.parseInt(jAgeFromTextField.getText());
@@ -893,19 +900,19 @@ public class WardPharmacy extends ModalJFrame implements
 			jComboBoxTypes.setMaximumSize(new Dimension(filterWidth, 24));
 			jComboBoxTypes.setPreferredSize(new Dimension(filterWidth, 24));
 			ArrayList<MedicalType> medicalTypes;
-			
+
 			jComboBoxTypes.addItem(MessageBundle.getMessage("angal.medicalstockward.alltypes")); //$NON-NLS-1$
-			
+
 			try {
 				medicalTypes = medicalTypeBrowserManager.getMedicalType();
-				
+
 				for (MedicalType aMedicalType : medicalTypes) {
 					jComboBoxTypes.addItem(aMedicalType);
 				}
 			} catch (OHServiceException e) {
 				OHServiceExceptionUtil.showMessages(e);
 			}
-			
+
 			jComboBoxTypes.addActionListener(new ActionListener() {
 
 				public void actionPerformed(ActionEvent arg0) {
@@ -918,69 +925,76 @@ public class WardPharmacy extends ModalJFrame implements
 		return jComboBoxTypes;
 	}
 
-        private JPanel getJPanelMedicalsSearch() {
-            searchButton = new JButton();
-            searchButton.setPreferredSize(new Dimension(20, 20));
-            searchButton.setIcon(new ImageIcon("rsc/icons/zoom_r_button.png"));
-            searchButton.addActionListener(new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent ae) {
-                    jComboBoxMedicals.removeAllItems();
-                    ArrayList<Medical> medicals;
-                    try {
-                            medicals = medicalManager.getMedicals();
-                    } catch (OHServiceException e1) {
-                            medicals = null;
-                            OHServiceExceptionUtil.showMessages(e1);
-                    }
-                    MedicalType medicalType;
-                    if (jComboBoxTypes.getSelectedItem() instanceof String) {
-                            medicalType = null;
-                    } else {
-                            medicalType = (MedicalType) jComboBoxTypes.getSelectedItem();
-                    }
-                    if (null != medicals) {
-                        ArrayList<Medical> results = getSearchMedicalsResults(searchTextField.getText(), medicals);
-                        int originalSize = medicals.size();
-                        int resultsSize = results.size();
-                        if(originalSize == resultsSize) {
-                            jComboBoxMedicals.addItem(MessageBundle.getMessage("angal.medicalstockward.allmedicals"));
-                        }
-                        for (Medical aMedical : results) {
-				boolean ok = true;
-				if (medicalType != null)
-					ok = ok && aMedical.getType().equals(medicalType);
-				if (ok)
-					jComboBoxMedicals.addItem(aMedical);
+	private JPanel getJPanelMedicalsSearch() {
+		searchButton = new JButton();
+		searchButton.setPreferredSize(new Dimension(20, 20));
+		searchButton.setIcon(new ImageIcon("rsc/icons/zoom_r_button.png"));
+		searchButton.addActionListener(new ActionListener() {
+
+			@Override
+			public void actionPerformed(ActionEvent ae) {
+				jComboBoxMedicals.removeAllItems();
+				ArrayList<Medical> medicals;
+				try {
+					medicals = medicalManager.getMedicals();
+				} catch (OHServiceException e1) {
+					medicals = null;
+					OHServiceExceptionUtil.showMessages(e1);
+				}
+				MedicalType medicalType;
+				if (jComboBoxTypes.getSelectedItem() instanceof String) {
+					medicalType = null;
+				} else {
+					medicalType = (MedicalType) jComboBoxTypes.getSelectedItem();
+				}
+				if (null != medicals) {
+					ArrayList<Medical> results = getSearchMedicalsResults(searchTextField.getText(), medicals);
+					int originalSize = medicals.size();
+					int resultsSize = results.size();
+					if (originalSize == resultsSize) {
+						jComboBoxMedicals.addItem(MessageBundle.getMessage("angal.medicalstockward.allmedicals"));
+					}
+					for (Medical aMedical : results) {
+						boolean ok = true;
+						if (medicalType != null)
+							ok = ok && aMedical.getType().equals(medicalType);
+						if (ok)
+							jComboBoxMedicals.addItem(aMedical);
+					}
+				}
 			}
-                    }
-                }
-            });
-            
-            searchTextField = new JTextField(15);
-            //searchTextField.setToolTipText(MessageBundle.getMessage("angal.medicalstock.pharmaceutical"));
-            searchTextField.addKeyListener(new KeyListener() {
-                @Override
-                public void keyPressed(KeyEvent e) {
-                    int key = e.getKeyCode();
-                    if (key == KeyEvent.VK_ENTER) {
-                        searchButton.doClick();
-                    }
-                }
-                @Override
-                public void keyReleased(KeyEvent e) {}
-                @Override
-                public void keyTyped(KeyEvent e) {}
-            });
-            
-            searchPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
-            searchPanel.add(searchTextField);
-            searchPanel.add(searchButton);
-            searchPanel.setMaximumSize(new Dimension(filterWidth, 25));
-            searchPanel.setMinimumSize(new Dimension(filterWidth, 25));
-            searchPanel.setPreferredSize(new Dimension(filterWidth, 25));
-            return searchPanel;
-        }
+		});
+
+		searchTextField = new JTextField(15);
+		//searchTextField.setToolTipText(MessageBundle.getMessage("angal.medicalstock.pharmaceutical"));
+		searchTextField.addKeyListener(new KeyListener() {
+
+			@Override
+			public void keyPressed(KeyEvent e) {
+				int key = e.getKeyCode();
+				if (key == KeyEvent.VK_ENTER) {
+					searchButton.doClick();
+				}
+			}
+
+			@Override
+			public void keyReleased(KeyEvent e) {
+			}
+
+			@Override
+			public void keyTyped(KeyEvent e) {
+			}
+		});
+
+		searchPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
+		searchPanel.add(searchTextField);
+		searchPanel.add(searchButton);
+		searchPanel.setMaximumSize(new Dimension(filterWidth, 25));
+		searchPanel.setMinimumSize(new Dimension(filterWidth, 25));
+		searchPanel.setPreferredSize(new Dimension(filterWidth, 25));
+		return searchPanel;
+	}
+
 	private JComboBox getJComboBoxMedicals() {
 		if (jComboBoxMedicals == null) {
 			jComboBoxMedicals = new JComboBox();
@@ -1080,7 +1094,7 @@ public class WardPharmacy extends ModalJFrame implements
 			WardBrowserManager wardManager = Context.getApplicationContext().getBean(WardBrowserManager.class);
 			try {
 				wardList = wardManager.getWards();
-			}catch(OHServiceException e){
+			} catch (OHServiceException e) {
 				wardList = new ArrayList<Ward>();
 				OHServiceExceptionUtil.showMessages(e);
 			}
@@ -1148,7 +1162,7 @@ public class WardPharmacy extends ModalJFrame implements
 	class IncomesModel extends DefaultTableModel {
 
 		/**
-		 * 
+		 *
 		 */
 		private static final long serialVersionUID = 1L;
 		//private ArrayList<Movement> wardIncomes; --> Global
@@ -1157,7 +1171,7 @@ public class WardPharmacy extends ModalJFrame implements
 			wardIncomes = new ArrayList<Movement>();
 			try {
 				listMovementCentral = movManager.getMovements(wardSelected.getCode(), dateFrom, dateTo);
-				
+
 				for (Movement mov : listMovementCentral) {
 					if (mov.getWard().getDescription() != null) {
 						if (mov.getWard().equals(wardSelected)) {
@@ -1165,24 +1179,24 @@ public class WardPharmacy extends ModalJFrame implements
 						}
 					}
 				}
-                                
-                //List movements from other wards 
-                for(MovementWard wMvnt: wardManager.getWardMovementsToWard(wardSelected.getCode(), dateFrom, dateTo)) {
-                    if (wMvnt.getWardTo().getDescription() != null) {
+
+				//List movements from other wards 
+				for (MovementWard wMvnt : wardManager.getWardMovementsToWard(wardSelected.getCode(), dateFrom, dateTo)) {
+					if (wMvnt.getWardTo().getDescription() != null) {
 						if (wMvnt.getWardTo().equals(wardSelected)) {
 							MovementType typeCharge = new MovementType("fromward", wMvnt.getWard().getDescription(), "*");
-                            wardIncomes.add(new Movement(
-                                    wMvnt.getMedical(), 
-                                    typeCharge, 
-                                    wardSelected, 
-                                    wMvnt.getLot(), 
-                                    wMvnt.getDate(), 
-                                    wMvnt.getQuantity().intValue(), 
-                                    null, 
-                                    null));
+							wardIncomes.add(new Movement(
+									wMvnt.getMedical(),
+									typeCharge,
+									wardSelected,
+									wMvnt.getLot(),
+									wMvnt.getDate(),
+									wMvnt.getQuantity().intValue(),
+									null,
+									null));
 						}
-                    }
-                }
+					}
+				}
 			} catch (OHServiceException e) {
 				OHServiceExceptionUtil.showMessages(e);
 				e.printStackTrace();
@@ -1208,7 +1222,8 @@ public class WardPharmacy extends ModalJFrame implements
 			if (c == 1) {
 				if (mov.getType().getCode().equals("fromward"))
 					return mov.getType().getDescription();
-				else return mov.getRefNo();
+				else
+					return mov.getRefNo();
 			}
 			if (c == 2) {
 				return mov.getMedical();
@@ -1250,7 +1265,7 @@ public class WardPharmacy extends ModalJFrame implements
 	class OutcomesModel extends DefaultTableModel {
 
 		/**
-		 * 
+		 *
 		 */
 		private static final long serialVersionUID = 1L;
 		//private ArrayList<MovementWard> wardOutcomes; --> Global
@@ -1323,7 +1338,7 @@ public class WardPharmacy extends ModalJFrame implements
 				if (ok)
 					wardOutcomes.add(mov);
 			}
-			
+
 			Collections.reverse(wardOutcomes);
 		}
 
@@ -1397,7 +1412,7 @@ public class WardPharmacy extends ModalJFrame implements
 	class DrugsModel extends DefaultTableModel {
 
 		/**
-		 * 
+		 *
 		 */
 		private static final long serialVersionUID = 1L;
 
@@ -1405,14 +1420,14 @@ public class WardPharmacy extends ModalJFrame implements
 
 		public DrugsModel() {
 			try {
-                //System.out.println("WardPharmacy: Looking for drugs ");
+				//System.out.println("WardPharmacy: Looking for drugs ");
 				tableModel = wardManager.getMedicalsWardTotalQuantity(wardSelected.getCode().charAt(0));
 				wardDrugs = wardManager.getMedicalsWard(wardSelected.getCode().charAt(0), true);
-				
+
 			} catch (OHServiceException e) {
 				OHServiceExceptionUtil.showMessages(e);
 				tableModel = new ArrayList<MedicalWard>();
-				wardDrugs= new ArrayList<MedicalWard>();
+				wardDrugs = new ArrayList<MedicalWard>();
 			}
 		}
 
@@ -1439,17 +1454,18 @@ public class WardPharmacy extends ModalJFrame implements
 			}
 			if (c == 3) {
 				final JButton button = new JButton(MessageBundle.getMessage("angal.medicalstockward.rectify"));
-                button.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent arg0) {
-                    	Medical medic = wardDrug.getMedical();
-                    	WardPharmacyRectify wardRectify = new WardPharmacyRectify(WardPharmacy.this, wardSelected, medic);
-    					wardRectify.addMovementWardListener(WardPharmacy.this);
-    					wardRectify.setVisible(true);
-    					TableCellRenderer buttonRenderer = new JTableButtonRenderer();
-    					jTableDrugs.getColumn("").setCellRenderer(buttonRenderer);
-                    }
-                });
-                return button;
+				button.addActionListener(new ActionListener() {
+
+					public void actionPerformed(ActionEvent arg0) {
+						Medical medic = wardDrug.getMedical();
+						WardPharmacyRectify wardRectify = new WardPharmacyRectify(WardPharmacy.this, wardSelected, medic);
+						wardRectify.addMovementWardListener(WardPharmacy.this);
+						wardRectify.setVisible(true);
+						TableCellRenderer buttonRenderer = new JTableButtonRenderer();
+						jTableDrugs.getColumn("").setCellRenderer(buttonRenderer);
+					}
+				});
+				return button;
 			}
 
 			return null;
@@ -1468,8 +1484,7 @@ public class WardPharmacy extends ModalJFrame implements
 			return false;
 		}
 	}
-	
-	
+
 	private JButton getJRectifyButton() {
 		if (jRectifyButton == null) {
 			jRectifyButton = new JButton(MessageBundle.getMessage("angal.medicalstockward.rectify")); //$NON-NLS-1$
@@ -1477,21 +1492,21 @@ public class WardPharmacy extends ModalJFrame implements
 			jRectifyButton.setBackground(Color.PINK);
 			jRectifyButton.setVisible(false);
 			jRectifyButton.addActionListener(new ActionListener() {
+
 				public void actionPerformed(ActionEvent arg0) {
-				
+
 					if (jTableDrugs.getSelectedRow() < 0) {
 						WardPharmacyRectify wardRectify = new WardPharmacyRectify(WardPharmacy.this, wardSelected);
 						wardRectify.addMovementWardListener(WardPharmacy.this);
 						wardRectify.setVisible(true);
-					}else {
+					} else {
 						int[] indexes = jTableDrugs.getSelectedRows();
 						Medical medic = (((MedicalWard) jTableDrugs.getValueAt(indexes[0], -1)).getMedical());
 						WardPharmacyRectify wardRectify = new WardPharmacyRectify(WardPharmacy.this, wardSelected, medic);
-    					wardRectify.addMovementWardListener(WardPharmacy.this);
-    					wardRectify.setVisible(true);
+						wardRectify.addMovementWardListener(WardPharmacy.this);
+						wardRectify.setVisible(true);
 					}
-					
-					
+
 					TableCellRenderer buttonRenderer = new JTableButtonRenderer();
 					jTableDrugs.getColumn("").setCellRenderer(buttonRenderer);
 				}
@@ -1499,7 +1514,7 @@ public class WardPharmacy extends ModalJFrame implements
 		}
 		return jRectifyButton;
 	}
-	
+
 	private JButton getPrintTableButton() {
 		if (jPrintTableButton == null) {
 			jPrintTableButton = new JButton(MessageBundle.getMessage("angal.medicalstockward.report")); //$NON-NLS-1$
@@ -1508,40 +1523,35 @@ public class WardPharmacy extends ModalJFrame implements
 			jPrintTableButton.addActionListener(new ActionListener() {
 
 				public void actionPerformed(ActionEvent arg0) {
-					
-					if (jTabbedPaneWard.getSelectedIndex() == 0) 
-					{
+
+					if (jTabbedPaneWard.getSelectedIndex() == 0) {
 						try {
 							printManager.print("WardPharmacyOutcomes", wardManager.convertMovementWardForPrint(wardOutcomes), 0); //$NON-NLS-1$
 						} catch (OHServiceException e) {
 							OHServiceExceptionUtil.showMessages(e, WardPharmacy.this);
 							return;
-						} 
-					} 
-					else if (jTabbedPaneWard.getSelectedIndex() == 1) 
-					{
+						}
+					} else if (jTabbedPaneWard.getSelectedIndex() == 1) {
 						try {
 							printManager.print("WardPharmacyIncomes", wardManager.convertMovementForPrint(wardIncomes), 0); //$NON-NLS-1$
 						} catch (OHServiceException e) {
 							OHServiceExceptionUtil.showMessages(e, WardPharmacy.this);
 							return;
 						}
-					} 
-					else if (jTabbedPaneWard.getSelectedIndex() == 2) 
-					{
+					} else if (jTabbedPaneWard.getSelectedIndex() == 2) {
 						ArrayList<String> options = new ArrayList<String>();
 						options.add(MessageBundle.getMessage("angal.medicals.today")); //$NON-NLS-1$
 						options.add(MessageBundle.getMessage("angal.common.date")); //$NON-NLS-1$
-						
+
 						Icon icon = new ImageIcon("rsc/icons/calendar_dialog.png"); //$NON-NLS-1$
-						String option = (String) JOptionPane.showInputDialog(WardPharmacy.this, 
+						String option = (String) JOptionPane.showInputDialog(WardPharmacy.this,
 								MessageBundle.getMessage("angal.medicals.pleaseselectareport"),  //$NON-NLS-1$
 								MessageBundle.getMessage("angal.medicals.report"),  //$NON-NLS-1$
-								JOptionPane.INFORMATION_MESSAGE, 
-								icon, 
-								options.toArray(), 
+								JOptionPane.INFORMATION_MESSAGE,
+								icon,
+								options.toArray(),
 								options.get(0));
-						
+
 						if (option == null)
 							return;
 						int i = 0;
@@ -1550,35 +1560,35 @@ public class WardPharmacy extends ModalJFrame implements
 							return;
 						}
 						if (options.indexOf(option) == ++i) {
-							
+
 							icon = new ImageIcon("rsc/icons/calendar_dialog.png"); //$NON-NLS-1$
-							
+
 							CustomJDateChooser dateChooser = new CustomJDateChooser();
 							dateChooser.setLocale(new Locale(GeneralData.LANGUAGE));
-							
-					        int r = JOptionPane.showConfirmDialog(WardPharmacy.this, 
-					        		dateChooser, 
-					        		MessageBundle.getMessage("angal.common.date"),  //$NON-NLS-1$
-					        		JOptionPane.OK_CANCEL_OPTION, 
-					        		JOptionPane.PLAIN_MESSAGE,
-					        		icon);
 
-					        if (r == JOptionPane.OK_OPTION) {
-					        	
+							int r = JOptionPane.showConfirmDialog(WardPharmacy.this,
+									dateChooser,
+									MessageBundle.getMessage("angal.common.date"),  //$NON-NLS-1$
+									JOptionPane.OK_CANCEL_OPTION,
+									JOptionPane.PLAIN_MESSAGE,
+									icon);
+
+							if (r == JOptionPane.OK_OPTION) {
+
 								new GenericReportPharmaceuticalStockWard(dateChooser.getDate(), "PharmaceuticalStockWard", wardSelected); //$NON-NLS-1$
 								return;
-								
-					        } else {
-					            return;
-					        }
+
+							} else {
+								return;
+							}
 						}
-					} 
+					}
 				}
 			});
 		}
 		return jPrintTableButton;
 	}
-	
+
 	private JButton getExportToExcelButton() {
 		if (jExportToExcelButton == null) {
 			jExportToExcelButton = new JButton("Excel"); //$NON-NLS-1$
@@ -1590,13 +1600,14 @@ public class WardPharmacy extends ModalJFrame implements
 					String fileName = compileFileName();
 					File defaultFileName = new File(fileName);
 					JFileChooser fcExcel = ExcelExporter.getJFileChooserExcel(defaultFileName);
-					
+
 					int iRetVal = fcExcel.showSaveDialog(WardPharmacy.this);
-					if(iRetVal == JFileChooser.APPROVE_OPTION) {
+					if (iRetVal == JFileChooser.APPROVE_OPTION) {
 						try {
 							File exportFile = fcExcel.getSelectedFile();
-							if (!exportFile.getName().endsWith("xls")) exportFile = new File(exportFile.getAbsoluteFile() + ".xls");
-							
+							if (!exportFile.getName().endsWith("xls"))
+								exportFile = new File(exportFile.getAbsoluteFile() + ".xls");
+
 							ExcelExporter xlsExport = new ExcelExporter();
 							int index = jTabbedPaneWard.getSelectedIndex();
 							if (index == 0) {
@@ -1606,22 +1617,22 @@ public class WardPharmacy extends ModalJFrame implements
 							} else if (index == 2) {
 								xlsExport.exportTableToExcel(jTableDrugs, exportFile);
 							}
-							
+
 						} catch (IOException exc) {
 							JOptionPane.showMessageDialog(WardPharmacy.this,
 									exc.getMessage(),
-			                        MessageBundle.getMessage("angal.hospital"),
-			                        JOptionPane.PLAIN_MESSAGE);	
-							logger.info("Export to excel error : "+ exc.getMessage());
+									MessageBundle.getMessage("angal.hospital"),
+									JOptionPane.PLAIN_MESSAGE);
+							logger.info("Export to excel error : {}", exc.getMessage());
 						}
-						
+
 					}
 				}
 			});
 		}
 		return jExportToExcelButton;
 	}
-	
+
 	private String compileFileName() {
 		StringBuilder filename = new StringBuilder("StockWard Ledger");
 		filename.append("_").append(jComboBoxWard.getSelectedItem());
@@ -1635,51 +1646,51 @@ public class WardPharmacy extends ModalJFrame implements
 		}
 		if (jComboBoxTypes.isEnabled()
 				&& !jComboBoxTypes.getSelectedItem().equals(
-						MessageBundle.getMessage("angal.medicalstockward.alltypes"))) {
-			
+				MessageBundle.getMessage("angal.medicalstockward.alltypes"))) {
+
 			filename.append("_").append(jComboBoxTypes.getSelectedItem());
 		}
 		if (jComboBoxMedicals.isEnabled()
 				&& !jComboBoxMedicals.getSelectedItem().equals(
-						MessageBundle.getMessage("angal.medicalstockward.allmedicals"))) {
-			
+				MessageBundle.getMessage("angal.medicalstockward.allmedicals"))) {
+
 			filename.append("_").append(jComboBoxMedicals.getSelectedItem());
 		}
 		filename.append("_").append(TimeTools.formatDateTime(jCalendarFrom.getDate(), "yyyyMMdd"))
-			.append("_").append(TimeTools.formatDateTime(jCalendarTo.getDate(), "yyyyMMdd"));
-		
+				.append("_").append(TimeTools.formatDateTime(jCalendarTo.getDate(), "yyyyMMdd"));
+
 		return filename.toString();
 	}
 
-	class CenterBoldTableCellRenderer extends DefaultTableCellRenderer {  
-		   
+	class CenterBoldTableCellRenderer extends DefaultTableCellRenderer {
+
 		/**
-		 * 
+		 *
 		 */
 		private static final long serialVersionUID = 1L;
 
-		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, 
-				boolean hasFocus, int row, int column) {  
-		   
-			Component cell=super.getTableCellRendererComponent(table,value,isSelected,hasFocus,row,column);
+		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
+				boolean hasFocus, int row, int column) {
+
+			Component cell = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
 			cell.setForeground(Color.BLACK);
 			setHorizontalAlignment(CENTER);
 			cell.setFont(new Font(null, Font.BOLD, 12));
 			return cell;
-	   }
+		}
 	}
-	
-	class BlueBoldTableCellRenderer extends DefaultTableCellRenderer {  
-		   
+
+	class BlueBoldTableCellRenderer extends DefaultTableCellRenderer {
+
 		/**
-		 * 
+		 *
 		 */
 		private static final long serialVersionUID = 1L;
 
-		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, 
-				boolean hasFocus, int row, int column) {  
-		   
-			Component cell=super.getTableCellRendererComponent(table,value,isSelected,hasFocus,row,column);
+		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
+				boolean hasFocus, int row, int column) {
+
+			Component cell = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
 			cell.setForeground(Color.BLACK);
 			cell.setFont(new Font(null, Font.PLAIN, 12));
 			MovementWard mov = wardOutcomes.get(row);
@@ -1688,7 +1699,7 @@ public class WardPharmacy extends ModalJFrame implements
 				cell.setFont(new Font(null, Font.BOLD, 12));
 			}
 			return cell;
-	   }
+		}
 	}
 
 	public String formatDate(GregorianCalendar time) {
@@ -1700,30 +1711,30 @@ public class WardPharmacy extends ModalJFrame implements
 		SimpleDateFormat format = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss"); //$NON-NLS-1$
 		return format.format(time.getTime());
 	}
-        
-        private ArrayList<Medical> getSearchMedicalsResults(String s, ArrayList<Medical> medicalsList) {
-            String query = s.trim();
-            ArrayList<Medical> results = new ArrayList<Medical>();
-            for (Medical medoc : medicalsList) {
-                if(!query.equals("")) {
-                    String[] patterns = query.split(" ");
-                    String code = medoc.getProd_code().toLowerCase();
-                    String description = medoc.getDescription().toLowerCase();
-                    boolean patternFound = false;
-                    for (String pattern : patterns) {
-                        if (code.contains(pattern.toLowerCase()) || description.contains(pattern.toLowerCase())) {
-                            patternFound = true;
-                            //It is sufficient that only one pattern matches the query
-                            break;
-                        }
-                    }
-                    if (patternFound){
-                        results.add(medoc);
-                    }
-                } else {
-                    results.add(medoc);
-                }
-            }		
-            return results;
-        }
+
+	private ArrayList<Medical> getSearchMedicalsResults(String s, ArrayList<Medical> medicalsList) {
+		String query = s.trim();
+		ArrayList<Medical> results = new ArrayList<Medical>();
+		for (Medical medoc : medicalsList) {
+			if (!query.equals("")) {
+				String[] patterns = query.split(" ");
+				String code = medoc.getProd_code().toLowerCase();
+				String description = medoc.getDescription().toLowerCase();
+				boolean patternFound = false;
+				for (String pattern : patterns) {
+					if (code.contains(pattern.toLowerCase()) || description.contains(pattern.toLowerCase())) {
+						patternFound = true;
+						//It is sufficient that only one pattern matches the query
+						break;
+					}
+				}
+				if (patternFound) {
+					results.add(medoc);
+				}
+			} else {
+				results.add(medoc);
+			}
+		}
+		return results;
+	}
 }

--- a/src/main/java/org/isf/menu/gui/Login.java
+++ b/src/main/java/org/isf/menu/gui/Login.java
@@ -31,8 +31,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Login extends JDialog implements ActionListener, KeyListener {
+
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 76205822226035164L;
 
@@ -43,6 +44,7 @@ public class Login extends JDialog implements ActionListener, KeyListener {
 	private UserBrowsingManager manager = Context.getApplicationContext().getBean(UserBrowsingManager.class);
 
 	public interface LoginListener extends EventListener {
+
 		public void loginInserted(AWTEvent e);
 	}
 
@@ -58,7 +60,7 @@ public class Login extends JDialog implements ActionListener, KeyListener {
 		AWTEvent event = new AWTEvent(aUser, AWTEvent.RESERVED_ID_MAX + 1) {
 
 			/**
-			 * 
+			 *
 			 */
 			private static final long serialVersionUID = 1L;
 		};
@@ -140,8 +142,8 @@ public class Login extends JDialog implements ActionListener, KeyListener {
 			}
 		}
 		if (!found) {
-			
-			logger.warn("Login failed: " + message);
+
+			logger.warn("Login failed: {}", message);
 			JOptionPane.showMessageDialog(this, message, "",
 					JOptionPane.PLAIN_MESSAGE);
 			pwd.setText("");
@@ -169,11 +171,11 @@ public class Login extends JDialog implements ActionListener, KeyListener {
 
 		public LoginPanel(Login myFrame) {
 
-            try {
-                users = manager.getUser();
-            } catch (OHServiceException e1) {
-                OHServiceExceptionUtil.showMessages(e1);
-            }
+			try {
+				users = manager.getUser();
+			} catch (OHServiceException e1) {
+				OHServiceExceptionUtil.showMessages(e1);
+			}
 
 			/*
 			 * for (User u : users) System.out.println(u);

--- a/src/main/java/org/isf/menu/gui/MainMenu.java
+++ b/src/main/java/org/isf/menu/gui/MainMenu.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 public class MainMenu extends JFrame implements ActionListener, Login.LoginListener, SubMenu.CommandListener {
+
 	private static final long serialVersionUID = 7620582079916035164L;
 	private boolean flag_Xmpp = false;
 	private boolean flag_Sms = false;
@@ -50,7 +51,7 @@ public class MainMenu extends JFrame implements ActionListener, Login.LoginListe
 			myUser = (User) e.getSource();
 			MDC.put("OHUser", myUser.getUserName());
 			MDC.put("OHUserGroup", myUser.getUserGroupName().getCode());
-			logger.info("Logging: \"" + myUser.getUserName() + "\" user has logged the system.");
+			logger.info("Logging: \"{}\" user has logged the system.", myUser.getUserName());
 		}
 	}
 
@@ -139,13 +140,13 @@ public class MainMenu extends JFrame implements ActionListener, Login.LoginListe
 		}
 
 		// get menu items
-        try {
-            myMenu = manager.getMenu(myUser);
-        } catch (OHServiceException e) {
-            OHServiceExceptionUtil.showMessages(e);
-        }
+		try {
+			myMenu = manager.getMenu(myUser);
+		} catch (OHServiceException e) {
+			OHServiceExceptionUtil.showMessages(e);
+		}
 
-        // start connection with xmpp server if is enabled
+		// start connection with xmpp server if is enabled
 		if (flag_Xmpp) {
 			try {
 				Server.getInstance().login(myUser.getUserName(), myUser.getPasswd());
@@ -170,7 +171,7 @@ public class MainMenu extends JFrame implements ActionListener, Login.LoginListe
 				} else if (message.contains("XMPPError connecting")) {
 					logger.error("No XMPP Server seems to be running: set XMPPMODULEENABLED = false");
 				} else {
-					logger.error("An error occurs: " + e.getMessage());
+					logger.error("An error occurs: {}", e.getMessage());
 				}
 				flag_Xmpp = GeneralData.XMPPMODULEENABLED = false;
 			}
@@ -287,7 +288,7 @@ public class MainMenu extends JFrame implements ActionListener, Login.LoginListe
 	}
 
 	/*
-	 * 
+	 *
 	 */
 	public void actionPerformed(ActionEvent e) {
 		String command = e.getActionCommand();
@@ -295,7 +296,6 @@ public class MainMenu extends JFrame implements ActionListener, Login.LoginListe
 	}
 
 	/**
-	 * 
 	 * @param itemMenuCode
 	 */
 	private void launchApp(String itemMenuCode) {
@@ -338,6 +338,7 @@ public class MainMenu extends JFrame implements ActionListener, Login.LoginListe
 	}
 
 	private class MainPanel extends JPanel {
+
 		private static final long serialVersionUID = 4338749100837551874L;
 
 		private JButton button[];
@@ -407,8 +408,8 @@ public class MainMenu extends JFrame implements ActionListener, Login.LoginListe
 			parentFrame.setMinButtonSize(maxPrf);
 		}
 	}// :~MainPanel
-        
-        public static User getUser() {
+
+	public static User getUser() {
 		return myUser;
 	}
 }// :~MainMenu

--- a/src/main/java/org/isf/menu/gui/Menu.java
+++ b/src/main/java/org/isf/menu/gui/Menu.java
@@ -18,11 +18,10 @@ public class Menu {
 
 	private static Logger logger = LoggerFactory.getLogger(Menu.class);
 
-	private final static float MIN_JAVA_VERSION = (float) 1.6; 
-	
+	private final static float MIN_JAVA_VERSION = (float) 1.6;
+
 	/**
 	 * Create the GUI and show it.
-	 * 
 	 */
 	private static void createAndShowGUI() {
 		logger = LoggerFactory.getLogger(Menu.class);
@@ -30,25 +29,25 @@ public class Menu {
 		checkOHVersion();
 		checkJavaVersion();
 		JFrame.setDefaultLookAndFeelDecorated(false);
-		new SplashWindow3("rsc"+File.separator+"images"+File.separator+"Splash.jpg",null,3000);
-		WaitCursorEventQueue waitQueue = new WaitCursorEventQueue(10,Toolkit.getDefaultToolkit().getSystemEventQueue());
+		new SplashWindow3("rsc" + File.separator + "images" + File.separator + "Splash.jpg", null, 3000);
+		WaitCursorEventQueue waitQueue = new WaitCursorEventQueue(10, Toolkit.getDefaultToolkit().getSystemEventQueue());
 		Toolkit.getDefaultToolkit().getSystemEventQueue().push(waitQueue);
 	}
-	
+
 	private static void checkOHVersion() {
 		Version.getVersion();
-		logger.info("OpenHospital version " + Version.VER_MAJOR + "." + Version.VER_MINOR + "." + Version.VER_RELEASE);
-		
+		logger.info("OpenHospital version {}.{}.{}", Version.VER_MAJOR, Version.VER_MINOR, Version.VER_RELEASE);
+
 	}
-	
+
 	public static void checkJavaVersion() {
 		String version = System.getProperty("java.version");
-		logger.info("Java version " + version);
+		logger.info("Java version {}", version);
 		Float f = Float.valueOf(version.substring(0, 3));
 		if (f.floatValue() < MIN_JAVA_VERSION) {
-			logger.error("Java version " + MIN_JAVA_VERSION + " or higher is required.");
+			logger.error("Java version {} or higher is required.", MIN_JAVA_VERSION);
 			logger.info("\n\n=====================\n OpenHospital closed \n=====================\n");
-		    System.exit(1);
+			System.exit(1);
 		}
 	}
 
@@ -57,10 +56,11 @@ public class Menu {
 		ApplicationContext context = new ClassPathXmlApplicationContext("applicationContext.xml");
 		Context.setApplicationContext(context);
 		javax.swing.SwingUtilities.invokeLater(new Runnable() {
+
 			public void run() {
 				createAndShowGUI();
 			}
 		});
-		
+
 	}
 }

--- a/src/main/java/org/isf/xmpp/gui/ChatMessages.java
+++ b/src/main/java/org/isf/xmpp/gui/ChatMessages.java
@@ -23,111 +23,112 @@ import org.slf4j.LoggerFactory;
 public class ChatMessages extends JTextPane {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 1L;
 	private Document sDoc;
-	private Color greenColor = new Color(0,100,0);
-	private Color blueColor = new Color(176,23,31);
-	private Color redColor =  new Color (25,25,112);
+	private Color greenColor = new Color(0, 100, 0);
+	private Color blueColor = new Color(176, 23, 31);
+	private Color redColor = new Color(25, 25, 112);
 	private SimpleAttributeSet keyWord;
 	private SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss");
-	
+
 	private final Logger logger = LoggerFactory.getLogger(ChatMessages.class);
 
-
-	public ChatMessages(){
+	public ChatMessages() {
 		setEditable(false);
 		setMinimumSize(getSize());
-		keyWord= new SimpleAttributeSet();
+		keyWord = new SimpleAttributeSet();
 	}
+
 	//print general notification
-	public void printNotification(String notification) throws BadLocationException{
+	public void printNotification(String notification) throws BadLocationException {
 		StyleConstants.setForeground(keyWord, greenColor);
-		sDoc=getDocument();
-		sDoc.insertString(sDoc.getEndPosition().getOffset(), "*** "+notification+"\n",keyWord);
+		sDoc = getDocument();
+		sDoc.insertString(sDoc.getEndPosition().getOffset(), "*** " + notification + "\n", keyWord);
 	}
+
 	//print notification of file transfer
-	public void printNotification(String name,String file_transfer,
-			JButton accept, JButton reject){
-		
-		Document doc=getDocument();
+	public void printNotification(String name, String file_transfer,
+			JButton accept, JButton reject) {
+
+		Document doc = getDocument();
 		int position = doc.getEndPosition().getOffset();
 		StyleConstants.setForeground(keyWord, greenColor);
 		try {
-			doc.insertString(position, "\n*** "+file_transfer+"\n", keyWord);
+			doc.insertString(position, "\n*** " + file_transfer + "\n", keyWord);
 		} catch (BadLocationException e) {
 			e.printStackTrace();
 		}
 		position = doc.getEndPosition().getOffset();
 		select(position, position);
-		
+
 		insertComponent(accept);
 		insertComponent(reject);
 	}
+
 	//print send and received messages
-	public void printMessage(String user, String message, boolean incomingType) throws BadLocationException{
+	public void printMessage(String user, String message, boolean incomingType) throws BadLocationException {
 		StyleConstants.setBold(keyWord, true);
-		if(incomingType)
-				StyleConstants.setForeground(keyWord, blueColor);
+		if (incomingType)
+			StyleConstants.setForeground(keyWord, blueColor);
 		else
-				StyleConstants.setForeground(keyWord, redColor);
-		sDoc= getDocument();
-		sDoc.insertString(sDoc.getEndPosition().getOffset(), "("+ sdf.format(new Date()) +") "+user+" : ",keyWord);
+			StyleConstants.setForeground(keyWord, redColor);
+		sDoc = getDocument();
+		sDoc.insertString(sDoc.getEndPosition().getOffset(), "(" + sdf.format(new Date()) + ") " + user + " : ", keyWord);
 		StyleConstants.setBold(keyWord, false);
 		StyleConstants.setForeground(keyWord, Color.black);
-		sDoc.insertString(sDoc.getEndPosition().getOffset(), message+"\n",keyWord);
+		sDoc.insertString(sDoc.getEndPosition().getOffset(), message + "\n", keyWord);
 
 	}
-	public void printReport(String name,String report){
+
+	public void printReport(String name, String report) {
 		final String fromDate;
 		final String toDate;
 		final String typeReport;
-	
-		Document doc=getDocument();
+
+		Document doc = getDocument();
 		ImageIcon open = new ImageIcon("rsc/icons/open.png");
-		final JButton view= new JButton(open);
-		view.setMargin(new Insets(1,1,1,1));
+		final JButton view = new JButton(open);
+		view.setMargin(new Insets(1, 1, 1, 1));
 		view.setOpaque(false);
-		view.setBorderPainted( false );
+		view.setBorderPainted(false);
 		view.setContentAreaFilled(false);
-		
-		String [] reports=new String[4];
-		int i=0;
+
+		String[] reports = new String[4];
+		int i = 0;
 		StringTokenizer st = new StringTokenizer(report);
-		while(st.hasMoreTokens()){
-			reports[i]=st.nextToken();
+		while (st.hasMoreTokens()) {
+			reports[i] = st.nextToken();
 			i++;
 		}
-		fromDate=reports[1];
-		logger.debug("fromDate: "+reports[1]);
-		toDate=reports[2];
-		logger.debug("toDate: "+reports[2]);
-		typeReport=reports[3];
-		logger.debug("typeReport: "+reports[3]);
+		fromDate = reports[1];
+		logger.debug("fromDate: {}", reports[1]);
+		toDate = reports[2];
+		logger.debug("toDate: {}", reports[2]);
+		typeReport = reports[3];
+		logger.debug("typeReport: {}", reports[3]);
 		int position = doc.getEndPosition().getOffset();
 		StyleConstants.setForeground(keyWord, greenColor);
 
 		try {
-			doc.insertString(position, "\n*** "+name+ " wants to share with you this report:"+typeReport+"\n", keyWord);
+			doc.insertString(position, "\n*** " + name + " wants to share with you this report:" + typeReport + "\n", keyWord);
 		} catch (BadLocationException e) {
 			e.printStackTrace();
 		}
 		position = doc.getEndPosition().getOffset();
 		select(position, position);
-		
+
 		insertComponent(view);
 		view.addActionListener(new ActionListener() {
-			
+
 			@Override
 			public void actionPerformed(ActionEvent arg0) {
-				new GenericReportFromDateToDate(fromDate,toDate,typeReport, typeReport, false);
+				new GenericReportFromDateToDate(fromDate, toDate, typeReport, typeReport, false);
 				view.setEnabled(false);
 			}
 		});
-		
+
 	}
-	
-	
-	
+
 }

--- a/src/main/java/org/isf/xmpp/gui/ChatTab.java
+++ b/src/main/java/org/isf/xmpp/gui/ChatTab.java
@@ -17,89 +17,91 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ChatTab extends JTabbedPane {
-	
+
 	private final Logger logger = LoggerFactory.getLogger(ChatTab.class);
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 1L;
 	public TabButton tab;
-	 public void addTab(String title,Component component){
-		 	super.addTab(title,component);
-		 	int index;
-		 	index=indexOfTab(title);
-		 	logger.debug("index: " + indexOfTabComponent(this));
-	    	tab=new TabButton(title,indexOfTabComponent(this),this);
-		 	setTabComponentAt(index, tab);
-		 	
-	    }
-	 public Color getTabColor()
-	 {
-		
+
+	public void addTab(String title, Component component) {
+		super.addTab(title, component);
+		int index;
+		index = indexOfTab(title);
+		logger.debug("index: {}", indexOfTabComponent(this));
+		tab = new TabButton(title, indexOfTabComponent(this), this);
+		setTabComponentAt(index, tab);
+
+	}
+
+	public Color getTabColor() {
+
 		return tab.getColor();
-				
-	 }
-	 public void setTabColor(Color color)
-	 {
-		 tab.setColor(color);
-	 }
-	
+
+	}
+
+	public void setTabColor(Color color) {
+		tab.setColor(color);
+	}
+
 	public class TabButton extends JPanel implements ActionListener {
-		
+
 		/**
-		 * 
+		 *
 		 */
 		private static final long serialVersionUID = 1L;
 		int tab_number;
-	    ImageIcon reg = null;
-	    ImageIcon over = null;
-	    ChatTab tabReference;
-	    JLabel user= null;
-	    public TabButton( String label,int index,ChatTab tab ){
-	    	
-	        super(new FlowLayout(FlowLayout.LEFT,1,1));
-	    	tabReference=tab;
-	    	tab_number=index;
-	    	user=new JLabel(label);
-	        add(user);
-	        try{
+		ImageIcon reg = null;
+		ImageIcon over = null;
+		ChatTab tabReference;
+		JLabel user = null;
 
-	            // load firefox buttons
-	            reg = new ImageIcon("rsc/icons/regular_close_tab.JPG");
-	            over = new ImageIcon("rsc/icons/hoverOver_close_tab.JPG");
+		public TabButton(String label, int index, ChatTab tab) {
 
-	        } catch( Exception e ){
+			super(new FlowLayout(FlowLayout.LEFT, 1, 1));
+			tabReference = tab;
+			tab_number = index;
+			user = new JLabel(label);
+			add(user);
+			try {
 
-	            e.printStackTrace();
+				// load firefox buttons
+				reg = new ImageIcon("rsc/icons/regular_close_tab.JPG");
+				over = new ImageIcon("rsc/icons/hoverOver_close_tab.JPG");
 
-	        }
-	        setOpaque(false);
-	        final JButton button = new JButton(reg);
-	        button.setMargin(new Insets(1,1,1,1));
-	        button.setOpaque(false);
-	        button.setRolloverIcon(over);
-	        button.setPressedIcon(over);
-	        button.setBorderPainted( false );
-	        button.setContentAreaFilled(false);
-	        button.addActionListener( this );
-	        add( button );
+			} catch (Exception e) {
 
-	    }
-	    
-	    public void setColor(Color color){
-	    	user.setForeground(color);
-	    }
-	    public Color getColor()
-	    {
-	    	return user.getForeground();
-	    }
-	    public void actionPerformed(ActionEvent ae ){
+				e.printStackTrace();
 
-	        tabReference.remove(tabReference.indexOfTabComponent(this));
-	    	
-	    }
-	   
+			}
+			setOpaque(false);
+			final JButton button = new JButton(reg);
+			button.setMargin(new Insets(1, 1, 1, 1));
+			button.setOpaque(false);
+			button.setRolloverIcon(over);
+			button.setPressedIcon(over);
+			button.setBorderPainted(false);
+			button.setContentAreaFilled(false);
+			button.addActionListener(this);
+			add(button);
+
+		}
+
+		public void setColor(Color color) {
+			user.setForeground(color);
+		}
+
+		public Color getColor() {
+			return user.getForeground();
+		}
+
+		public void actionPerformed(ActionEvent ae) {
+
+			tabReference.remove(tabReference.indexOfTabComponent(this));
+
+		}
 
 	}
 }

--- a/src/main/java/org/isf/xmpp/gui/CommunicationFrame.java
+++ b/src/main/java/org/isf/xmpp/gui/CommunicationFrame.java
@@ -63,42 +63,40 @@ import org.slf4j.LoggerFactory;
 public class CommunicationFrame extends AbstractCommunicationFrame {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 1L;
 
 	private final Logger logger = LoggerFactory.getLogger(CommunicationFrame.class);
-	
+
 	private JPanel leftpanel;
-	private JSeparator separator=new JSeparator(SwingConstants.VERTICAL);
+	private JSeparator separator = new JSeparator(SwingConstants.VERTICAL);
 	private JList buddyList;
 	private ChatTab tabs;
-	public  Object user;
+	public Object user;
 	private ChatPanel newChat;
 	private Interaction interaction;
 	private static JFrame frame;
 	private Roster roster;
-	private JMenuItem sendFile,getInfo;
+	private JMenuItem sendFile, getInfo;
 	private JTextPane userInfo;
 	private ChatMessages area;
 
 	private UserBrowsingManager userBrowsingManager = Context.getApplicationContext().getBean(UserBrowsingManager.class);
 
-	public CommunicationFrame(){
-		if (frame==null){
+	public CommunicationFrame() {
+		if (frame == null) {
 
 			createFrame();
-			frame= this;
+			frame = this;
 			frame.validate();
 			frame.repaint();
 			frame.setVisible(false);
 			frame.validate();
 			frame.repaint();
 			logger.info("XMPP Server active and running"); //$NON-NLS-1$
-		}
-		else
-		{
-			frame=getFrame();
+		} else {
+			frame = getFrame();
 			frame.setVisible(true);
 			frame.validate();
 			frame.repaint();
@@ -106,62 +104,68 @@ public class CommunicationFrame extends AbstractCommunicationFrame {
 		}
 	}
 
-	private void createFrame()
-	{
+	private void createFrame() {
 		interaction = new Interaction();
 		activateListeners();
-		getContentPane().add(createLeftPanel(),BorderLayout.WEST);
-		getContentPane().add(separator,BorderLayout.CENTER);
+		getContentPane().add(createLeftPanel(), BorderLayout.WEST);
+		getContentPane().add(separator, BorderLayout.CENTER);
 
-		tabs= new ChatTab();
-		tabs.setPreferredSize(new Dimension(200,400));
-		tabs.setMaximumSize(new Dimension(200,400));
-		tabs.setMinimumSize(new Dimension(200,400));
-		tabs.setSize(new Dimension(200,400));
-		getContentPane().add(tabs,BorderLayout.CENTER);
+		tabs = new ChatTab();
+		tabs.setPreferredSize(new Dimension(200, 400));
+		tabs.setMaximumSize(new Dimension(200, 400));
+		tabs.setMinimumSize(new Dimension(200, 400));
+		tabs.setSize(new Dimension(200, 400));
+		getContentPane().add(tabs, BorderLayout.CENTER);
 		addWindowListener(new WindowListener() {
 
 			@Override
 			public void windowOpened(WindowEvent e) {
 			}
+
 			@Override
 			public void windowIconified(WindowEvent e) {
 			}
+
 			@Override
 			public void windowDeiconified(WindowEvent e) {
 			}
+
 			@Override
 			public void windowDeactivated(WindowEvent e) {
 			}
+
 			@Override
 			public void windowClosing(WindowEvent e) {
 				setVisible(false);
 			}
+
 			@Override
 			public void windowClosed(WindowEvent e) {
 			}
+
 			@Override
 			public void windowActivated(WindowEvent e) {
 			}
 		});
-		setSize(600,450);
-		
+		setSize(600, 450);
+
 		StringBuilder sb = new StringBuilder();
 		sb.append(MessageBundle.getMessage("angal.xmpp.communication")).append(" - ").append(UserBrowsingManager.getCurrentUser());
-		
+
 		setTitle(sb.toString()); //$NON-NLS-1$ //$NON-NLS-2$
 		setResizable(false);
 		setLocationRelativeTo(null);
-		
+
 	}
-	public void activateListeners(){
+
+	public void activateListeners() {
 		senseRoster();
 		incomingChat();
 		receiveFile();
 	}
 
 	/**
-	 * 
+	 *
 	 */
 	public void senseRoster() {
 		roster = interaction.getRoster();
@@ -169,20 +173,17 @@ public class CommunicationFrame extends AbstractCommunicationFrame {
 		roster.addRosterListener(new RosterListener() {
 
 			public void presenceChanged(Presence presence) {
-				logger.debug("State changed -> "+presence.getFrom()+" - "+presence); //$NON-NLS-1$ //$NON-NLS-2$
-				String user_name=interaction.userFromAddress(presence.getFrom());
+				logger.debug("State changed -> {} - {}", presence.getFrom(), presence); //$NON-NLS-1$ //$NON-NLS-2$
+				String user_name = interaction.userFromAddress(presence.getFrom());
 				StringBuilder sb = new StringBuilder();
-				if(!presence.isAvailable())
-				{
+				if (!presence.isAvailable()) {
 					sb.append(user_name).append(" ").append(MessageBundle.getMessage("angal.xmpp.isnowoffline"));
-				}
-				else if(presence.isAvailable())
-				{
+				} else if (presence.isAvailable()) {
 					sb.append(user_name).append(" ").append(MessageBundle.getMessage("angal.xmpp.isnowonline"));
 				}
-				int index=tabs.indexOfTab(user_name);
-				if(index!=-1){
-					area=getArea(user_name, true);
+				int index = tabs.indexOfTab(user_name);
+				if (index != -1) {
+					area = getArea(user_name, true);
 					try {
 						area.printNotification(sb.toString()); //$NON-NLS-1$
 					} catch (BadLocationException e) {
@@ -191,34 +192,42 @@ public class CommunicationFrame extends AbstractCommunicationFrame {
 				}
 				refreshBuddyList();
 			}
-			public void entriesUpdated(Collection<String> arg0) {}
-			public void entriesDeleted(Collection<String> arg0) {}
-			public void entriesAdded(Collection<String> arg0) {}
+
+			public void entriesUpdated(Collection<String> arg0) {
+			}
+
+			public void entriesDeleted(Collection<String> arg0) {
+			}
+
+			public void entriesAdded(Collection<String> arg0) {
+			}
 		});
 	}
-	public void refreshBuddyList()
-	{
+
+	public void refreshBuddyList() {
 		getContentPane().remove(leftpanel);
-		leftpanel=createLeftPanel();
-		getContentPane().add(leftpanel,BorderLayout.WEST);
+		leftpanel = createLeftPanel();
+		getContentPane().add(leftpanel, BorderLayout.WEST);
 		validate();
 		repaint();
 	}
-	private void incomingChat(){
+
+	private void incomingChat() {
 		ChatManager chatmanager = interaction.getServer().getChatManager();
 		chatmanager.addChatListener(new ChatManagerListener() {
+
 			@Override
 			public void chatCreated(Chat chat, boolean createLocally) {
 				chat.addMessageListener(new MessageListener() {
 
 					@Override
 					public void processMessage(Chat chat, Message message) {
-						if(message.getType() == Message.Type.chat){
-							logger.debug("Incoming message from: " + chat.getThreadID());
-							logger.debug("GUI: " + CommunicationFrame.this);
-							String user = chat.getParticipant().substring(0,chat.getParticipant().indexOf("@"));
-							printMessage(getArea(user,true), interaction.userFromAddress(message.getFrom()), message.getBody(), false);
-							if(!isVisible()) {
+						if (message.getType() == Message.Type.chat) {
+							logger.debug("Incoming message from: {}", chat.getThreadID());
+							logger.debug("GUI: {}", CommunicationFrame.this);
+							String user = chat.getParticipant().substring(0, chat.getParticipant().indexOf("@"));
+							printMessage(getArea(user, true), interaction.userFromAddress(message.getFrom()), message.getBody(), false);
+							if (!isVisible()) {
 								setVisible(true);
 								setState(java.awt.Frame.NORMAL);
 								toFront();
@@ -228,24 +237,25 @@ public class CommunicationFrame extends AbstractCommunicationFrame {
 						}
 					}
 				});
-				if(!createLocally) {
-					
+				if (!createLocally) {
+
 				}
 			}
 		});
 	}
-	public void receiveFile(){
+
+	public void receiveFile() {
 		FileTransferNegotiator.setServiceEnabled(interaction.getConnection(), true);
 	}
-	
-	private JScrollPane createBuddyList(){
+
+	private JScrollPane createBuddyList() {
 
 		buddyList = getBuddyList();
-		final JPopupMenu popUpMenu= new JPopupMenu();
-		popUpMenu.add(sendFile= new JMenuItem(MessageBundle.getMessage("angal.xmpp.sendfile"))); //$NON-NLS-1$
+		final JPopupMenu popUpMenu = new JPopupMenu();
+		popUpMenu.add(sendFile = new JMenuItem(MessageBundle.getMessage("angal.xmpp.sendfile"))); //$NON-NLS-1$
 		popUpMenu.add(new JPopupMenu.Separator());
-		popUpMenu.add(getInfo=new JMenuItem(MessageBundle.getMessage("angal.xmpp.getinfo"))); //$NON-NLS-1$
-		final JFileChooser fileChooser=new JFileChooser();
+		popUpMenu.add(getInfo = new JMenuItem(MessageBundle.getMessage("angal.xmpp.getinfo"))); //$NON-NLS-1$
+		final JFileChooser fileChooser = new JFileChooser();
 		sendFile.addActionListener(new ActionListener() {
 
 			@Override
@@ -253,10 +263,10 @@ public class CommunicationFrame extends AbstractCommunicationFrame {
 				int returnVal = fileChooser.showOpenDialog(getParent());
 				if (returnVal == JFileChooser.APPROVE_OPTION) {
 					File file = fileChooser.getSelectedFile();
-					logger.debug("Selected file: " + file.toString());
-					String receiver = (String)(((RosterEntry) buddyList.getSelectedValue()).getName());
-					logger.debug("Receiver: " + receiver);
-					interaction.sendFile(receiver, file, null);				
+					logger.debug("Selected file: {}", file.toString());
+					String receiver = (String) (((RosterEntry) buddyList.getSelectedValue()).getName());
+					logger.debug("Receiver: {}", receiver);
+					interaction.sendFile(receiver, file, null);
 				}
 			}
 		});
@@ -264,20 +274,20 @@ public class CommunicationFrame extends AbstractCommunicationFrame {
 
 			@Override
 			public void actionPerformed(ActionEvent arg0) {
-				String user_name = (String)((RosterEntry)buddyList.getSelectedValue()).getName();
-                String info = null;
-                try {
-                    info = userBrowsingManager.getUsrInfo(user_name);
-                } catch (OHServiceException e) {
-                    OHServiceExceptionUtil.showMessages(e);
-                }
+				String user_name = (String) ((RosterEntry) buddyList.getSelectedValue()).getName();
+				String info = null;
+				try {
+					info = userBrowsingManager.getUsrInfo(user_name);
+				} catch (OHServiceException e) {
+					OHServiceExceptionUtil.showMessages(e);
+				}
 
-                StringBuilder sb = new StringBuilder();
+				StringBuilder sb = new StringBuilder();
 				sb.append(MessageBundle.getMessage("angal.xmpp.user")).append(": ");
 				sb.append(user_name).append("\n");
 				sb.append(MessageBundle.getMessage("angal.xmpp.info")).append(": ");
 				sb.append(info);
-				
+
 				userInfo.setText(sb.toString()); //$NON-NLS-1$ //$NON-NLS-2$
 				validate();
 				repaint();
@@ -288,79 +298,83 @@ public class CommunicationFrame extends AbstractCommunicationFrame {
 		buddyList.addMouseListener(new MouseListener() {
 
 			@Override
-			public void mouseReleased(MouseEvent e) {}
+			public void mouseReleased(MouseEvent e) {
+			}
+
 			@Override
 			public void mousePressed(MouseEvent e) {
 				if (e.getClickCount() == 1) {
 					int index = buddyList.locationToIndex(e.getPoint());
 					if (index >= 0) {
-						user = ((RosterEntry)buddyList.getModel().getElementAt(index)).getName();
+						user = ((RosterEntry) buddyList.getModel().getElementAt(index)).getName();
 					}
-				}				
+				}
 			}
+
 			@Override
-			public void mouseExited(MouseEvent e) {}
+			public void mouseExited(MouseEvent e) {
+			}
+
 			@Override
-			public void mouseEntered(MouseEvent e) {}
+			public void mouseEntered(MouseEvent e) {
+			}
+
 			@Override
 			public void mouseClicked(MouseEvent e) {
-				if(SwingUtilities.isRightMouseButton(e)&&!buddyList.isSelectionEmpty()&& buddyList.locationToIndex(e.getPoint())== buddyList.getSelectedIndex())
+				if (SwingUtilities.isRightMouseButton(e) && !buddyList.isSelectionEmpty() && buddyList.locationToIndex(e.getPoint()) == buddyList
+						.getSelectedIndex())
 					popUpMenu.show(buddyList, e.getX(), e.getY());
 
 				if (e.getClickCount() == 2) {
 					int index = buddyList.locationToIndex(e.getPoint());
-					logger.debug("Index : " + index);
+					logger.debug("Index : {}", index);
 					if (index >= 0) {
-						user = ((RosterEntry)buddyList.getModel().getElementAt(index)).getName();
-						logger.debug("User selected: " + user.toString()); //$NON-NLS-1$
-						newChat=new ChatPanel();
-						roster=interaction.getRoster();
-						Presence presence=roster.getPresence(((RosterEntry)buddyList.getModel().getElementAt(index)).getUser());
-						if(presence.isAvailable()==true){
-							if(tabs.indexOfTab((String)user) == -1){
-								tabs.addTab((String) user,newChat);
-								tabs.setSelectedIndex(tabs.indexOfTab((String)user));
+						user = ((RosterEntry) buddyList.getModel().getElementAt(index)).getName();
+						logger.debug("User selected: {}", user.toString()); //$NON-NLS-1$
+						newChat = new ChatPanel();
+						roster = interaction.getRoster();
+						Presence presence = roster.getPresence(((RosterEntry) buddyList.getModel().getElementAt(index)).getUser());
+						if (presence.isAvailable() == true) {
+							if (tabs.indexOfTab((String) user) == -1) {
+								tabs.addTab((String) user, newChat);
+								tabs.setSelectedIndex(tabs.indexOfTab((String) user));
 							}
-							tabs.setSelectedIndex(tabs.indexOfTab((String)user));
-						}
-						else
-						{
+							tabs.setSelectedIndex(tabs.indexOfTab((String) user));
+						} else {
 							logger.debug("User offline"); //$NON-NLS-1$
 						}
 					}
 				}
 			}
 		});
-		JScrollPane buddy= new JScrollPane(buddyList,JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
-		Dimension size = new Dimension(150,1000);
+		JScrollPane buddy = new JScrollPane(buddyList, JScrollPane.VERTICAL_SCROLLBAR_ALWAYS, JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+		Dimension size = new Dimension(150, 1000);
 		buddy.setPreferredSize(size);
 
 		return buddy;
 	}
 
-	private JTextPane userInfoArea()
-	{
-		Dimension size = new Dimension(150,150);
+	private JTextPane userInfoArea() {
+		Dimension size = new Dimension(150, 150);
 		userInfo = new JTextPane();
-		userInfo.setForeground(new Color(58,95,205));
-		userInfo.setBackground(new Color(238,238,238));
+		userInfo.setForeground(new Color(58, 95, 205));
+		userInfo.setBackground(new Color(238, 238, 238));
 		userInfo.setMinimumSize(size);
 		userInfo.setMaximumSize(size);
-		userInfo.setSize(size);	
+		userInfo.setSize(size);
 		userInfo.setBorder(BorderFactory.createTitledBorder(MessageBundle.getMessage("angal.xmpp.usersinfo"))); //$NON-NLS-1$
 		userInfo.setEditable(false);
-
 
 		return userInfo;
 	}
 
-	private JPanel createLeftPanel(){//pannello lista dei contatti
-		leftpanel=new JPanel();
-		JScrollPane buddy=new JScrollPane();
-		Dimension size = new Dimension(150,200);
+	private JPanel createLeftPanel() {//pannello lista dei contatti
+		leftpanel = new JPanel();
+		JScrollPane buddy = new JScrollPane();
+		Dimension size = new Dimension(150, 200);
 
 		leftpanel.setLayout(new BoxLayout(leftpanel, BoxLayout.Y_AXIS));
-		buddy=createBuddyList();
+		buddy = createBuddyList();
 		buddy.setBorder(BorderFactory.createTitledBorder(MessageBundle.getMessage("angal.xmpp.contacts"))); //$NON-NLS-1$
 		buddy.setPreferredSize(size);
 		buddy.setMaximumSize(size);
@@ -371,93 +385,89 @@ public class CommunicationFrame extends AbstractCommunicationFrame {
 		return leftpanel;
 	}
 
-	public ChatMessages getArea(String name,boolean incoming)
-	{
+	public ChatMessages getArea(String name, boolean incoming) {
 
 		int index = tabs.indexOfTab(name);
-		logger.debug("Index_: " + index); //$NON-NLS-1$
-		if(index != -1){
-			if(incoming){
-				((TabButton)tabs.getTabComponentAt(index)).setColor(Color.red);
-			}
-			else
-			{
-				((TabButton)tabs.getTabComponentAt(index)).setColor(Color.black);
+		logger.debug("Index_: {}", index); //$NON-NLS-1$
+		if (index != -1) {
+			if (incoming) {
+				((TabButton) tabs.getTabComponentAt(index)).setColor(Color.red);
+			} else {
+				((TabButton) tabs.getTabComponentAt(index)).setColor(Color.black);
 			}
 
 			return ((ChatPanel) tabs.getComponentAt(index)).getChatMessages();
 
-		}
-		else
-		{
-			logger.debug("Index creation: " + index); //$NON-NLS-1$
-			newChat=new ChatPanel();
+		} else {
+			logger.debug("Index creation: {}", index); //$NON-NLS-1$
+			newChat = new ChatPanel();
 			tabs.addTab(name, newChat);
-			tabs.setTabColor(new Color(176,23,31));
+			tabs.setTabColor(new Color(176, 23, 31));
 			validate();
 			repaint();
 			index = tabs.indexOfTab(name);
-			logger.debug("Index creation: " + index); //$NON-NLS-1$
+			logger.debug("Index creation: {}", index); //$NON-NLS-1$
 			return ((ChatPanel) tabs.getComponentAt(index)).getChatMessages();
 		}
 	}
 
-	public String getSelectedUser(){
-		int index=tabs.getSelectedIndex();
-		logger.debug("Title : " + tabs.getTitleAt(index)); //$NON-NLS-1$
-		logger.debug("Index : " + index); //$NON-NLS-1$
+	public String getSelectedUser() {
+		int index = tabs.getSelectedIndex();
+		logger.debug("Title : {}", tabs.getTitleAt(index)); //$NON-NLS-1$
+		logger.debug("Index : {}", index); //$NON-NLS-1$
 		return tabs.getTitleAt(index);
 	}
-	public void printMessage(ChatMessages area,String user,String text, boolean visualize){
+
+	public void printMessage(ChatMessages area, String user, String text, boolean visualize) {
 		try {
 
-			if(text.startsWith("011100100110010101110000011011110111001001110100")){//report jasper //$NON-NLS-1$
-				area.printReport(user,text);
-			}
-			else if(text.startsWith("0101010001000001"))//trasferimento file accettato 0101010001000001=TA //$NON-NLS-1$
+			if (text.startsWith("011100100110010101110000011011110111001001110100")) {//report jasper //$NON-NLS-1$
+				area.printReport(user, text);
+			} else if (text.startsWith("0101010001000001"))//trasferimento file accettato 0101010001000001=TA //$NON-NLS-1$
 			{
 				int index = text.indexOf("$"); //$NON-NLS-1$
-				area.printNotification(text.substring(index+1));
+				area.printNotification(text.substring(index + 1));
 				logger.debug("Transfer accepted."); //$NON-NLS-1$
-			}
-			else if(text.startsWith("0101010001010010")){//trasferimento file rifiutato 0101010001010010=TR //$NON-NLS-1$
+			} else if (text.startsWith("0101010001010010")) {//trasferimento file rifiutato 0101010001010010=TR //$NON-NLS-1$
 				int index = text.indexOf("$"); //$NON-NLS-1$
 				logger.debug("Transfer rejected."); //$NON-NLS-1$
-				area.printNotification(text.substring(index+1));
-			}
-			else{	
+				area.printNotification(text.substring(index + 1));
+			} else {
 				area.printMessage(user, text, visualize);
 			}
-		}catch (BadLocationException e) {
+		} catch (BadLocationException e) {
 			e.printStackTrace();
-		} 
+		}
 
 	}
-	public void printNotification(ChatMessages area,String user,String file_transfer, JButton accept, JButton reject){
+
+	public void printNotification(ChatMessages area, String user, String file_transfer, JButton accept, JButton reject) {
 		area.printNotification(user, file_transfer, accept, reject);
 	}
-	public void printNotification(ChatMessages area,String text){
+
+	public void printNotification(ChatMessages area, String text) {
 		try {
 			area.printNotification(text);
 		} catch (BadLocationException e) {
 			e.printStackTrace();
 		}
 	}
-	
-	public JList getBuddyList(){
 
-		logger.debug("==> roster : " + roster);
-		List<RosterEntry> entries= new ArrayList<RosterEntry>( roster.getEntries());
-		Collections.sort(entries,new Comparator<RosterEntry>(){
-			public int compare(RosterEntry r1, RosterEntry r2){
+	public JList getBuddyList() {
+
+		logger.debug("==> roster : {}", roster);
+		List<RosterEntry> entries = new ArrayList<RosterEntry>(roster.getEntries());
+		Collections.sort(entries, new Comparator<RosterEntry>() {
+
+			public int compare(RosterEntry r1, RosterEntry r2) {
 				Presence presence1 = roster.getPresence(r1.getUser());
 				Presence presence2 = roster.getPresence(r2.getUser());
 				String r1_name = r1.getName();
 				String r2_name = r2.getName();
-				if(presence1.isAvailable() == presence2.isAvailable())
+				if (presence1.isAvailable() == presence2.isAvailable())
 					return r1_name.toLowerCase().compareTo(r2_name.toLowerCase());
 
-				if(presence1.isAvailable() && (presence2.isAvailable() == false))
+				if (presence1.isAvailable() && (presence2.isAvailable() == false))
 					return -1;
 
 				else
@@ -474,26 +484,25 @@ public class CommunicationFrame extends AbstractCommunicationFrame {
 		return buddy;
 	}
 
-	public void sendMessage(String text_message, String to, boolean visualize){
+	public void sendMessage(String text_message, String to, boolean visualize) {
 
 		interaction.sendMessage(CommunicationFrame.this, text_message, to, visualize);
 		if (visualize) {
-			printMessage(getArea(getSelectedUser(),false),"me", text_message, visualize);
+			printMessage(getArea(getSelectedUser(), false), "me", text_message, visualize);
 		}
 	}
 
-
-	public static JFrame getFrame(){
+	public static JFrame getFrame() {
 		return frame;
 	}
 
 	@Override
 	public void processMessage(Chat arg0, Message arg1) {
-		if(arg1.getType() == Message.Type.normal){
-			logger.debug("Send message from: " + arg0.getThreadID() );
-			String user = arg0.getParticipant().substring(0,arg0.getParticipant().indexOf("@"));
-			printMessage((getArea(user,false)), user, arg1.getBody(), false);
-			if(!this.isVisible()) {
+		if (arg1.getType() == Message.Type.normal) {
+			logger.debug("Send message from: {}", arg0.getThreadID());
+			String user = arg0.getParticipant().substring(0, arg0.getParticipant().indexOf("@"));
+			printMessage((getArea(user, false)), user, arg1.getBody(), false);
+			if (!this.isVisible()) {
 				this.setVisible(true);
 				this.setState(java.awt.Frame.ICONIFIED);
 				this.toFront();
@@ -506,28 +515,27 @@ public class CommunicationFrame extends AbstractCommunicationFrame {
 	@Override
 	public void fileTransferRequest(final FileTransferRequest request) {
 
-		if(!this.isVisible())
+		if (!this.isVisible())
 			this.setVisible(true);
-		
+
 		ImageIcon acceptIcon;
 		ImageIcon rejectIcon;
-		
-		String file_transfer=((interaction.userFromAddress(request.getRequestor())+" would like to send: \n"+request.getFileName()));
-		acceptIcon= new ImageIcon("rsc/icons/ok_button.png");
-		rejectIcon= new ImageIcon("rsc/icons/delete_button.png");
-		final JButton accept = new JButton(acceptIcon);
-		accept.setMargin(new Insets(1,1,1,1));
-		accept.setOpaque(false);
-		accept.setBorderPainted( false );
-		accept.setContentAreaFilled(false);
-		final JButton reject= new JButton(rejectIcon);
-		reject.setMargin(new Insets(1,1,1,1));
-		reject.setOpaque(false);
-		reject.setBorderPainted( false );
-		reject.setContentAreaFilled(false);
-		final String user=interaction.userFromAddress(request.getRequestor());
-		this.printNotification((this.getArea(user,false)),user, file_transfer, accept, reject);
 
+		String file_transfer = ((interaction.userFromAddress(request.getRequestor()) + " would like to send: \n" + request.getFileName()));
+		acceptIcon = new ImageIcon("rsc/icons/ok_button.png");
+		rejectIcon = new ImageIcon("rsc/icons/delete_button.png");
+		final JButton accept = new JButton(acceptIcon);
+		accept.setMargin(new Insets(1, 1, 1, 1));
+		accept.setOpaque(false);
+		accept.setBorderPainted(false);
+		accept.setContentAreaFilled(false);
+		final JButton reject = new JButton(rejectIcon);
+		reject.setMargin(new Insets(1, 1, 1, 1));
+		reject.setOpaque(false);
+		reject.setBorderPainted(false);
+		reject.setContentAreaFilled(false);
+		final String user = interaction.userFromAddress(request.getRequestor());
+		this.printNotification((this.getArea(user, false)), user, file_transfer, accept, reject);
 
 		accept.addActionListener(new ActionListener() {
 
@@ -535,22 +543,21 @@ public class CommunicationFrame extends AbstractCommunicationFrame {
 			public void actionPerformed(ActionEvent e) {
 				accept.setEnabled(false);
 				reject.setEnabled(false);
-				JFileChooser chooser = new JFileChooser(); 
+				JFileChooser chooser = new JFileChooser();
 				chooser.setCurrentDirectory(new java.io.File("."));
 				chooser.setDialogTitle("Select the directoty");
 				chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
 
 				chooser.setAcceptAllFileFilterUsed(false);
 
-				if (chooser.showOpenDialog(CommunicationFrame.this) == JFileChooser.APPROVE_OPTION) { 
-					logger.debug("getCurrentDirectory(): " +  chooser.getCurrentDirectory());
-					logger.debug("getSelectedFile() : " +  chooser.getSelectedFile());
-				}
-				else {
+				if (chooser.showOpenDialog(CommunicationFrame.this) == JFileChooser.APPROVE_OPTION) {
+					logger.debug("getCurrentDirectory(): {}", chooser.getCurrentDirectory());
+					logger.debug("getSelectedFile() : {}", chooser.getSelectedFile());
+				} else {
 					logger.debug("No Selection.");
 				}
 				IncomingFileTransfer transfer = request.accept();
-				String path= chooser.getSelectedFile()+"/"+request.getFileName();
+				String path = chooser.getSelectedFile() + "/" + request.getFileName();
 				File file = new File(path);
 				try {
 					transfer.recieveFile(file);
@@ -558,8 +565,8 @@ public class CommunicationFrame extends AbstractCommunicationFrame {
 					k.printStackTrace();
 				}
 
-				printNotification((getArea(user,true)),"the file transfer of: "+request.getFileName()+" between you and "+ user+" ended successfully");
-				sendMessage("0101010001000001 $File transfer of: "+request.getFileName()+ " has been accepted",request.getRequestor(),false);
+				printNotification((getArea(user, true)), "the file transfer of: " + request.getFileName() + " between you and " + user + " ended successfully");
+				sendMessage("0101010001000001 $File transfer of: " + request.getFileName() + " has been accepted", request.getRequestor(), false);
 			}
 		});
 		reject.addActionListener(new ActionListener() {
@@ -570,26 +577,26 @@ public class CommunicationFrame extends AbstractCommunicationFrame {
 				reject.setEnabled(false);
 				request.reject();
 
-				printNotification((getArea(user,false))," you have rejected the file transfer");
-				sendMessage("0101010001010010 $File transfer of: "+request.getFileName()+" has been rejected",request.getRequestor(), false);
+				printNotification((getArea(user, false)), " you have rejected the file transfer");
+				sendMessage("0101010001010010 $File transfer of: " + request.getFileName() + " has been rejected", request.getRequestor(), false);
 			}
 		});
 	}
 
 	@Override
 	public void chatCreated(Chat chat, boolean createdLocally) {
-		if(!createdLocally) {
+		if (!createdLocally) {
 
 			chat.addMessageListener(new MessageListener() {
 
 				@Override
 				public void processMessage(Chat chat, Message message) {
-					if(message.getType() == Message.Type.chat){
-						logger.debug("Incoming message from: " + chat.getThreadID());
-						logger.debug("GUI: " + CommunicationFrame.this);
-						String user = chat.getParticipant().substring(0,chat.getParticipant().indexOf("@"));
-						printMessage((getArea(user,false)),interaction.userFromAddress(message.getFrom()), message.getBody(), false);
-						if(!isVisible()) {
+					if (message.getType() == Message.Type.chat) {
+						logger.debug("Incoming message from: {}", chat.getThreadID());
+						logger.debug("GUI: {}", CommunicationFrame.this);
+						String user = chat.getParticipant().substring(0, chat.getParticipant().indexOf("@"));
+						printMessage((getArea(user, false)), interaction.userFromAddress(message.getFrom()), message.getBody(), false);
+						if (!isVisible()) {
 							setVisible(true);
 							setState(java.awt.Frame.NORMAL);
 							toFront();


### PR DESCRIPTION
Non-constant concatenations in logging messages are evaluated at runtime even when the logging message is not logged; this can negatively impact performance. Thus these changes use a parameterized log message instead which will not be evaluated when logging is disabled.

Because there were only 9 files, reformatting to match the standards was done.

If you want to hide the white space changes:
![HideWhiteSpaceChanges](https://user-images.githubusercontent.com/1105445/90763599-f6279000-e2b4-11ea-850a-80bc60254678.jpg)
