### PR TITLE
Removing repo-spring-io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,14 +334,6 @@
 		</dependency> -->
   </dependencies>
   <repositories>
-    	<repository>
-        	<id>spring-libs-release</id>
-        	<name>Spring Releases</name>
-        	<url>https://repo.spring.io/libs-release</url>
-        	<snapshots>
-            	<enabled>false</enabled>
-        	</snapshots>
-    	</repository>
         <repository>
                 <id>dcm4che</id>
                 <name>Dcm4Che Repository</name>


### PR DESCRIPTION
following Spring notice:
https://spring.io/blog/2020/10/29/notice-of-permissions-changes-to-repo-spring-io-fall-and-winter-2020

Paired with informatici/openhospital-core#248.