### PR TITLE
Java version check update

### DIFF
--- a/src/main/java/org/isf/menu/gui/Menu.java
+++ b/src/main/java/org/isf/menu/gui/Menu.java
@@ -39,7 +39,7 @@ public class Menu {
 
 	private static Logger logger = LoggerFactory.getLogger(Menu.class);
 
-	private final static float MIN_JAVA_VERSION = (float) 1.6;
+	private final static float MIN_JAVA_VERSION = (float) 1.8;
 
 	/**
 	 * Create the GUI and show it.


### PR DESCRIPTION
Strictly speaking I'm not sure why that java version check is there: if the version isn't right, it wouldn't be able to execute the bytecode at all, no? If so, should I remove that check?