### PR TITLE
Add maven license plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,34 @@
 					<finalName>OpenHospital20/bin/OH-gui</finalName>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>license-maven-plugin</artifactId>
+				<version>2.0.0</version>
+				<configuration>
+					<verbose>false</verbose>
+					<addSvnKeyWords>true</addSvnKeyWords>
+				</configuration>
+				<executions>
+					<execution>
+						<id>first</id>
+						<goals>
+							<goal>update-file-header</goal>
+						</goals>
+						<phase>process-sources</phase>
+						<configuration>
+							<licenseName>gpl_v3</licenseName>
+							<inceptionYear>2006</inceptionYear>
+							<organizationName>Informatici Senza Frontiere</organizationName>
+							<projectName>OpenHospital</projectName>
+							<addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>
+							<roots>
+								<root>src/main/java</root>
+							</roots>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
As was done in the Core repository in this [PR](https://github.com/informatici/openhospital-core/pull/165), adding the maven license plugin.   The actual adding of the header will be done in another PR.