### PR TITLE
OP-328 fix optimistic lock exception

### DIFF
--- a/src/main/java/org/isf/hospital/gui/HospitalBrowser.java
+++ b/src/main/java/org/isf/hospital/gui/HospitalBrowser.java
@@ -332,7 +332,7 @@ public class HospitalBrowser extends ModalJFrame{
 	
 	private void updateHospital(HospitalBrowsingManager manager, Hospital hospital) {
 		try {
-			manager.updateHospital(hospital);
+			this.hospital = manager.updateHospital(hospital);
 		} catch (OHServiceException e) {
 			OHServiceExceptionUtil.showMessages(e);
 		}


### PR DESCRIPTION
Fix for OP-328 **Optimistic lock exception** being thrown When updating Hospital twice without closing the window (Edit → Update → Edit → Update).
Depends on [core-changes](https://github.com/informatici/openhospital-core/pull/250
)
@mwithi The case name might need to be updated to reflect the issue mentioned in the comment section of the case