### PR TITLE
Add JFrog repository to resolve jai-core dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,5 +350,13 @@
                     <enabled>false</enabled>
                 </snapshots>
         </repository>
+	  <repository>
+		  <id>JFrog</id>
+		  <name>Atlassian JFrog></name>
+		  <url>https://packages.atlassian.com/maven-3rdparty-legacy-local</url>
+		  <snapshots>
+			  <enabled>false</enabled>
+		  </snapshots>
+	  </repository>
 	</repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -332,6 +332,11 @@
 			<version>poi-3.7</version>
 			<scope>provided</scope>
 		</dependency> -->
+		<dependency>
+			<groupId>javax.media</groupId>
+			<artifactId>jai-core</artifactId>
+			<version>1.1.3</version>
+		</dependency>
   </dependencies>
   <repositories>
     	<repository>


### PR DESCRIPTION
Add Atlassian JFrog repository to resolved missing jai-core jar.   Same fix as in the core repository.