### PR TITLE
Update Spring from 4.3.18 to latest 4.x branch 4.3.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 	
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring.framework.version>4.3.18.RELEASE</spring.framework.version>
+		<spring.framework.version>4.3.28.RELEASE</spring.framework.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
Update Spring to latest 4.3.28 reversion that is compatible.  This matches the change made to the CORE repository. 

This also replaces this [PR](https://github.com/informatici/openhospital-gui/pull/192).