### PR TITLE
Chore: fix project name references

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For Eclipse the process requires loading the formatting style and the import ord
  
 </details> 
 
-Please read the OpenHospital [Wiki](https://openhospital.atlassian.net/wiki/display/OH/Contribution+Guidelines)
+Please read the Open Hospital [Wiki](https://openhospital.atlassian.net/wiki/display/OH/Contribution+Guidelines)
 
 See the Open Issues on [Jira](https://openhospital.atlassian.net/issues/)
 

--- a/SetupGSM.sh
+++ b/SetupGSM.sh
@@ -31,7 +31,7 @@ if [ -z $JAVA_HOME ]; then
   JAVA_EXE=java
 fi
 
-######## OPENHOSPITAL Configuration:
+######## OPEN HOSPITAL Configuration:
 
 # add the libraries to the OPENHOSPITAL_CLASSPATH.
 # EXEDIR is the directory where this executable is.

--- a/build.properties
+++ b/build.properties
@@ -4,7 +4,7 @@ app.version = 1_8_3
 src.dir = src
 #directory for binary files result of compilation
 bin.dir = bin
-#main directory file of the OpenHospital project
+#main directory file of the Open Hospital project
 main.dir = ./
 #Directory for distribution files
 dist.dir = ../OpenHospital

--- a/doc/changelog_1_7_0.txt
+++ b/doc/changelog_1_7_0.txt
@@ -13,9 +13,9 @@
 			- org.isf.stat.reportlauncher.gui.ReportLauncher.java
 			
 	Communication new module:
-	This module allow users, to share informations and files. I have also modify 
-	many other source file, to make possible the sharing of informations on openhospital
-	such as information about In/out patient, statistic informations, informations about medical's stock
+	This module allows users to share information and files. I have also modified
+	many other source files to make possible the sharing of information on Open Hospital
+	such as information about In/out patient, statistic information, information about medical stock, etc.
 ========================================================================================================
 2.
 	20/02/2012

--- a/doc/changelog_1_8_0.txt
+++ b/doc/changelog_1_8_0.txt
@@ -652,8 +652,8 @@
 			   --> mysql/db/step_03_dump_default_data_it.sql
 			   <-- mysql/db/step_04_dump_example_data.sql
 			   
-	Added sample mechanism to install OpenHospital in different languages (the internal
-	data set is changed accordingly) or with demo data (english only)
+	Added sample mechanism to install Open Hospital in different languages (the internal
+	data set is changed accordingly) or with demo data (English only)
 ===========================================================================================
 73.
 	29/11/2014 --> poh_files/oh.bat

--- a/doc/changelog_1_8_3.txt
+++ b/doc/changelog_1_8_3.txt
@@ -30,7 +30,7 @@ Date:   2018-09-05
     Upgrade to 1.8.3 - Commit 17. and 18.
     
     - Enhanced Ant build in order to build portable versions too (only
-    OpenHospital part)
+    the Open Hospital part)
     - Fixed Ant script and added missing poh-win32 files
 
 commit 1bd571e6b6a7ddb196923103cc967dcb835e46ac

--- a/rsc/generalData.properties
+++ b/rsc/generalData.properties
@@ -1,4 +1,4 @@
-# This file contains OpenHospital settings
+# This file contains Open Hospital settings
 LANGUAGE=en
 SINGLEUSER=no
 AUTOMATICLOT_IN=no

--- a/src/main/java/org/isf/menu/gui/MainMenu.java
+++ b/src/main/java/org/isf/menu/gui/MainMenu.java
@@ -304,7 +304,7 @@ public class MainMenu extends JFrame implements ActionListener, Login.LoginListe
 	private void actionExit(int status) {
 		if (status == 2)
 			logger.info("Login failed.");
-		logger.info("\n\n=====================\n OpenHospital closed \n=====================\n");
+		logger.info("\n\n=====================\n Open Hospital closed \n=====================\n");
 		System.exit(status);
 	}
 

--- a/src/main/java/org/isf/menu/gui/Menu.java
+++ b/src/main/java/org/isf/menu/gui/Menu.java
@@ -46,7 +46,7 @@ public class Menu {
 	 */
 	private static void createAndShowGUI() {
 		logger = LoggerFactory.getLogger(Menu.class);
-		logger.info("\n\n=====================\nStarting OpenHospital\n=====================\n");
+		logger.info("\n\n=====================\nStarting Open Hospital\n=====================\n");
 		checkOHVersion();
 		checkJavaVersion();
 		JFrame.setDefaultLookAndFeelDecorated(false);
@@ -57,7 +57,7 @@ public class Menu {
 
 	private static void checkOHVersion() {
 		Version.getVersion();
-		logger.info("OpenHospital version {}.{}.{}", Version.VER_MAJOR, Version.VER_MINOR, Version.VER_RELEASE);
+		logger.info("Open Hospital version {}.{}.{}", Version.VER_MAJOR, Version.VER_MINOR, Version.VER_RELEASE);
 
 	}
 
@@ -67,7 +67,7 @@ public class Menu {
 		Float f = Float.valueOf(version.substring(0, 3));
 		if (f.floatValue() < MIN_JAVA_VERSION) {
 			logger.error("Java version {} or higher is required.", MIN_JAVA_VERSION);
-			logger.info("\n\n=====================\n OpenHospital closed \n=====================\n");
+			logger.info("\n\n=====================\n Open Hospital closed \n=====================\n");
 			System.exit(1);
 		}
 	}

--- a/src/main/java/org/isf/utils/jobjects/BusyState.java
+++ b/src/main/java/org/isf/utils/jobjects/BusyState.java
@@ -22,7 +22,7 @@
 package org.isf.utils.jobjects;
 
 /*
- * OpenHospital
+ * Open Hospital
  *
  * $Id: BusyState.java,v 1.1 2014/11/16 11:32:09 eppesuig Exp $ $Date: 2014/11/16 11:32:09 $ $Revision: 1.1 $
  */

--- a/startup.sh
+++ b/startup.sh
@@ -39,7 +39,7 @@ if [ -z $JAVA_HOME ]; then
   JAVA_BIN=$JAVA_HOME/bin/java
 fi
 
-######## OPENHOSPITAL Configuration
+######## OPEN HOSPITAL Configuration
 # OPENHOSPITAL_HOME is the directory where OpenHospital files are located
 #OPENHOSPITAL_HOME=/usr/local/OpenHospital
 
@@ -101,7 +101,7 @@ case $ARCH in
 		;;
 esac
 
-######### OPENHOSPITAL STARTUP
+######### OPEN HOSPITAL STARTUP
 
 cd $OPENHOSPITAL_HOME&& $JAVA_BIN -Dsun.java2d.dpiaware=false -Djava.library.path=${NATIVE_LIB_PATH} -classpath "$OPENHOSPITAL_CLASSPATH" org.isf.menu.gui.Menu "$@"
 


### PR DESCRIPTION
Mainly change text references from `OpenHospital` to `Open Hospital`.   In the process fixed a little grammar too.