### PR TITLE
OP-248 Adding bundle message for email validation

### DIFF
--- a/bundle/language_ar.properties
+++ b/bundle/language_ar.properties
@@ -277,6 +277,7 @@ angal.common.descriptionstar                                                    
 angal.common.doyouwanttoproceed                                                  = هل تريد المتابعة؟
 angal.common.edit                                                                = تعديل
 angal.common.editm                                                               = تعديل
+angal.common.emailmustbevalid                                                    = يجب ان يكون البريد الاكتروني صحيح
 angal.common.excel                                                               = Excel
 angal.common.from                                                                = من
 angal.common.hours                                                               = Hours

--- a/bundle/language_de.properties
+++ b/bundle/language_de.properties
@@ -275,6 +275,7 @@ angal.common.descriptionstar                                                    
 angal.common.doyouwanttoproceed                                                  = Willst du fortfahren?
 angal.common.edit                                                                = Ändern
 angal.common.editm                                                               = ÄNDERN
+angal.common.emailmustbevalid                                                    = Email muss gültig sein
 angal.common.excel                                                               = Excel
 angal.common.from                                                                = Seit
 angal.common.hours                                                               = Hours

--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -281,7 +281,7 @@ angal.common.descriptionstar                                                    
 angal.common.doyouwanttoproceed                                                  = Do you want to proceed?
 angal.common.edit                                                                = Edit
 angal.common.editm                                                               = EDIT
-angal.common.emailmustbevalid                                           		 = Email must be valid
+angal.common.emailmustbevalid                                                    = Email must be valid
 angal.common.excel                                                               = Excel
 angal.common.from                                                                = From
 angal.common.hours                                                               = Hours

--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -281,6 +281,7 @@ angal.common.descriptionstar                                                    
 angal.common.doyouwanttoproceed                                                  = Do you want to proceed?
 angal.common.edit                                                                = Edit
 angal.common.editm                                                               = EDIT
+angal.common.emailmustbevalid                                           		 = Email must be valid
 angal.common.excel                                                               = Excel
 angal.common.from                                                                = From
 angal.common.hours                                                               = Hours

--- a/bundle/language_es.properties
+++ b/bundle/language_es.properties
@@ -278,6 +278,7 @@ angal.common.descriptionstar                                                    
 angal.common.doyouwanttoproceed                                                  = Quieres proceder?
 angal.common.edit                                                                = Modificar
 angal.common.editm                                                               = MODIFICAR
+angal.common.emailmustbevalid                                                    = El email debe ser válido
 angal.common.excel                                                               = Excel
 angal.common.from                                                                = Da
 angal.common.hours                                                               = Horas

--- a/bundle/language_fr.properties
+++ b/bundle/language_fr.properties
@@ -280,6 +280,7 @@ angal.common.descriptionstar                                                    
 angal.common.doyouwanttoproceed                                                  = Voulez-vous poursuivre?
 angal.common.edit                                                                = Modification
 angal.common.editm                                                               = MODIFICATION
+angal.common.emailmustbevalid                                                    = L'email doit être valide
 angal.common.excel                                                               = Excel
 angal.common.from                                                                = De
 angal.common.hours                                                               = Hours

--- a/bundle/language_it.properties
+++ b/bundle/language_it.properties
@@ -280,6 +280,7 @@ angal.common.descriptionstar                                                    
 angal.common.doyouwanttoproceed                                                  = Vuoi procedere?
 angal.common.edit                                                                = Modifica
 angal.common.editm                                                               = MODIFICA
+angal.common.emailmustbevalid                                                    = L'email deve essere valida
 angal.common.excel                                                               = Excel
 angal.common.from                                                                = Da
 angal.common.hours                                                               = Ore

--- a/bundle/language_pt.properties
+++ b/bundle/language_pt.properties
@@ -275,6 +275,7 @@ angal.common.descriptionstar                                                    
 angal.common.doyouwanttoproceed                                                  = Você quer prosseguir?
 angal.common.edit                                                                = Editar
 angal.common.editm                                                               = EDITAR
+angal.common.emailmustbevalid                                                    = E-mail deve ser válido
 angal.common.excel                                                               = Excel
 angal.common.from                                                                = De
 angal.common.hours                                                               = Horas

--- a/bundle/language_sw.properties
+++ b/bundle/language_sw.properties
@@ -275,6 +275,7 @@ angal.common.descriptionstar                                                    
 angal.common.doyouwanttoproceed                                                  = Je, unataka kuendelea?
 angal.common.edit                                                                = Hariri
 angal.common.editm                                                               = HARIRI
+angal.common.emailmustbevalid                                                    = Email måste vara giltig
 angal.common.excel                                                               = Excel
 angal.common.from                                                                = Kutoka
 angal.common.hours                                                               = Masaa

--- a/bundle/language_zh_CN.properties
+++ b/bundle/language_zh_CN.properties
@@ -263,6 +263,7 @@ angal.common.descriptionstar                                                    
 angal.common.doyouwanttoproceed                                                  = Do you want to proceed?
 angal.common.edit                                                                = Edit
 angal.common.editm                                                               = EDIT
+angal.common.emailmustbevalid                                                    = Email must be valid
 angal.common.excel                                                               = Excel
 angal.common.from                                                                = From
 angal.common.hours                                                               = Hours


### PR DESCRIPTION
Adding the OP-248 email validation messages in the bundles.

Sibling PR: https://github.com/informatici/openhospital-core/pull/190