### PR TITLE
Chore: update JavaDoc

### DIFF
--- a/src/main/java/org/isf/accounting/gui/BillBrowser.java
+++ b/src/main/java/org/isf/accounting/gui/BillBrowser.java
@@ -21,13 +21,6 @@
  */
 package org.isf.accounting.gui;
 
-/**
- * Browsing of table BILLS
- * 
- * @author Mwithi
- * 
- */
-
 import java.awt.AWTEvent;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -98,6 +91,12 @@ import org.joda.time.DateTime;
 import com.toedter.calendar.JMonthChooser;
 import com.toedter.calendar.JYearChooser;
 
+/**
+ * Browsing of table BILLS
+ *
+ * @author Mwithi
+ *
+ */
 public class BillBrowser extends ModalJFrame implements PatientBillListener {
 
 	public void billInserted(AWTEvent event){

--- a/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
+++ b/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
@@ -121,7 +121,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			((PatientBillListener)listeners[i]).billInserted(event);
 	}
 //---------------------------------------------------------------------------
-	/**
+	/* *
 	public void patientSelected(Patient patient) {
 		patientSelected = patient;
 		ArrayList<Bill> patientPendingBills;
@@ -213,7 +213,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		//jTextFieldSearch.setEnabled(true);
 		//jTextFieldSearch.grabFocus();
 		checkIfsameMonth();
-	} **/
+	} * */
 	
 	public void patientSelected(Patient patient){
 		// patientSelected = patient;
@@ -246,9 +246,9 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 						insert = false;
 						setBill(patientPendingBills.get(0));
 						
-						/******* Check if it is same month ***************/
+						/* ****** Check if it is same month ************** */
 						//checkIfsameMonth();
-						/*************************************************/
+						/* *********************************************** */
 					}
 				}
 				else{
@@ -257,9 +257,9 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 					insert = false;
 					setBill(patientPendingBills.get(0));
 					
-					/******* Check if it is same month ***************/
+					/* ****** Check if it is same month ************** */
 					//checkIfsameMonth();
-					/*************************************************/
+					/* *********************************************** */
 				}
 			} else {
 
@@ -284,9 +284,9 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 						if(resp==JOptionPane.YES_OPTION){							
 							insert = false;
 							setBill(patientPendingBills.get(0));						
-							/******* Check if it is same month ***************/
+							/* ****** Check if it is same month ************** */
 							//checkIfsameMonth();
-							/*************************************************/
+							/* *********************************************** */
 						} else {
 							dispose();
 						}

--- a/src/main/java/org/isf/admission/gui/AdmissionBrowser.java
+++ b/src/main/java/org/isf/admission/gui/AdmissionBrowser.java
@@ -1660,9 +1660,9 @@ public class AdmissionBrowser extends ModalJFrame {
 //		return operationPanel;
 //	}
 
-	/**
-	 * @return
-	 */
+//	/**
+//	 * @return
+//	 */
 //	private JPanel getOperationResultPanel() {
 //		if (resultPanel == null) {
 //			resultPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
@@ -2187,7 +2187,7 @@ public class AdmissionBrowser extends ModalJFrame {
 
 					// ready to save...
 					if (!editing && !isDischarge) {
-                                                /**** operation date control ****/
+                                                /* *** operation date control *** */
 //						if(!checkAllOperationRowDate(operationad.getOprowData(), admission))
 //						{
 //							JOptionPane.showMessageDialog(AdmissionBrowser.this,
@@ -2195,7 +2195,7 @@ public class AdmissionBrowser extends ModalJFrame {
 //										JOptionPane.PLAIN_MESSAGE);
 //				  		    return;
 //						}	
-					    /*********************************/
+					    /* ******************************* */
 						List<OHExceptionMessage> errors = checkAllOperationRowDate(operationad.getOprowData(), admission);
 						if(!errors.isEmpty()) {
 							OHServiceExceptionUtil.showMessages(new OHServiceException(errors));
@@ -2219,7 +2219,7 @@ public class AdmissionBrowser extends ModalJFrame {
 						}
 						
 					} else if (!editing && isDischarge) {
-                                                /**** operation date control ****/
+                                                /* *** operation date control *** */
 //						if(!checkAllOperationRowDate(operationad.getOprowData(), admission))
 //						{								
 //					  		  JOptionPane.showMessageDialog(AdmissionBrowser.this,
@@ -2243,7 +2243,7 @@ public class AdmissionBrowser extends ModalJFrame {
 						}
 						
 					} else {
-                                                /**** operation date control ****/
+                                                /* *** operation date control *** */
 //						if(!checkAllOperationRowDate(operationad.getOprowData(), admission))
 //						{
 //							JOptionPane.showMessageDialog(AdmissionBrowser.this,
@@ -2317,7 +2317,7 @@ public class AdmissionBrowser extends ModalJFrame {
 		if(admission.getDisDate()!=null)endDate=admission.getDisDate().getTime();else endDate=null;
 		for (org.isf.operation.model.OperationRow opRow : list) {
 			Date currentRowDate = opRow.getOpDate().getTime();
-			/**
+			/*
 			 * prevent for fails due to time 
 			 */
 			currentRowDate.setHours(23);

--- a/src/main/java/org/isf/admission/gui/PatientFolderBrowser.java
+++ b/src/main/java/org/isf/admission/gui/PatientFolderBrowser.java
@@ -264,7 +264,7 @@ public class PatientFolderBrowser extends ModalJFrame implements
 		sorter = new TableSorter(admModel);
 		admTable = new JTable(sorter);   
                 
-                /*** apply default oh cellRender *****/
+                /* ** apply default oh cellRender **** */
 		admTable.setDefaultRenderer(Object.class, cellRenderer);
 		admTable.setDefaultRenderer(Double.class, cellRenderer);
 		admTable.addMouseMotionListener(new MouseMotionListener() {			
@@ -320,7 +320,7 @@ public class PatientFolderBrowser extends ModalJFrame implements
 		labModel = new LabBrowserModel();
 		sorterLab = new TableSorter(labModel);
 		labTable = new JTable(sorterLab);
-                /*** apply default oh cellRender *****/
+                /* ** apply default oh cellRender **** */
 		labTable.setDefaultRenderer(Object.class, cellRenderer);
 		labTable.setDefaultRenderer(Double.class, cellRenderer);
 		labTable.addMouseMotionListener(new MouseMotionListener() {

--- a/src/main/java/org/isf/admtype/gui/AdmissionTypeBrowserEdit.java
+++ b/src/main/java/org/isf/admtype/gui/AdmissionTypeBrowserEdit.java
@@ -122,8 +122,6 @@ public class AdmissionTypeBrowserEdit extends JDialog{
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		

--- a/src/main/java/org/isf/dicom/gui/DicomViewGui.java
+++ b/src/main/java/org/isf/dicom/gui/DicomViewGui.java
@@ -78,9 +78,7 @@ import org.isf.utils.exception.model.OHSeverityLevel;
  */
 @Deprecated // what is this class???
 public class DicomViewGui extends JPanel {
-	/**
-	 * 
-	 */
+
 	private static final long serialVersionUID = 1L;
 
 	// status of fremereader
@@ -183,7 +181,7 @@ public class DicomViewGui extends JPanel {
 	}
 
 	/**
-	 * initialize GUI
+	 * Initialize GUI
 	 */
 	void initComponent() {
 
@@ -487,8 +485,6 @@ public class DicomViewGui extends JPanel {
 
 	/**
 	 * Load actual frame from storage
-	 * 
-	 * @return
 	 */
 	private void refreshFrame() {
 		Long id = frames[frameIndex];
@@ -511,10 +507,9 @@ public class DicomViewGui extends JPanel {
 	}
 	
 	/**
-	 * get the BufferedImage from JPG/JPEG object
+	 * Get the BufferedImage from JPG/JPEG object
 	 * 
 	 * @param dett
-	 * @return
 	 */
 	private void getImageFromJPG(FileDicom dett) {
 		try {
@@ -543,10 +538,9 @@ public class DicomViewGui extends JPanel {
 	}
 	
 	/**
-	 * get the BufferedImage from DICOM object
+	 * Get the BufferedImage from DICOM object
 	 * 
 	 * @param dett
-	 * @return
 	 */
 	private void getImageFromDicom(FileDicom dett) {
 		try {
@@ -662,7 +656,7 @@ public class DicomViewGui extends JPanel {
 	class DicomViewGuiMouseWheelListener implements MouseWheelListener {
 
 		/**
-		 * mouse wheel rolled
+		 * Mouse wheel rolled
 		 */
 		@Override
 		public void mouseWheelMoved(MouseWheelEvent e) {
@@ -682,7 +676,7 @@ public class DicomViewGui extends JPanel {
 	class DicomViewGuiMouseMotionListener implements MouseMotionListener {
 
 		/**
-		 * mouse dragged, if is also pressed a button calculate the displacement
+		 * Mouse dragged, if is also pressed a button calculate the displacement
 		 * of position with point of initial position
 		 */
 		public void mouseDragged(MouseEvent e) {
@@ -692,7 +686,7 @@ public class DicomViewGui extends JPanel {
 		}
 
 		/**
-		 * mouse moved, NOT USED
+		 * Mouse moved, NOT USED
 		 */
 		public void mouseMoved(MouseEvent e) {
 		}
@@ -726,19 +720,19 @@ public class DicomViewGui extends JPanel {
 		}
 
 		/**
-		 * mouse clicked in frame, NOT USED
+		 * Mouse clicked in frame, NOT USED
 		 */
 		public void mouseClicked(MouseEvent e) {
 		}
 
 		/**
-		 * mouse entred in frame, NOT USED
+		 * Mouse entred in frame, NOT USED
 		 */
 		public void mouseEntered(MouseEvent e) {
 		}
 
 		/**
-		 * mouse exited of frame, NOT USED
+		 * Mouse exited of frame, NOT USED
 		 */
 		public void mouseExited(MouseEvent e) {
 		}

--- a/src/main/java/org/isf/dicomtype/gui/DicomTypeEdit.java
+++ b/src/main/java/org/isf/dicomtype/gui/DicomTypeEdit.java
@@ -105,8 +105,8 @@ public class DicomTypeEdit extends JDialog{
 	private JPanel jCodeLabelPanel = null;
 	private JPanel jDescriptionLabelPanel = null;
 	private JLabel jDescripitonLabel = null;
+
 	/**
-     * 
 	 * This is the default constructor; we pass the arraylist and the selectedrow
      * because we need to update them
 	 */
@@ -121,8 +121,6 @@ public class DicomTypeEdit extends JDialog{
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		
@@ -345,11 +343,6 @@ public class DicomTypeEdit extends JDialog{
 		}
 		return jDescriptionLabelPanel;
 	}
-	
-	
-	
-
 
 }  //  @jve:decl-index=0:visual-constraint="146,61"
-
 

--- a/src/main/java/org/isf/disctype/gui/DischargeTypeBrowserEdit.java
+++ b/src/main/java/org/isf/disctype/gui/DischargeTypeBrowserEdit.java
@@ -121,8 +121,6 @@ public class DischargeTypeBrowserEdit extends JDialog{
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		

--- a/src/main/java/org/isf/disease/gui/DiseaseEdit.java
+++ b/src/main/java/org/isf/disease/gui/DiseaseEdit.java
@@ -134,7 +134,6 @@ public class DiseaseEdit extends JDialog {
 	private DiseaseTypeBrowserManager manager = Context.getApplicationContext().getBean(DiseaseTypeBrowserManager.class);
 
 	/**
-	 * 
 	 * This is the default constructor; we pass the arraylist and the selectedrow
 	 * because we need to update them
 	 */
@@ -147,8 +146,6 @@ public class DiseaseEdit extends JDialog {
 	
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		this.setContentPane(getJContentPane());

--- a/src/main/java/org/isf/distype/gui/DiseaseTypeBrowserEdit.java
+++ b/src/main/java/org/isf/distype/gui/DiseaseTypeBrowserEdit.java
@@ -105,9 +105,9 @@ public class DiseaseTypeBrowserEdit extends JDialog{
 	private JPanel jCodeLabelPanel = null;
 	private JPanel jDescriptionLabelPanel = null;
 	private JLabel jDescripitonLabel = null;
+
 	/**
-     * 
-	 * This is the default constructor; we pass the arraylist and the selectedrow
+     * This is the default constructor; we pass the arraylist and the selectedrow
      * because we need to update them
 	 */
 	public DiseaseTypeBrowserEdit(JFrame owner,DiseaseType old,boolean inserting) {
@@ -121,8 +121,6 @@ public class DiseaseTypeBrowserEdit extends JDialog{
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		
@@ -350,5 +348,3 @@ public class DiseaseTypeBrowserEdit extends JDialog{
 
 
 }  //  @jve:decl-index=0:visual-constraint="146,61"
-
-

--- a/src/main/java/org/isf/dlvrrestype/gui/DeliveryResultTypeBrowserEdit.java
+++ b/src/main/java/org/isf/dlvrrestype/gui/DeliveryResultTypeBrowserEdit.java
@@ -46,9 +46,6 @@ import org.isf.utils.jobjects.VoLimitedTextField;
 
 public class DeliveryResultTypeBrowserEdit extends JDialog{
 
-    /**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 	private EventListenerList deliveryresultTypeListeners = new EventListenerList();
 
@@ -68,9 +65,6 @@ public class DeliveryResultTypeBrowserEdit extends JDialog{
     private void fireDeliveryResultInserted() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = deliveryresultTypeListeners.getListeners(DeliveryResultTypeListener.class);
@@ -80,9 +74,6 @@ public class DeliveryResultTypeBrowserEdit extends JDialog{
     private void fireDeliveryResultUpdated() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = deliveryresultTypeListeners.getListeners(DeliveryResultTypeListener.class);
@@ -105,8 +96,8 @@ public class DeliveryResultTypeBrowserEdit extends JDialog{
 	private JPanel jCodeLabelPanel = null;
 	private JPanel jDescriptionLabelPanel = null;
 	private JLabel jDescripitonLabel = null;
+
 	/**
-     * 
 	 * This is the default constructor; we pass the arraylist and the selectedrow
      * because we need to update them
 	 */
@@ -121,8 +112,6 @@ public class DeliveryResultTypeBrowserEdit extends JDialog{
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		
@@ -344,5 +333,4 @@ public class DeliveryResultTypeBrowserEdit extends JDialog{
 
 
 }  //  @jve:decl-index=0:visual-constraint="146,61"
-
 

--- a/src/main/java/org/isf/dlvrtype/gui/DeliveryTypeBrowserEdit.java
+++ b/src/main/java/org/isf/dlvrtype/gui/DeliveryTypeBrowserEdit.java
@@ -46,9 +46,6 @@ import org.isf.utils.jobjects.VoLimitedTextField;
 
 public class DeliveryTypeBrowserEdit extends JDialog{
 
-    /**
-     *
-     */
     private static final long serialVersionUID = 1L;
     private EventListenerList deliveryTypeListeners = new EventListenerList();
 
@@ -68,9 +65,6 @@ public class DeliveryTypeBrowserEdit extends JDialog{
     private void fireDeliveryInserted() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-            /**
-             *
-             */
             private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = deliveryTypeListeners.getListeners(DeliveryTypeListener.class);
@@ -80,9 +74,6 @@ public class DeliveryTypeBrowserEdit extends JDialog{
     private void fireDeliveryUpdated() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-            /**
-             *
-             */
             private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = deliveryTypeListeners.getListeners(DeliveryTypeListener.class);
@@ -105,8 +96,8 @@ public class DeliveryTypeBrowserEdit extends JDialog{
     private JPanel jCodeLabelPanel = null;
     private JPanel jDescriptionLabelPanel = null;
     private JLabel jDescripitonLabel = null;
+
     /**
-     *
      * This is the default constructor; we pass the arraylist and the selectedrow
      * because we need to update them
      */
@@ -121,8 +112,6 @@ public class DeliveryTypeBrowserEdit extends JDialog{
 
     /**
      * This method initializes this
-     *
-     * @return void
      */
     private void initialize() {
 
@@ -349,5 +338,3 @@ public class DeliveryTypeBrowserEdit extends JDialog{
 
 
 }  //  @jve:decl-index=0:visual-constraint="146,61"
-
-

--- a/src/main/java/org/isf/exa/gui/ExamEdit.java
+++ b/src/main/java/org/isf/exa/gui/ExamEdit.java
@@ -60,9 +60,6 @@ import org.isf.utils.jobjects.VoLimitedTextField;
 
 public class ExamEdit extends JDialog {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 
 	private static final String VERSION="v1.2";  
@@ -85,9 +82,6 @@ public class ExamEdit extends JDialog {
     private void fireExamInserted() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = examListeners.getListeners(ExamListener.class);
@@ -97,9 +91,6 @@ public class ExamEdit extends JDialog {
     private void fireExamUpdated() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = examListeners.getListeners(ExamListener.class);
@@ -128,7 +119,6 @@ public class ExamEdit extends JDialog {
 	private ExamBrowsingManager manager = Context.getApplicationContext().getBean(ExamBrowsingManager.class);
     
 	/**
-     * 
 	 * This is the default constructor; we pass the arraylist and the selectedrow
      * because we need to update them
 	 */
@@ -141,8 +131,6 @@ public class ExamEdit extends JDialog {
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		

--- a/src/main/java/org/isf/exa/gui/ExamRowEdit.java
+++ b/src/main/java/org/isf/exa/gui/ExamRowEdit.java
@@ -56,9 +56,6 @@ import org.isf.utils.jobjects.VoLimitedTextField;
 
 public class ExamRowEdit extends JDialog {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 
 	private static final String VERSION="v1.2";
@@ -80,9 +77,6 @@ public class ExamRowEdit extends JDialog {
     private void fireExamRowInserted() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = examRowListeners.getListeners(ExamRowListener.class);
@@ -101,7 +95,6 @@ public class ExamRowEdit extends JDialog {
 	private ExamRow examRow = null;
     
 	/**
-     * 
 	 * This is the default constructor; we pass the arraylist and the selectedrow
      * because we need to update them
 	 */
@@ -114,8 +107,6 @@ public class ExamRowEdit extends JDialog {
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		Toolkit kit = Toolkit.getDefaultToolkit();

--- a/src/main/java/org/isf/exatype/gui/ExamTypeEdit.java
+++ b/src/main/java/org/isf/exatype/gui/ExamTypeEdit.java
@@ -54,9 +54,6 @@ import org.isf.utils.jobjects.VoLimitedTextField;
 
 public class ExamTypeEdit extends JDialog{
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 
 	private static final String VERSION="v1.2"; 
@@ -79,9 +76,6 @@ public class ExamTypeEdit extends JDialog{
     private void fireExamTypeInserted() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = examTypeListeners.getListeners(ExamTypeListener.class);
@@ -91,9 +85,6 @@ public class ExamTypeEdit extends JDialog{
     private void fireExamTypeUpdated() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = examTypeListeners.getListeners(ExamTypeListener.class);
@@ -116,8 +107,8 @@ public class ExamTypeEdit extends JDialog{
 	private JPanel jCodeLabelPanel = null;
 	private JPanel jDescriptionLabelPanel = null;
 	private JLabel jDescripitonLabel = null;
+
 	/**
-     * 
 	 * This is the default constructor; we pass the arraylist and the selectedrow
      * because we need to update them
 	 */
@@ -132,8 +123,6 @@ public class ExamTypeEdit extends JDialog{
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		
@@ -354,5 +343,3 @@ public class ExamTypeEdit extends JDialog{
 
 
 }  //  @jve:decl-index=0:visual-constraint="146,61"
-
-

--- a/src/main/java/org/isf/help/HelpViewer.java
+++ b/src/main/java/org/isf/help/HelpViewer.java
@@ -21,10 +21,6 @@
  */
 package org.isf.help;
 
-/**
- * HelpViewer.java - 27/nov/2012
- */
-
 import java.awt.Desktop;
 import java.io.File;
 import java.io.IOException;
@@ -36,21 +32,16 @@ import org.isf.generaldata.GeneralData;
 import org.isf.generaldata.MessageBundle;
 
 /**
+ * HelpViewer.java - 27/nov/2012
  * @author Mwithi
  * 
  */
 public class HelpViewer extends JDialog {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 
 	private final String MANUAL_PDF_FILE = "doc/UserManual.pdf";
 
-	/**
-	 * 
-	 */
 	public HelpViewer() {
 		File file = new File(MANUAL_PDF_FILE);
 		if (file != null) {

--- a/src/main/java/org/isf/lab/gui/LabBrowser.java
+++ b/src/main/java/org/isf/lab/gui/LabBrowser.java
@@ -77,10 +77,7 @@ import org.isf.utils.jobjects.ModalJFrame;
 import org.isf.utils.jobjects.VoDateTextField;
 
 public class LabBrowser extends ModalJFrame implements LabListener, LabEditListener, LabEditExtendedListener {
-	
-	/**
-	 * 
-	 */
+
 	private static final long serialVersionUID = 1L;
 
 	public void labInserted() {
@@ -149,8 +146,6 @@ public class LabBrowser extends ModalJFrame implements LabListener, LabEditListe
 
 	/**
 	 * This method initializes this Frame, sets the correct Dimensions
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		Toolkit kit = Toolkit.getDefaultToolkit();
@@ -585,9 +580,7 @@ public class LabBrowser extends ModalJFrame implements LabListener, LabEditListe
 	 * 
 	 */
 	class LabBrowsingModel extends DefaultTableModel {
-		/**
-		 * 
-		 */
+
 		private static final long serialVersionUID = 1L;
 		private LabManager manager = Context.getApplicationContext().getBean(LabManager.class,Context.getApplicationContext().getBean(LabIoOperations.class));
 
@@ -654,7 +647,6 @@ public class LabBrowser extends ModalJFrame implements LabListener, LabEditListe
 	/**
 	 * This method updates the Table because a laboratory test has been updated
 	 * Sets the focus on the same record as before
-	 * 
 	 */
 	public void laboratoryUpdated() {
 		pLabs.set(pLabs.size() - selectedrow - 1, laboratory);
@@ -667,7 +659,6 @@ public class LabBrowser extends ModalJFrame implements LabListener, LabEditListe
 	/**
 	 * This method updates the Table because a laboratory test has been inserted
 	 * Sets the focus on the first record
-	 * 
 	 */
 	public void laboratoryInserted() {
 		pLabs.add(pLabs.size(), laboratory);

--- a/src/main/java/org/isf/medicals/gui/MedicalEdit.java
+++ b/src/main/java/org/isf/medicals/gui/MedicalEdit.java
@@ -61,10 +61,6 @@ import org.isf.utils.jobjects.VoLimitedTextField;
  */
 public class MedicalEdit extends JDialog {
 
-
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 	
 	private EventListenerList medicalListeners = new EventListenerList();
@@ -85,9 +81,6 @@ public class MedicalEdit extends JDialog {
 	private void fireMedicalInserted(Medical medical) {
 		new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;
 		};
 
@@ -99,9 +92,6 @@ public class MedicalEdit extends JDialog {
 	private void fireMedicalUpdated() {
 		AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;
 		};
 
@@ -133,7 +123,6 @@ public class MedicalEdit extends JDialog {
 	private MedicalBrowsingManager medicalBrowsingManager = Context.getApplicationContext().getBean(MedicalBrowsingManager.class);
 
 	/**
-	 * 
 	 * This is the default constructor; we pass the arraylist and the
 	 * selectedrow because we need to update them
 	 */
@@ -151,8 +140,6 @@ public class MedicalEdit extends JDialog {
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 
@@ -378,6 +365,7 @@ public class MedicalEdit extends JDialog {
 		}
 		return descriptionTextField;
 	}
+
 	/**
 	 * This method initializes codeTextField
 	 * 

--- a/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
@@ -106,9 +106,6 @@ import org.slf4j.LoggerFactory;
 
 public class MovStockBrowser extends ModalJFrame {
 
-	/**
-	 *
-	 */
 	private static final long serialVersionUID = 1L;
 
 	private static Logger logger = LoggerFactory.getLogger(MovStockBrowser.class);
@@ -226,7 +223,7 @@ public class MovStockBrowser extends ModalJFrame {
 	}
 
 	/**
-	 * this method controls if the automaticlot option is on
+	 * This method controls if the automaticlot option is on
 	 *
 	 * @return
 	 */
@@ -809,11 +806,10 @@ public class MovStockBrowser extends ModalJFrame {
 	}
 
 	/**
-	 * this method creates the button that filters the data
+	 * This method creates the button that filters the data
 	 *
 	 * @return
 	 */
-
 	private JButton getFilterButton() {
 		filterButton = new JButton(MessageBundle.getMessage("angal.medicalstock.filter"));
 		filterButton.setMnemonic(KeyEvent.VK_F);
@@ -924,7 +920,7 @@ public class MovStockBrowser extends ModalJFrame {
 	}
 
 	/**
-	 * this method creates the button that close the mask
+	 * This method creates the button that close the mask
 	 *
 	 * @return
 	 */
@@ -941,13 +937,13 @@ public class MovStockBrowser extends ModalJFrame {
 		return closeButton;
 	}
 
-	/**
-	 * this method creates the button that deletes all the records in
-	 * medicaldsrstockmov and lot it is for training pourposes only to be
-	 * deleted in production environment
-	 *
-	 * @return
-	 */
+//	/**
+//	 * This method creates the button that deletes all the records in
+//	 * medicaldsrstockmov and lot it is for training pourposes only to be
+//	 * deleted in production environment
+//	 *
+//	 * @return
+//	 */
 	/*private JButton getdeleteAllButton() {
 		deleteAllButton = new JButton(MessageBundle.getMessage("angal.medicalstock.deleteall"));
 		deleteAllButton.setMnemonic(KeyEvent.VK_D);
@@ -980,7 +976,7 @@ public class MovStockBrowser extends ModalJFrame {
 	}*/
 
 	//	/**
-	//	 * this method creates the button that load the insert movement mask
+	//	 * This method creates the button that load the insert movement mask
 	//	 *
 	//	 * @return
 	//	 */
@@ -1001,7 +997,7 @@ public class MovStockBrowser extends ModalJFrame {
 	//	}
 
 	/**
-	 * this method creates the button that load the charging movement mask
+	 * This method creates the button that load the charging movement mask
 	 *
 	 * @return
 	 */
@@ -1024,7 +1020,7 @@ public class MovStockBrowser extends ModalJFrame {
 	}
 
 	/**
-	 * this method creates the button that load the discharging movement mask
+	 * This method creates the button that load the discharging movement mask
 	 *
 	 * @return
 	 */
@@ -1170,9 +1166,6 @@ public class MovStockBrowser extends ModalJFrame {
 	 */
 	class MovBrowserModel extends DefaultTableModel {
 
-		/**
-		 *
-		 */
 		private static final long serialVersionUID = 1L;
 
 		public MovBrowserModel() {
@@ -1286,9 +1279,6 @@ public class MovStockBrowser extends ModalJFrame {
 
 	class EnabledTableCellRenderer extends DefaultTableCellRenderer {
 
-		/**
-		 *
-		 */
 		private static final long serialVersionUID = 1L;
 
 		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
@@ -1303,9 +1293,6 @@ public class MovStockBrowser extends ModalJFrame {
 
 	class RightAlignCellRenderer extends DefaultTableCellRenderer {
 
-		/**
-		 *
-		 */
 		private static final long serialVersionUID = 1L;
 
 		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
@@ -1317,9 +1304,6 @@ public class MovStockBrowser extends ModalJFrame {
 
 	class DecimalFormatRenderer extends DefaultTableCellRenderer {
 
-		/**
-		 *
-		 */
 		private static final long serialVersionUID = 1L;
 		private final DecimalFormat formatter100 = new DecimalFormat("#,##0.000");
 		private final DecimalFormat formatter10 = new DecimalFormat("#,##0.00");

--- a/src/main/java/org/isf/medstockmovtype/gui/MedicaldsrstockmovTypeBrowserEdit.java
+++ b/src/main/java/org/isf/medstockmovtype/gui/MedicaldsrstockmovTypeBrowserEdit.java
@@ -47,9 +47,6 @@ import org.isf.utils.jobjects.VoLimitedTextField;
 
 public class MedicaldsrstockmovTypeBrowserEdit extends JDialog{
 
-    /**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 	private EventListenerList medicaldsrstockmovTypeListeners = new EventListenerList();
 
@@ -69,9 +66,6 @@ public class MedicaldsrstockmovTypeBrowserEdit extends JDialog{
     private void fireMedicaldsrstockmovInserted(MovementType anMedicaldsrstockmovType) {
         AWTEvent event = new AWTEvent(anMedicaldsrstockmovType, AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = medicaldsrstockmovTypeListeners.getListeners(MedicaldsrstockmovTypeListener.class);
@@ -81,9 +75,6 @@ public class MedicaldsrstockmovTypeBrowserEdit extends JDialog{
     private void fireMedicaldsrstockmovUpdated() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = medicaldsrstockmovTypeListeners.getListeners(MedicaldsrstockmovTypeListener.class);
@@ -113,7 +104,6 @@ public class MedicaldsrstockmovTypeBrowserEdit extends JDialog{
 	private MedicaldsrstockmovTypeBrowserManager manager = Context.getApplicationContext().getBean(MedicaldsrstockmovTypeBrowserManager.class);
 	
 	/**
-     * 
 	 * This is the default constructor; we pass the arraylist and the selectedrow
      * because we need to update them
 	 */
@@ -128,8 +118,6 @@ public class MedicaldsrstockmovTypeBrowserEdit extends JDialog{
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		
@@ -390,5 +378,3 @@ public class MedicaldsrstockmovTypeBrowserEdit extends JDialog{
 
 
 }  //  @jve:decl-index=0:visual-constraint="146,61"
-
-

--- a/src/main/java/org/isf/medstockmovtype/gui/MedicalsrMovPatList.java
+++ b/src/main/java/org/isf/medstockmovtype/gui/MedicalsrMovPatList.java
@@ -75,7 +75,7 @@ public class MedicalsrMovPatList extends JPanel {
 		}
 		JtableData = new JTable();
 		scrollPaneData.setViewportView(JtableData);
-		/*** apply default oh cellRender *****/
+		/* ** apply default oh cellRender **** */
 		JtableData.setDefaultRenderer(Object.class, cellRenderer);
 		JtableData.setDefaultRenderer(Double.class, cellRenderer);
 		

--- a/src/main/java/org/isf/medtype/gui/MedicalTypeBrowserEdit.java
+++ b/src/main/java/org/isf/medtype/gui/MedicalTypeBrowserEdit.java
@@ -46,9 +46,6 @@ import org.isf.utils.jobjects.VoLimitedTextField;
 
 public class MedicalTypeBrowserEdit extends JDialog{
 
-    /**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 	private EventListenerList medicalTypeListeners = new EventListenerList();
 
@@ -68,9 +65,6 @@ public class MedicalTypeBrowserEdit extends JDialog{
     private void fireMedicalInserted() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = medicalTypeListeners.getListeners(MedicalTypeListener.class);
@@ -80,9 +74,6 @@ public class MedicalTypeBrowserEdit extends JDialog{
     private void fireMedicalUpdated() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = medicalTypeListeners.getListeners(MedicalTypeListener.class);
@@ -109,7 +100,6 @@ public class MedicalTypeBrowserEdit extends JDialog{
 	private MedicalTypeBrowserManager manager = Context.getApplicationContext().getBean(MedicalTypeBrowserManager.class);
 
 	/**
-     * 
 	 * This is the default constructor; we pass the arraylist and the selectedrow
      * because we need to update them
 	 */
@@ -124,8 +114,6 @@ public class MedicalTypeBrowserEdit extends JDialog{
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		
@@ -355,5 +343,4 @@ public class MedicalTypeBrowserEdit extends JDialog{
 
 
 }  //  @jve:decl-index=0:visual-constraint="146,61"
-
 

--- a/src/main/java/org/isf/menu/gui/GroupEdit.java
+++ b/src/main/java/org/isf/menu/gui/GroupEdit.java
@@ -44,9 +44,6 @@ import org.isf.utils.exception.gui.OHServiceExceptionUtil;
 
 public class GroupEdit extends JDialog {
 
-    /**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 	private EventListenerList groupListeners = new EventListenerList();
 
@@ -68,9 +65,6 @@ public class GroupEdit extends JDialog {
     private void fireGroupInserted(UserGroup aGroup) {
         AWTEvent event = new AWTEvent(aGroup, AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = groupListeners.getListeners(GroupListener.class);
@@ -80,9 +74,6 @@ public class GroupEdit extends JDialog {
     private void fireGroupUpdated() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = groupListeners.getListeners(GroupListener.class);
@@ -105,7 +96,6 @@ public class GroupEdit extends JDialog {
 	private boolean insert = false;
     
 	/**
-     * 
 	 * This is the default constructor; we pass the arraylist and the selectedrow
      * because we need to update them
 	 */
@@ -119,8 +109,6 @@ public class GroupEdit extends JDialog {
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		

--- a/src/main/java/org/isf/menu/gui/UserEdit.java
+++ b/src/main/java/org/isf/menu/gui/UserEdit.java
@@ -52,9 +52,6 @@ import org.isf.utils.exception.gui.OHServiceExceptionUtil;
 
 public class UserEdit extends JDialog {
 
-    /**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 	private EventListenerList userListeners = new EventListenerList();
 
@@ -74,9 +71,6 @@ public class UserEdit extends JDialog {
     private void fireUserInserted(User aUser) {
         AWTEvent event = new AWTEvent(aUser, AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = userListeners.getListeners(UserListener.class);
@@ -86,9 +80,6 @@ public class UserEdit extends JDialog {
     private void fireUserUpdated() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = userListeners.getListeners(UserListener.class);
@@ -118,7 +109,6 @@ public class UserEdit extends JDialog {
 	private UserBrowsingManager manager = Context.getApplicationContext().getBean(UserBrowsingManager.class);
     
 	/**
-     * 
 	 * This is the default constructor; we pass the arraylist and the selectedrow
      * because we need to update them
 	 */
@@ -132,8 +122,6 @@ public class UserEdit extends JDialog {
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		

--- a/src/main/java/org/isf/operation/gui/OperationEdit.java
+++ b/src/main/java/org/isf/operation/gui/OperationEdit.java
@@ -66,9 +66,6 @@ import org.isf.utils.jobjects.VoLimitedTextField;
  */
 public class OperationEdit extends JDialog {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 	private EventListenerList operationListeners = new EventListenerList();
 
@@ -89,9 +86,6 @@ public class OperationEdit extends JDialog {
 	private void fireOperationInserted() {
 		AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;
 		};
 
@@ -103,9 +97,6 @@ public class OperationEdit extends JDialog {
 	private void fireOperationUpdated() {
 		AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;
 		};
 
@@ -135,7 +126,6 @@ public class OperationEdit extends JDialog {
 	private JComboBox operBox;
 
 	/**
-	 * 
 	 * This is the default constructor; we pass the arraylist and the selectedrow
 	 * because we need to update them
 	 */
@@ -148,8 +138,6 @@ public class OperationEdit extends JDialog {
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 

--- a/src/main/java/org/isf/operation/gui/OperationList.java
+++ b/src/main/java/org/isf/operation/gui/OperationList.java
@@ -63,9 +63,6 @@ import org.isf.utils.jobjects.OhTableOperationModel;
 
 public class OperationList extends JPanel implements OperationRowListener, OperationRowEditListener {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 	private JTable JtableData;
 	private JLabel TypeSourceLabelValue;
@@ -204,7 +201,7 @@ public class OperationList extends JPanel implements OperationRowListener, Opera
 		});
 		panelButtons.add(cancelButton);
 
-		/**** getting data **/
+		/* *** getting data *** */
 		if (myOpd != null) {
 			try {
 				oprowData = opeRowManager.getOperationRowByOpd(myOpd);
@@ -249,7 +246,7 @@ public class OperationList extends JPanel implements OperationRowListener, Opera
 		});
 		scrollPaneData.setViewportView(JtableData);
 
-		/*** apply default oh cellRender *****/
+		/* ** apply default oh cellRender **** */
 		JtableData.setDefaultRenderer(Object.class, cellRenderer);
 		JtableData.setDefaultRenderer(Double.class, cellRenderer);
 		JtableData.addMouseMotionListener(new MouseMotionListener() {
@@ -348,7 +345,7 @@ public class OperationList extends JPanel implements OperationRowListener, Opera
 		this.parentContainer = parentContainer;
 	}
 
-	/****** functions events *****/
+	/* ***** functions events **** */
 	private void cancelButtonMouseClicked(java.awt.event.MouseEvent evt) {// GEN-FIRST:event_jTableDataMouseClicked
 		this.setVisible(false);
 		this.parentContainer.dispose();

--- a/src/main/java/org/isf/operation/gui/OperationRowAdm.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowAdm.java
@@ -74,9 +74,7 @@ import org.joda.time.DateTime;
  * @author hp
  */
 public class OperationRowAdm extends JPanel implements AdmissionBrowser.AdmissionListener {
-	/**
-	 * 
-	 */
+
 	private static final long serialVersionUID = 1L;
 	private JLabel labelDate;
 	private JTextField textFieldUnit;
@@ -247,7 +245,7 @@ public class OperationRowAdm extends JPanel implements AdmissionBrowser.Admissio
 		panelGridData.add(scrollPaneData);
 
 		tableData = new JTable();
-		/*** apply default oh cellRender *****/
+		/* ** apply default oh cellRender **** */
 		tableData.setDefaultRenderer(Object.class, cellRenderer);
 		tableData.setDefaultRenderer(Double.class, cellRenderer);
 
@@ -382,7 +380,7 @@ public class OperationRowAdm extends JPanel implements AdmissionBrowser.Admissio
 
 	public void addToForm() {
 		OperationRow opeRow = (OperationRow) oprowData.get(tableData.getSelectedRow());
-		/*** for combo operation *****/
+		/* ** for combo operation **** */
 		ArrayList<Operation> opeList = new ArrayList<Operation>();
 		try {
 			opeList.addAll(opeManager.getOperationAdm());
@@ -411,7 +409,7 @@ public class OperationRowAdm extends JPanel implements AdmissionBrowser.Admissio
 			textFieldUnit.setText(opeRow.getTransUnit() + ""); //$NON-NLS-1$
 		}
 
-		/****** resultat *****/
+		/* ***** resultat **** */
 		int index = -1;
 		for (int i = 0; i < operationResults.size(); i++) {
 			if (opeRow.getOpResult() != null && (operationResults.get(i) + "").equals(opeRow.getOpResult())) { //$NON-NLS-1$
@@ -419,7 +417,7 @@ public class OperationRowAdm extends JPanel implements AdmissionBrowser.Admissio
 			}
 		}
 		comboResult.setSelectedIndex(index + 1);
-		/*************/
+		/* *********** */
 
 	}
 

--- a/src/main/java/org/isf/operation/gui/OperationRowOpd.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowOpd.java
@@ -72,9 +72,6 @@ import com.toedter.calendar.JDateChooser;
 
 public class OperationRowOpd extends JPanel implements OpdEditExtended.SurgeryListener{
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 	private JLabel labelDate;
 	private JTextField textFieldUnit;
@@ -245,7 +242,7 @@ public class OperationRowOpd extends JPanel implements OpdEditExtended.SurgeryLi
 		panelGridData.add(scrollPaneData);
 
 		tableData = new JTable();
-		/*** apply default oh cellRender *****/
+		/* ** apply default oh cellRender **** */
 		tableData.setDefaultRenderer(Object.class, cellRenderer);
 		tableData.setDefaultRenderer(Double.class, cellRenderer);
 
@@ -372,7 +369,7 @@ public class OperationRowOpd extends JPanel implements OpdEditExtended.SurgeryLi
 
 	public void addToForm() {
 		OperationRow opeRow = (OperationRow) oprowData.get(tableData.getSelectedRow());
-		/*** for combo operation *****/
+		/* ** for combo operation **** */
 		ArrayList<Operation> opeList = new ArrayList<Operation>();
 		try {
 			opeList.addAll(opeManager.getOperationOpd());
@@ -401,7 +398,7 @@ public class OperationRowOpd extends JPanel implements OpdEditExtended.SurgeryLi
 			textFieldUnit.setText(opeRow.getTransUnit() + ""); //$NON-NLS-1$
 		}
 
-		/****** resultat *****/
+		/* ***** resultat **** */
 		int index = -1;
 		for (int i = 0; i < operationResults.size(); i++) {
 			if (opeRow.getOpResult() != null && (operationResults.get(i) + "").equals(opeRow.getOpResult())) { //$NON-NLS-1$
@@ -409,7 +406,7 @@ public class OperationRowOpd extends JPanel implements OpdEditExtended.SurgeryLi
 			}
 		}
 		comboResult.setSelectedIndex(index + 1);
-		/*************/
+		/* *********** */
 
 	}
 
@@ -519,8 +516,5 @@ public class OperationRowOpd extends JPanel implements OpdEditExtended.SurgeryLi
 	public void setOprowData(List<OperationRow> oprowData) {
 		this.oprowData = oprowData;
 	}
-
-
-
 
 }

--- a/src/main/java/org/isf/opetype/gui/OperationTypeEdit.java
+++ b/src/main/java/org/isf/opetype/gui/OperationTypeEdit.java
@@ -46,9 +46,6 @@ import org.isf.utils.jobjects.VoLimitedTextField;
 
 public class OperationTypeEdit extends JDialog{
 
-    /**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 	private EventListenerList operationTypeListeners = new EventListenerList();
 
@@ -68,9 +65,6 @@ public class OperationTypeEdit extends JDialog{
     private void fireOperationInserted() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = operationTypeListeners.getListeners(OperationTypeListener.class);
@@ -80,9 +74,6 @@ public class OperationTypeEdit extends JDialog{
     private void fireOperationUpdated() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = operationTypeListeners.getListeners(OperationTypeListener.class);
@@ -105,8 +96,8 @@ public class OperationTypeEdit extends JDialog{
 	private JPanel jCodeLabelPanel = null;
 	private JPanel jDescriptionLabelPanel = null;
 	private JLabel jDescripitonLabel = null;
+
 	/**
-     * 
 	 * This is the default constructor; we pass the arraylist and the selectedrow
      * because we need to update them
 	 */
@@ -121,8 +112,6 @@ public class OperationTypeEdit extends JDialog{
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		
@@ -353,5 +342,4 @@ public class OperationTypeEdit extends JDialog{
 
 
 }  //  @jve:decl-index=0:visual-constraint="146,61"
-
 

--- a/src/main/java/org/isf/patient/gui/PatientInsertExtended.java
+++ b/src/main/java/org/isf/patient/gui/PatientInsertExtended.java
@@ -322,8 +322,7 @@ public class PatientInsertExtended extends JDialog {
 
 	/**
 	 * This method initializes
-	 * @param owner 
-	 * 
+	 * @param owner
 	 */
 	public PatientInsertExtended(JFrame owner, Patient old, boolean inserting) {
 		super(owner, true);
@@ -351,7 +350,6 @@ public class PatientInsertExtended extends JDialog {
 
 	/**
 	 * This method initializes this
-	 * 
 	 */
 	private void initialize() {
 
@@ -757,7 +755,6 @@ public class PatientInsertExtended extends JDialog {
 	 * 
 	 * @return javax.swing.JPanel
 	 */
-
 	private JPanel getJBirthDateGroupPanel() {
 		class BirthDateChooser extends JDateChooser {
 
@@ -1325,8 +1322,6 @@ public class PatientInsertExtended extends JDialog {
 
 	/**
 	 * This method initializes ageType & ageTypeMonths
-	 * 
-	 * @return javax.swing.JPanel
 	 */
 	private void parseAgeType() {
 
@@ -2135,7 +2130,7 @@ public class PatientInsertExtended extends JDialog {
 	}
 
 	/**
-	 * set a specific border+title to a panel
+	 * Set a specific border+title to a panel
 	 */
 	private JPanel setMyBorder(JPanel c, String title) {
 		javax.swing.border.Border b1 = BorderFactory.createLineBorder(Color.lightGray);

--- a/src/main/java/org/isf/patient/gui/PatientSummary.java
+++ b/src/main/java/org/isf/patient/gui/PatientSummary.java
@@ -67,7 +67,7 @@ public class PatientSummary {
 	}
 
 	/**
-	 * a short summary in AdmissionBrowser
+	 * A short summary in AdmissionBrowser
 	 * 
 	 * @return
 	 */
@@ -90,7 +90,7 @@ public class PatientSummary {
 	}
 
 	/**
-	 * create and returns a JPanel with all patient's informations
+	 * Create and returns a JPanel with all patient's information
 	 * 
 	 * @return
 	 */

--- a/src/main/java/org/isf/patvac/gui/PatVacBrowser.java
+++ b/src/main/java/org/isf/patvac/gui/PatVacBrowser.java
@@ -80,9 +80,6 @@ import org.isf.vactype.model.VaccineType;
 
 public class PatVacBrowser extends ModalJFrame {
 
-    /**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 
 	private static final String VERSION="v1.2";
@@ -141,8 +138,6 @@ public class PatVacBrowser extends ModalJFrame {
 
 	/**
 	 * This method initializes this Frame, sets the correct Dimensions
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		Toolkit kit = Toolkit.getDefaultToolkit();
@@ -646,10 +641,9 @@ public class PatVacBrowser extends ModalJFrame {
 	/**
 	 * This method initializes comboVaccine.
 	 * It used to display available vaccine  
-      * 
+     *
 	 * @return vaccineComboBox (JComboBox)
 	 */
-	
 	private JComboBox getComboVaccines() {
 		if (vaccineComboBox == null) {
 			vaccineComboBox = new JComboBox();
@@ -683,7 +677,6 @@ public class PatVacBrowser extends ModalJFrame {
 	 * 
 	 * @return dateFrom (JPanel)
 	 */
-	
 	private CustomJDateChooser getDateFromPanel() {
 		if (dateFrom == null) {
 			GregorianCalendar now = new GregorianCalendar();
@@ -716,7 +709,7 @@ public class PatVacBrowser extends ModalJFrame {
 	}
 	
 	/**
-	 * This method initializes filterButton, which is the button that perform
+	 * This method initializes filterButton, which is the button that performs
 	 * the filtering and calls the methods to refresh the Table
 	 * 
 	 * @return filterButton (JButton)
@@ -807,14 +800,9 @@ public class PatVacBrowser extends ModalJFrame {
 	
 	/**
 	 * This class defines the model for the Table
-	 * 
-	 * 
 	 */
-	
 	class PatVacBrowsingModel extends DefaultTableModel {
-		/**
-		 * 
-		 */
+
 		private static final long serialVersionUID = 1L;
 		private PatVacManager manager = Context.getApplicationContext().getBean(PatVacManager.class);
 
@@ -862,7 +850,7 @@ public class PatVacBrowser extends ModalJFrame {
 
 		/** 
 	     * This method converts a column number in the table
-	     * to the right number of the datas.
+	     * to the right number in the data.
 	     */
 	    protected int getNumber(int col) {
 	    	// right number to return
@@ -919,11 +907,7 @@ public class PatVacBrowser extends ModalJFrame {
 		
 	}
 
-	/**
-	 * 
-	 */
 	private void updateRowCounter() {
 		rowCounter.setText(rowCounterText + lPatVac.size());
 	}
 }
-

--- a/src/main/java/org/isf/patvac/gui/PatVacEdit.java
+++ b/src/main/java/org/isf/patvac/gui/PatVacEdit.java
@@ -69,9 +69,7 @@ import org.isf.vactype.manager.VaccineTypeBrowserManager;
 import org.isf.vactype.model.VaccineType;
 
 public class PatVacEdit extends JDialog {
-	/**
-	 * 
-	 */
+
 	private static final long serialVersionUID = -4271389493861772053L;
 	private static final String VERSION = "v1.2";
 	private boolean insert = false;
@@ -142,8 +140,6 @@ public class PatVacEdit extends JDialog {
 
 	/**
 	 * This method initializes this Frame, sets the correct Dimensions
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 
@@ -233,7 +229,6 @@ public class PatVacEdit extends JDialog {
 	 * 
 	 * @return JPanel
 	 */
-
 	private JPanel getPatientSearchPanel() {
 		if (jPatientSearchPanel == null) {
 			jPatientSearchPanel = new JPanel();
@@ -309,7 +304,6 @@ public class PatVacEdit extends JDialog {
 	 * 
 	 * @return JButton
 	 */
-
 	private JButton getJSearchButton() {
 		if (jSearchButton == null) {
 			jSearchButton = new JButton();
@@ -367,7 +361,7 @@ public class PatVacEdit extends JDialog {
 	}
 
 	/**
-	 * This method initializes vaccineTypeCOmboBox. It used to display available
+	 * This method initializes vaccineTypeCOmboBox. It is used to display available
 	 * vaccine types
 	 * 
 	 * @return vaccineTypeComboBox (JComboBox)
@@ -411,7 +405,7 @@ public class PatVacEdit extends JDialog {
 	}
 
 	/**
-	 * This method initializes comboVaccine. It used to display available
+	 * This method initializes comboVaccine. It is used to display available
 	 * vaccines
 	 * 
 	 * @return vaccineComboBox (JComboBox)
@@ -453,8 +447,6 @@ public class PatVacEdit extends JDialog {
 
 	/**
 	 * This method filter patient based on search string
-	 * 
-	 * @return void
 	 */
 	private void filterPatient(String key) {
 		patientComboBox.removeAllItems();
@@ -498,8 +490,6 @@ public class PatVacEdit extends JDialog {
 
 	/**
 	 * This method reset patient's additonal data
-	 * 
-	 * @return void
 	 */
 	private void resetPatVacPat() {
 		patTextField.setText("");
@@ -510,8 +500,6 @@ public class PatVacEdit extends JDialog {
 
 	/**
 	 * This method sets patient's additonal data
-	 * 
-	 * @return void
 	 */
 	private void setPatient(Patient selectedPatient) {
 		patTextField.setText(selectedPatient.getName());
@@ -520,7 +508,7 @@ public class PatVacEdit extends JDialog {
 	}
 
 	/**
-	 * This method initializes patientComboBox. It used to display available
+	 * This method initializes patientComboBox. It is used to display available
 	 * patients
 	 * 
 	 * @return patientComboBox (JComboBox)
@@ -753,7 +741,6 @@ public class PatVacEdit extends JDialog {
 	 * 
 	 * @return cancelButton (JPanel)
 	 */
-
 	private JButton getCancelButton() {
 		if (cancelButton == null) {
 			cancelButton = new JButton();

--- a/src/main/java/org/isf/pregtreattype/gui/PregnantTreatmentTypeEdit.java
+++ b/src/main/java/org/isf/pregtreattype/gui/PregnantTreatmentTypeEdit.java
@@ -46,9 +46,6 @@ import org.isf.utils.jobjects.VoLimitedTextField;
 
 public class PregnantTreatmentTypeEdit extends JDialog{
 
-    /**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 	private EventListenerList pregnantTreatmentTypeListeners = new EventListenerList();
 
@@ -68,9 +65,6 @@ public class PregnantTreatmentTypeEdit extends JDialog{
     private void firePregnantTreatmentInserted() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = pregnantTreatmentTypeListeners.getListeners(PregnantTreatmentTypeListener.class);
@@ -80,9 +74,6 @@ public class PregnantTreatmentTypeEdit extends JDialog{
     private void firePregnantTreatmentUpdated() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = pregnantTreatmentTypeListeners.getListeners(PregnantTreatmentTypeListener.class);
@@ -105,8 +96,8 @@ public class PregnantTreatmentTypeEdit extends JDialog{
 	private JPanel jCodeLabelPanel = null;
 	private JPanel jDescriptionLabelPanel = null;
 	private JLabel jDescripitonLabel = null;
+
 	/**
-     * 
 	 * This is the default constructor; we pass the arraylist and the selectedrow
      * because we need to update them
 	 */
@@ -121,8 +112,6 @@ public class PregnantTreatmentTypeEdit extends JDialog{
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		
@@ -345,5 +334,4 @@ public class PregnantTreatmentTypeEdit extends JDialog{
 
 
 }  //  @jve:decl-index=0:visual-constraint="146,61"
-
 

--- a/src/main/java/org/isf/serviceprinting/gui/MedicalPrintSelection.java
+++ b/src/main/java/org/isf/serviceprinting/gui/MedicalPrintSelection.java
@@ -56,10 +56,9 @@ import org.isf.utils.exception.gui.OHServiceExceptionUtil;
 /**
  * @deprecated in favor of new reports StockCard and StockLedger
  */
+@Deprecated
 public class MedicalPrintSelection extends JDialog implements ActionListener{
-	/**
-	 * 
-	 */
+
 	private static final long serialVersionUID = 1L;
 	private JPanel selectionPanel;
 	private JPanel buttonsPanel;

--- a/src/main/java/org/isf/serviceprinting/gui/MedicalStockSelection.java
+++ b/src/main/java/org/isf/serviceprinting/gui/MedicalStockSelection.java
@@ -67,11 +67,9 @@ import org.isf.ward.model.Ward;
 /**
  * @deprecated in favor of new reports StockCard and StockLedger
  */
+@Deprecated
 public class MedicalStockSelection extends JDialog implements ActionListener{
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 
 	private JPanel selectionPanel;
@@ -135,6 +133,7 @@ public class MedicalStockSelection extends JDialog implements ActionListener{
 		this.setTitle("Movement Stock Print Selection");
 		pack();
 	}
+
 	/**
 	 * ascaksch
 	 * @return un pannello

--- a/src/main/java/org/isf/stat/gui/DiseasesListLauncher.java
+++ b/src/main/java/org/isf/stat/gui/DiseasesListLauncher.java
@@ -42,13 +42,9 @@ import org.isf.utils.jobjects.ModalJFrame;
  * This class launch reports creation
  * 
  * @author Rick
- *
  */
 public class DiseasesListLauncher extends ModalJFrame{
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 
 	private static final String VERSION="v 1.0"; 
@@ -77,9 +73,7 @@ public class DiseasesListLauncher extends ModalJFrame{
 	}
 
 	/**
-	 * This method initializes this	
-	 * 	
-	 * @return void	
+	 * This method initializes this
 	 */
 	private void initialize() {
 		this.setTitle(MessageBundle.getMessage("angal.stat.diseasereport") + " ("+VERSION+")");
@@ -181,8 +175,8 @@ public class DiseasesListLauncher extends ModalJFrame{
 	}
 
 	
-	/*
-	 * set a specific border+title to a panel
+	/**
+	 * Set a specific border+title to a panel
 	 */
 	private JPanel setMyBorder(JPanel c, String title) {
 		javax.swing.border.Border b2 = BorderFactory.createCompoundBorder(

--- a/src/main/java/org/isf/stat/gui/ExamsList1Launcher.java
+++ b/src/main/java/org/isf/stat/gui/ExamsList1Launcher.java
@@ -42,13 +42,9 @@ import org.isf.utils.jobjects.ModalJFrame;
  * This class launch reports creation
  * 
  * @author Rick
- *
  */
 public class ExamsList1Launcher extends ModalJFrame{
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 
 	private static final String VERSION="v 1.0"; 
@@ -77,9 +73,7 @@ public class ExamsList1Launcher extends ModalJFrame{
 	}
 
 	/**
-	 * This method initializes this	
-	 * 	
-	 * @return void	
+	 * This method initializes this
 	 */
 	private void initialize() {
 		this.setTitle(MessageBundle.getMessage("angal.stat.examsreport") + " ("+VERSION+")");
@@ -181,8 +175,8 @@ public class ExamsList1Launcher extends ModalJFrame{
 	}
 
 	
-	/*
-	 * set a specific border+title to a panel
+	/**
+	 * Set a specific border+title to a panel
 	 */
 	private JPanel setMyBorder(JPanel c, String title) {
 		javax.swing.border.Border b2 = BorderFactory.createCompoundBorder(

--- a/src/main/java/org/isf/stat/reportlauncher/gui/ReportLauncher.java
+++ b/src/main/java/org/isf/stat/reportlauncher/gui/ReportLauncher.java
@@ -62,9 +62,6 @@ import org.isf.xmpp.manager.Interaction;
 
 public class ReportLauncher extends ModalJFrame{
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 	private int pfrmExactWidth = 500;
 	private int pfrmExactHeight = 165;
@@ -146,9 +143,7 @@ public class ReportLauncher extends ModalJFrame{
 	}
 
 	/**
-	 * This method initializes this	
-	 * 	
-	 * @return void	
+	 * This method initializes this
 	 */
 	private void initialize() {
 		this.setTitle(MessageBundle.getMessage("angal.stat.reportlauncher"));
@@ -460,8 +455,8 @@ public class ReportLauncher extends ModalJFrame{
 		
 	}
 
-	/*
-	 * set a specific border+title to a panel
+	/**
+	 * Set a specific border+title to a panel
 	 */
 	private JPanel setMyBorder(JPanel c, String title) {
 		javax.swing.border.Border b2 = BorderFactory.createCompoundBorder(

--- a/src/main/java/org/isf/supplier/gui/SupplierBrowser.java
+++ b/src/main/java/org/isf/supplier/gui/SupplierBrowser.java
@@ -51,13 +51,9 @@ import org.isf.utils.jobjects.ModalJFrame;
  * It is possible to edit-insert-delete records
  * 
  * @author Mwithi
- * 
  */
 public class SupplierBrowser extends ModalJFrame implements SupplierEdit.SupplierListener {
-	
-	/**
-	 * 
-	 */
+
 	private static final long serialVersionUID = 1L;
 
 	public void supplierInserted(AWTEvent e) {
@@ -120,8 +116,6 @@ public class SupplierBrowser extends ModalJFrame implements SupplierEdit.Supplie
 	
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		this.setTitle(MessageBundle.getMessage("angal.supplier.suppliersbrowser"));
@@ -321,10 +315,7 @@ public class SupplierBrowser extends ModalJFrame implements SupplierEdit.Supplie
 	}
 	
 	class SupplierBrowserModel extends DefaultTableModel {
-		
-		/**
-		 * 
-		 */
+
 		private static final long serialVersionUID = 1L;
 
 		public SupplierBrowserModel() {

--- a/src/main/java/org/isf/supplier/gui/SupplierEdit.java
+++ b/src/main/java/org/isf/supplier/gui/SupplierEdit.java
@@ -52,13 +52,9 @@ import org.isf.utils.jobjects.VoLimitedTextField;
  * This class allows suppliers edits and inserts
  * 
  * @author Mwithi
- * 
  */
 public class SupplierEdit extends JDialog {
-	
-	/**
-	 * 
-	 */
+
 	private static final long serialVersionUID = 1L;
 	private EventListenerList supplierListeners = new EventListenerList();
 	
@@ -78,9 +74,6 @@ public class SupplierEdit extends JDialog {
 	private void fireSupplierInserted() {
 		AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 		
 		EventListener[] listeners = supplierListeners.getListeners(SupplierListener.class);
@@ -90,9 +83,6 @@ public class SupplierEdit extends JDialog {
 	private void fireSupplierUpdated() {
 		AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 		
 		EventListener[] listeners = supplierListeners.getListeners(SupplierListener.class);
@@ -137,7 +127,6 @@ public class SupplierEdit extends JDialog {
 	private SupplierBrowserManager supplierBrowserManager = Context.getApplicationContext().getBean(SupplierBrowserManager.class);
 	
 	/**
-	 * 
 	 * This is the default constructor; we pass the parent frame
 	 * (because it is a jdialog), the arraylist and the selected
 	 * row because we need to update them
@@ -151,8 +140,6 @@ public class SupplierEdit extends JDialog {
 	
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		Toolkit kit = Toolkit.getDefaultToolkit();
@@ -456,4 +443,4 @@ public class SupplierEdit extends JDialog {
 		}
 		return isDeletedCheck;
 	}
-} 
+}

--- a/src/main/java/org/isf/utils/jobjects/BusyState.java
+++ b/src/main/java/org/isf/utils/jobjects/BusyState.java
@@ -31,8 +31,8 @@ import java.awt.Container;
 
 /**
  * Offer a method that enable or disable a component and all its children.
- * The cursor is changed to <code>WAIT_CURSOR</code> when disabling widgets, to
- * <code>DEFAULT_CURSOR</code> when enabling them.
+ * The cursor is changed to {@code WAIT_CURSOR} when disabling widgets, to
+ * {@code DEFAULT_CURSOR} when enabling them.
  * 
  * The method is not recursive, so <i>grandchildren</i> aren't processed: it only
  * works on a component and its first level children.

--- a/src/main/java/org/isf/utils/jobjects/Cropping.java
+++ b/src/main/java/org/isf/utils/jobjects/Cropping.java
@@ -21,12 +21,6 @@
  */
 package org.isf.utils.jobjects;
 
-/**
- * Cropping.java - 27/gen/2014
- *
- * @author Internet, Mwithi
- */
-
 import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Dimension;
@@ -50,10 +44,13 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.event.MouseInputAdapter;
 
+/**
+ * Cropping.java - 27/gen/2014
+ *
+ * @author Internet, Mwithi
+ */
 public class Cropping extends JPanel {
-	/**
-	 * 
-	 */
+
 	private static final long serialVersionUID = 1L;
 	
 	BufferedImage image;
@@ -250,4 +247,3 @@ class ClipMoverAndResizer extends MouseInputAdapter {
 		}
 	}
 }
-

--- a/src/main/java/org/isf/utils/jobjects/DateTextField.java
+++ b/src/main/java/org/isf/utils/jobjects/DateTextField.java
@@ -21,11 +21,6 @@
  */
 package org.isf.utils.jobjects;
 
-/**
- * 02-mar-2006
- * @author Theo
- */
-
 import java.awt.FlowLayout;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
@@ -35,11 +30,12 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 
-
+/**
+ * 02-mar-2006
+ * @author Theo
+ */
 public class DateTextField extends JPanel{
-	/**
-	 * 
-	 */
+
 	private static final long serialVersionUID = 1L;
 	private JTextField day;
 	private JTextField month;
@@ -50,7 +46,6 @@ public class DateTextField extends JPanel{
 	 * This is the constructor of the DateTextField object
 	 * It displays the Date of the parameter "time"
 	 * This object consists in 3 textfields (day,month,year) editable by the user
-	 * @param time (GregorianCalendar)
 	 */
 	public DateTextField(){
 		date=new GregorianCalendar();
@@ -59,6 +54,13 @@ public class DateTextField extends JPanel{
 		month.setText("");
 		year.setText("");
 	}
+
+	/**
+	 * This is the constructor of the DateTextField object
+	 * It displays the Date of the parameter "time"
+	 * This object consists in 3 textfields (day,month,year) editable by the user
+	 * @param time (GregorianCalendar)
+	 */
 	public DateTextField(GregorianCalendar time){
 		date=time;
 		initialize();
@@ -125,6 +127,7 @@ public class DateTextField extends JPanel{
 		add(new JLabel("/"));
 		add(year);
 	}
+
 	/**
 	 * This method returns the day displayed by the object
 	 * @return int
@@ -132,6 +135,7 @@ public class DateTextField extends JPanel{
 	public int getDay(){
 		return Integer.valueOf(day.getText());
 	}
+
 	/**
 	 * This method returns the month displayed by the object
 	 * @return int
@@ -139,6 +143,7 @@ public class DateTextField extends JPanel{
 	public int getMonth(){
 		return Integer.valueOf(month.getText());
 	}
+
 	/**
 	 * This method returns the year displayed by the object
 	 * @return int
@@ -146,6 +151,7 @@ public class DateTextField extends JPanel{
 	public int getYear(){
 		return Integer.valueOf(year.getText());
 	}
+
 	/**
 	 * This method update the parameter toModify setting the date displayed by the object
 	 * @param toModify (GregorianCalendar)
@@ -157,6 +163,7 @@ public class DateTextField extends JPanel{
 		toModify.set(GregorianCalendar.YEAR,Integer.valueOf(year.getText()));
 		return toModify;
 	}
+
 	/**
 	 * This method returns the date displayed by the object
 	 * @return GregorianCalendar
@@ -173,6 +180,7 @@ public class DateTextField extends JPanel{
 		date.set(GregorianCalendar.YEAR,getYear());
 		return date;
 	}
+
 	/**
 	 * This is a basic control for the day field input
 	 * @param day (String)
@@ -187,6 +195,7 @@ public class DateTextField extends JPanel{
 			return false;
 		return true;
 	}
+
 	/**
 	 * This is a basic control for the month field input
 	 * @param month (String)
@@ -201,6 +210,7 @@ public class DateTextField extends JPanel{
 			return false;
 		return true;
 	}
+
 	/**
 	 * This is a basic control for the year field input
 	 * @param year (String)

--- a/src/main/java/org/isf/utils/jobjects/IconButton.java
+++ b/src/main/java/org/isf/utils/jobjects/IconButton.java
@@ -21,10 +21,6 @@
  */
 package org.isf.utils.jobjects;
 
-/**
- * just a subclass to set transparency and some stuff.
- */
-
 import javax.swing.Icon;
 import javax.swing.JButton;
 
@@ -33,12 +29,11 @@ import javax.swing.JButton;
  * 
  * JButton subclass, it help to create a transparent
  * button with only an Icon in the center
+ *
+ * just a subclass to set transparency and some stuff.
  */
 public class IconButton extends JButton {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/src/main/java/org/isf/utils/jobjects/JLabelRequired.java
+++ b/src/main/java/org/isf/utils/jobjects/JLabelRequired.java
@@ -21,26 +21,19 @@
  */
 package org.isf.utils.jobjects;
 
+import javax.swing.Icon;
+import javax.swing.JLabel;
+
 /**
  * JLabelRequired.java - 28/gen/2014
  * @author Mwithi
  */
-
-import javax.swing.Icon;
-import javax.swing.JLabel;
-
 public class JLabelRequired extends JLabel {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1519907071350395237L;
 	
 	private static String MARK = " *";
 
-	/**
-	 * 
-	 */
 	public JLabelRequired() {
 	}
 

--- a/src/main/java/org/isf/utils/jobjects/JMonthYearChooser.java
+++ b/src/main/java/org/isf/utils/jobjects/JMonthYearChooser.java
@@ -21,10 +21,6 @@
  */
 package org.isf.utils.jobjects;
 
-/**
- * MonthYearChooser.java - 14/dic/2012
- */
-
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.GregorianCalendar;
@@ -39,14 +35,11 @@ import com.toedter.calendar.JMonthChooser;
 import com.toedter.calendar.JYearChooser;
 
 /**
+ * MonthYearChooser.java - 14/dic/2012
  * @author Mwithi
- *
  */
 public class JMonthYearChooser extends JPanel {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 	
 	private GregorianCalendar gc = new GregorianCalendar();

--- a/src/main/java/org/isf/utils/jobjects/ScaledJSlider.java
+++ b/src/main/java/org/isf/utils/jobjects/ScaledJSlider.java
@@ -33,9 +33,6 @@ import javax.swing.JSlider;
  */
 public class ScaledJSlider extends JSlider {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 	
 	/**
@@ -66,7 +63,7 @@ public class ScaledJSlider extends JSlider {
 
 	/**
 	 * JSlider customization in order to manage decimal values with a given step.
-	 * Internally the component still works with <code>int</code> values
+	 * Internally the component still works with {@code int} values
 	 * @param scaledMin - minimum value
 	 * @param scaledMax - maximum value
 	 * @param step - step between values
@@ -102,11 +99,8 @@ public class ScaledJSlider extends JSlider {
 	}
 
 	/**
-	 * New setValue() method in order to accept <code>double</code> values, range and step
+	 * New setValue() method in order to accept {@code double} values, range and step
 	 * @param doubleValue
-	 * @param scaledMin
-	 * @param step
-	 * @param scaledMax
 	 */
 	public void setValue(Double doubleValue) {
 		int value = convertFromDoubleToInt(doubleValue, scaledMin, step, scaledMax);
@@ -114,12 +108,12 @@ public class ScaledJSlider extends JSlider {
 	}
 	
 	/**
-	 * Convert from <code>Double</code> to <code>int</code> with specified range and step
+	 * Convert from {@code Double} to {@code int} with specified range and step
 	 * @param doubleValue - the value to be converted
-	 * @param scaledMin - the minimum value (implicit casting from <code>int</code> to <code>double</code>)
-	 * @param step - the step to round up the result (implicit casting from <code>int</code> to <code>double</code>)
-	 * @param scaledMax - the maximum value (implicit casting from <code>int</code> to <code>double</code>)
-	 * @return the nearest integer to the provided <code>Double</code> value, or min or max if value is out of range
+	 * @param scaledMin - the minimum value (implicit casting from {@code int} to {@code double})
+	 * @param step - the step to round up the result (implicit casting from {@code int} to {@code double})
+	 * @param scaledMax - the maximum value (implicit casting from {@code int} to {@code double})
+	 * @return the nearest integer to the provided {@code Double} value, or min or max if value is out of range
 	 */
 	private int convertFromDoubleToInt(Double doubleValue, double scaledMin, double step, double scaledMax) {
 		if (doubleValue == null) return (int) Math.round(scaledInit * (1. / step));
@@ -136,7 +130,6 @@ public class ScaledJSlider extends JSlider {
 	
 	/**
 	 * New getScaledValue() method in order to scale the internal value using step
-	 * @param step
 	 */
 	public double getScaledValue() {
 		double value = super.getValue() * step;

--- a/src/main/java/org/isf/utils/time/Converters.java
+++ b/src/main/java/org/isf/utils/time/Converters.java
@@ -32,10 +32,11 @@ import org.joda.time.DateTime;
  * Contact: nicosalvato@gmail.com
  */
 public class Converters {
+
     /**
-     * Returns a {@link String} representing the date in format <code>yyyy-MM-dd HH:mm:ss</code>.
+     * Returns a {@link String} representing the date in format {@code yyyy-MM-dd HH:mm:ss}.
      * @param datetime {@link GregorianCalendar} object.
-     * @return the date in format <code>yyyy-MM-dd HH:mm:ss</code>.
+     * @return the date in format {@code yyyy-MM-dd HH:mm:ss}.
      */
     public static String convertToSQLDate(GregorianCalendar datetime) {
         if (datetime == null)
@@ -44,9 +45,9 @@ public class Converters {
     }
 
     /**
-     * Returns a {@link String} representing the date in format <code>yyyy-MM-dd HH:mm:ss</code>.
+     * Returns a {@link String} representing the date in format {@code yyyy-MM-dd HH:mm:ss}.
      * @param datetime {@link Date} input.
-     * @return the date in format <code>yyyy-MM-dd HH:mm:ss</code>.
+     * @return the date in format {@code yyyy-MM-dd HH:mm:ss}.
      */
     public static String convertToSQLDate(Date datetime) {
         if (datetime == null)
@@ -56,9 +57,9 @@ public class Converters {
     }
 
     /**
-     * Returns a {@link String} representing the date in format <code>yyyy-MM-dd</code>.
+     * Returns a {@link String} representing the date in format {@code yyyy-MM-dd}.
      * @param date {@link Date} object.
-     * @return the date in format <code>yyyy-MM-dd</code>.
+     * @return the date in format {@code yyyy-MM-dd}.
      */
     public static String convertToSQLDateLimited(GregorianCalendar date) {
         if (date == null)
@@ -67,9 +68,9 @@ public class Converters {
     }
 
     /**
-     * Returns a {@link String} representing the date in format <code>yyyy-MM-dd</code>.
+     * Returns a {@link String} representing the date in format {@code yyyy-MM-dd}.
      * @param date {@link Date} object.
-     * @return the date in format <code>yyyy-MM-dd</code>.
+     * @return the date in format {@code yyyy-MM-dd}.
      */
     public static String convertToSQLDateLimited(Date date) {
         if (date == null)
@@ -81,7 +82,7 @@ public class Converters {
     /**
      * Converts a {@link GregorianCalendar} to a {@link Date}.
      * @param calendar the calendar to convert.
-     * @return the converted value or <code>null</code> if the passed value is <code>null</code>.
+     * @return the converted value or {@code null} if the passed value is {@code null}.
      */
     public static Date toDate(GregorianCalendar calendar) {
         if (calendar == null)

--- a/src/main/java/org/isf/utils/time/DateTextField.java
+++ b/src/main/java/org/isf/utils/time/DateTextField.java
@@ -21,11 +21,6 @@
  */
 package org.isf.utils.time;
 
-/**
- * 02-mar-2006
- * @author Theo
- */
-
 import java.awt.FlowLayout;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
@@ -38,11 +33,12 @@ import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.DefaultStyledDocument;
 
-
+/**
+ * 02-mar-2006
+ * @author Theo
+ */
 public class DateTextField extends JPanel{
-	/**
-	 * 
-	 */
+
 	private static final long serialVersionUID = 1L;
 	private JTextField day;
 	private JTextField month;
@@ -53,7 +49,6 @@ public class DateTextField extends JPanel{
 	 * This is the constructor of the DateTextField object
 	 * It displays the Date of the parameter "time"
 	 * This object consists in 3 textfields (day,month,year) editable by the user
-	 * @param time (GregorianCalendar)
 	 */
 	public DateTextField(){
 		date=new GregorianCalendar();
@@ -62,7 +57,13 @@ public class DateTextField extends JPanel{
 		month.setText("");
 		year.setText("");
 	}
-	
+
+	/**
+	 * This is the constructor of the DateTextField object
+	 * It displays the Date of the parameter "time"
+	 * This object consists in 3 textfields (day,month,year) editable by the user
+	 * @param time (GregorianCalendar)
+	 */
 	public DateTextField(GregorianCalendar time){
 		date=time;
 		initialize();
@@ -134,6 +135,7 @@ public class DateTextField extends JPanel{
 		add(new JLabel("/"));
 		add(year);
 	}
+
 	/**
 	 * This method returns the day displayed by the object
 	 * @return int
@@ -141,6 +143,7 @@ public class DateTextField extends JPanel{
 	public int getDay(){
 		return Integer.valueOf(day.getText());
 	}
+
 	/**
 	 * This method returns the month displayed by the object
 	 * @return int
@@ -148,6 +151,7 @@ public class DateTextField extends JPanel{
 	public int getMonth(){
 		return Integer.valueOf(month.getText());
 	}
+
 	/**
 	 * This method returns the year displayed by the object
 	 * @return int
@@ -155,6 +159,7 @@ public class DateTextField extends JPanel{
 	public int getYear(){
 		return Integer.valueOf(year.getText());
 	}
+
 	/**
 	 * This method update the parameter toModify setting the date displayed by the object
 	 * @param toModify (GregorianCalendar)
@@ -166,6 +171,7 @@ public class DateTextField extends JPanel{
 		toModify.set(GregorianCalendar.YEAR,Integer.valueOf(year.getText()));
 		return toModify;
 	}
+
 	/**
 	 * This method returns the date displayed by the object
 	 * @return GregorianCalendar
@@ -182,6 +188,7 @@ public class DateTextField extends JPanel{
 		date.set(GregorianCalendar.YEAR,getYear());
 		return date;
 	}
+
 	/**
 	 * This is a basic control for the day field input
 	 * @param day (String)
@@ -197,6 +204,7 @@ public class DateTextField extends JPanel{
 			return false;
 		return true;
 	}
+
 	/**
 	 * This is a basic control for the month field input
 	 * @param month (String)
@@ -212,6 +220,7 @@ public class DateTextField extends JPanel{
 			return false;
 		return true;
 	}
+
 	/**
 	 * This is a basic control for the year field input
 	 * @param year (String)
@@ -249,11 +258,8 @@ public class DateTextField extends JPanel{
 	 * This class extends DefaultStyledDocument and is needed to limit of each input field
 	 * @author someone (found on the web)
 	 */
-	
 	public class DocumentoLimitato extends DefaultStyledDocument {
-		/**
-		 * 
-		 */
+
 		private static final long serialVersionUID = 1L;
 		private final int NUMERO_MASSIMO_CARATTERI;
 

--- a/src/main/java/org/isf/vaccine/gui/VaccineBrowser.java
+++ b/src/main/java/org/isf/vaccine/gui/VaccineBrowser.java
@@ -57,13 +57,9 @@ import org.isf.vactype.model.VaccineType;
  * 
  * modification history
  * 20/10/2011 - Cla - insert vaccinetype managment
- *
  */
 public class VaccineBrowser extends ModalJFrame implements VaccineEdit.VaccineListener {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 
 	public void vaccineInserted(AWTEvent e) {
@@ -116,8 +112,6 @@ public class VaccineBrowser extends ModalJFrame implements VaccineEdit.VaccineLi
 
 	/**
 	 * This method initializes this
-	 *
-	 * @return void
 	 */
 	private void initialize() {
 		this.setTitle(MessageBundle.getMessage("angal.vaccine.vaccinebrowser"));
@@ -356,9 +350,6 @@ public class VaccineBrowser extends ModalJFrame implements VaccineEdit.VaccineLi
 
 	class VaccineBrowserModel extends DefaultTableModel {
 
-		/**
-		 * 
-		 */
 		private static final long serialVersionUID = 1L;
 
 		public VaccineBrowserModel() {

--- a/src/main/java/org/isf/vaccine/gui/VaccineEdit.java
+++ b/src/main/java/org/isf/vaccine/gui/VaccineEdit.java
@@ -57,13 +57,9 @@ import org.isf.vactype.model.VaccineType;
  *
  * modification history
  *  20/10/2011 - Cla - insert vaccinetype managment
- *
  */
 public class VaccineEdit extends JDialog {
 
-    /**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 	private EventListenerList vaccineListeners = new EventListenerList();
 
@@ -83,9 +79,6 @@ public class VaccineEdit extends JDialog {
     private void fireVaccineInserted() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = vaccineListeners.getListeners(VaccineListener.class);
@@ -95,9 +88,6 @@ public class VaccineEdit extends JDialog {
     private void fireVaccineUpdated() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = vaccineListeners.getListeners(VaccineListener.class);
@@ -125,7 +115,6 @@ public class VaccineEdit extends JDialog {
 	private boolean insert = false;
 
 	/**
-     *
 	 * This is the default constructor; we pass the arraylist and the selected row
      * because we need to update them
 	 */
@@ -138,8 +127,6 @@ public class VaccineEdit extends JDialog {
 
 	/**
 	 * This method initializes this
-	 *
-	 * @return void
 	 */
 	private void initialize() {
 		Toolkit kit = Toolkit.getDefaultToolkit();

--- a/src/main/java/org/isf/vactype/gui/VaccineTypeEdit.java
+++ b/src/main/java/org/isf/vactype/gui/VaccineTypeEdit.java
@@ -77,9 +77,6 @@ public class VaccineTypeEdit extends JDialog{
     private void fireVaccineInserted() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
         EventListener[] listeners = vaccineTypeListeners.getListeners(VaccineTypeListener.class);
@@ -91,9 +88,6 @@ public class VaccineTypeEdit extends JDialog{
     private void fireVaccineUpdated() {
         AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;};
 
 		EventListener[] listeners = vaccineTypeListeners.getListeners(VaccineTypeListener.class);
@@ -118,7 +112,6 @@ public class VaccineTypeEdit extends JDialog{
 	private JLabel jDescripitonLabel = null;
 
 	/**
-     * 
 	 * This is the default constructor; we pass the arraylist and the selectedrow
      * because we need to update them
 	 */
@@ -133,8 +126,6 @@ public class VaccineTypeEdit extends JDialog{
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		
@@ -355,6 +346,4 @@ public class VaccineTypeEdit extends JDialog{
 		}
 		return jDescriptionLabelPanel;
 	}
-}  //
-
-
+}

--- a/src/main/java/org/isf/visits/gui/VisitView.java
+++ b/src/main/java/org/isf/visits/gui/VisitView.java
@@ -79,10 +79,6 @@ import org.isf.ward.model.Ward;
 import com.toedter.calendar.JDateChooser;
 
 /**
- * @author Mwithi
- */
-
-/**
  * This code was edited or generated using CloudGarden's Jigloo SWT/Swing GUI
  * Builder, which is free for non-commercial use. If Jigloo is being used
  * commercially (ie, by a corporation, company or business for any purpose
@@ -91,12 +87,11 @@ import com.toedter.calendar.JDateChooser;
  * acceptance of these licensing terms. A COMMERCIAL LICENSE HAS NOT BEEN
  * PURCHASED FOR THIS MACHINE, SO JIGLOO OR THIS CODE CANNOT BE USED LEGALLY FOR
  * ANY CORPORATE OR COMMERCIAL PURPOSE.
+ *
+ * @author Mwithi
  */
 public class VisitView extends ModalJFrame {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 	private EventListenerList visitViewListeners = new EventListenerList();
 
@@ -112,9 +107,6 @@ public class VisitView extends ModalJFrame {
 	private void fireVisitsUpdated() {
 		AWTEvent event = new AWTEvent(VisitView.this, AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
 			private static final long serialVersionUID = 1L;
 		};
 
@@ -570,9 +562,6 @@ public class VisitView extends ModalJFrame {
 
 	class CenterTableCellRenderer extends DefaultTableCellRenderer {
 
-		/**
-		 * 
-		 */
 		private static final long serialVersionUID = 1L;
 
 		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {

--- a/src/main/java/org/isf/ward/gui/WardBrowser.java
+++ b/src/main/java/org/isf/ward/gui/WardBrowser.java
@@ -51,13 +51,9 @@ import org.isf.ward.model.Ward;
  * It is possible to edit-insert-delete records
  * 
  * @author Rick
- * 
  */
 public class WardBrowser extends ModalJFrame implements WardEdit.WardListener {
-	
-	/**
-	 * 
-	 */
+
 	private static final long serialVersionUID = 1L;
 
 	public void wardInserted(AWTEvent e) {
@@ -129,8 +125,6 @@ public class WardBrowser extends ModalJFrame implements WardEdit.WardListener {
 	
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		this.setTitle(MessageBundle.getMessage("angal.ward.wardsbrowser"));
@@ -330,10 +324,7 @@ public class WardBrowser extends ModalJFrame implements WardEdit.WardListener {
 	}
 	
 	class WardBrowserModel extends DefaultTableModel {
-		
-		/**
-		 * 
-		 */
+
 		private static final long serialVersionUID = 1L;
 
 		public WardBrowserModel() {

--- a/src/main/java/org/isf/ward/gui/WardEdit.java
+++ b/src/main/java/org/isf/ward/gui/WardEdit.java
@@ -53,54 +53,49 @@ import org.isf.ward.model.Ward;
  * This class allows wards edits and inserts
  * 
  * @author Rick
- * 
  */
 public class WardEdit extends JDialog {
-	
-	/**
-	 * 
-	 */
+
 	private static final long serialVersionUID = 1L;
 	private EventListenerList wardListeners = new EventListenerList();
-	
+
 	public interface WardListener extends EventListener {
+
 		void wardUpdated(AWTEvent e);
+
 		void wardInserted(AWTEvent e);
 	}
-	
+
 	public void addWardListener(WardListener l) {
 		wardListeners.add(WardListener.class, l);
 	}
-	
+
 	public void removeWardListener(WardListener listener) {
 		wardListeners.remove(WardListener.class, listener);
 	}
-	
+
 	private void fireWardInserted() {
 		AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
-			private static final long serialVersionUID = 1L;};
-		
+			private static final long serialVersionUID = 1L;
+		};
+
 		EventListener[] listeners = wardListeners.getListeners(WardListener.class);
 		for (int i = 0; i < listeners.length; i++)
-			((WardListener)listeners[i]).wardInserted(event);
+			((WardListener) listeners[i]).wardInserted(event);
 	}
+
 	private void fireWardUpdated() {
 		AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
 
-			/**
-			 * 
-			 */
-			private static final long serialVersionUID = 1L;};
-		
+			private static final long serialVersionUID = 1L;
+		};
+
 		EventListener[] listeners = wardListeners.getListeners(WardListener.class);
 		for (int i = 0; i < listeners.length; i++)
-			((WardListener)listeners[i]).wardUpdated(event);
+			((WardListener) listeners[i]).wardUpdated(event);
 	}
-	
+
 	private JPanel jContentPane = null;
 	private JPanel dataPanel = null;
 	private JPanel buttonPanel = null;
@@ -131,24 +126,21 @@ public class WardEdit extends JDialog {
 	private int beds;
 	private int nurs;
 	private int docs;
-	
+
 	/**
-	 * 
 	 * This is the default constructor; we pass the parent frame
 	 * (because it is a jdialog), the arraylist and the selected
 	 * row because we need to update them
 	 */
-	public WardEdit(JFrame parent,Ward old,boolean inserting) {
+	public WardEdit(JFrame parent, Ward old, boolean inserting) {
 		super(parent, true);
 		insert = inserting;
-		ward = old;		//operation will be used for every operation
+		ward = old;        //operation will be used for every operation
 		initialize();
 	}
-	
+
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		this.setContentPane(getJContentPane());
@@ -160,10 +152,10 @@ public class WardEdit extends JDialog {
 		pack();
 		setLocationRelativeTo(null);
 	}
-	
+
 	/**
 	 * This method initializes jContentPane
-	 * 
+	 *
 	 * @return javax.swing.JPanel
 	 */
 	private JPanel getJContentPane() {
@@ -176,17 +168,17 @@ public class WardEdit extends JDialog {
 		}
 		return jContentPane;
 	}
-	
+
 	/**
-	 * This method initializes dataPanel	
-	 * 	
-	 * @return javax.swing.JPanel	
+	 * This method initializes dataPanel
+	 *
+	 * @return javax.swing.JPanel
 	 */
 	private JPanel getDataPanel() {
 		if (dataPanel == null) {
 			dataPanel = new JPanel();
 			GridBagLayout gbl_dataPanel = new GridBagLayout();
-			gbl_dataPanel.columnWeights = new double[]{0.0, 1.0};
+			gbl_dataPanel.columnWeights = new double[] { 0.0, 1.0 };
 			dataPanel.setLayout(gbl_dataPanel);
 			codeLabel = new JLabel();
 			codeLabel.setText(MessageBundle.getMessage("angal.common.codestar"));
@@ -321,7 +313,7 @@ public class WardEdit extends JDialog {
 			gbc_isFemaleCheck.gridx = 0;
 			gbc_isFemaleCheck.gridy = 10;
 			dataPanel.add(getIsFemaleCheck(), gbc_isFemaleCheck);
-			requiredLabel= new JLabel();
+			requiredLabel = new JLabel();
 			requiredLabel.setText(MessageBundle.getMessage("angal.ward.requiredfields"));
 			GridBagConstraints gbc_requiredLabel = new GridBagConstraints();
 			gbc_requiredLabel.gridwidth = 2;
@@ -332,11 +324,11 @@ public class WardEdit extends JDialog {
 		}
 		return dataPanel;
 	}
-	
+
 	/**
-	 * This method initializes buttonPanel	
-	 * 	
-	 * @return javax.swing.JPanel	
+	 * This method initializes buttonPanel
+	 *
+	 * @return javax.swing.JPanel
 	 */
 	private JPanel getButtonPanel() {
 		if (buttonPanel == null) {
@@ -346,11 +338,11 @@ public class WardEdit extends JDialog {
 		}
 		return buttonPanel;
 	}
-	
+
 	/**
-	 * This method initializes cancelButton	
-	 * 	
-	 * @return javax.swing.JButton	
+	 * This method initializes cancelButton
+	 *
+	 * @return javax.swing.JButton
 	 */
 	private JButton getCancelButton() {
 		if (cancelButton == null) {
@@ -358,6 +350,7 @@ public class WardEdit extends JDialog {
 			cancelButton.setText(MessageBundle.getMessage("angal.common.cancel"));  // Generated
 			cancelButton.setMnemonic(KeyEvent.VK_C);
 			cancelButton.addActionListener(new ActionListener() {
+
 				public void actionPerformed(java.awt.event.ActionEvent e) {
 					dispose();
 				}
@@ -365,19 +358,20 @@ public class WardEdit extends JDialog {
 		}
 		return cancelButton;
 	}
-	
+
 	/**
-	 * This method initializes okButton	
-	 * 	
-	 * @return javax.swing.JButton	
+	 * This method initializes okButton
+	 *
+	 * @return javax.swing.JButton
 	 */
 	private JButton getOkButton() {
 		if (okButton == null) {
 			okButton = new JButton();
 			okButton.setText(MessageBundle.getMessage("angal.common.ok"));  // Generated
 			okButton.setMnemonic(KeyEvent.VK_O);
-			
+
 			okButton.addActionListener(new ActionListener() {
+
 				public void actionPerformed(java.awt.event.ActionEvent e) {
 					WardBrowserManager manager = Context.getApplicationContext().getBean(WardBrowserManager.class);
 
@@ -420,7 +414,7 @@ public class WardEdit extends JDialog {
 					if (insert) { // inserting
 						try {
 							savedWard = manager.newWard(ward);
-							if(savedWard != null) {
+							if (savedWard != null) {
 								ward.setLock(savedWard.getLock());
 								result = true;
 							}
@@ -433,7 +427,7 @@ public class WardEdit extends JDialog {
 					} else {
 						try { // updating
 							savedWard = manager.updateWard(ward);
-							if(savedWard != null) {
+							if (savedWard != null) {
 								ward.setLock(savedWard.getLock());
 								result = true;
 							}
@@ -454,30 +448,30 @@ public class WardEdit extends JDialog {
 		}
 		return okButton;
 	}
-	
+
 	/**
-	 * This method initializes descriptionTextField	
-	 * 	
-	 * @return javax.swing.JTextField	
+	 * This method initializes descriptionTextField
+	 *
+	 * @return javax.swing.JTextField
 	 */
 	private JTextField getDescriptionTextField() {
 		if (descriptionTextField == null) {
 			descriptionTextField = new VoLimitedTextField(50);
-			if (!insert) {				
+			if (!insert) {
 				descriptionTextField.setText(ward.getDescription());
 			}
 		}
 		return descriptionTextField;
 	}
-	
+
 	/**
-	 * This method initializes codeTextField	
-	 * 	
-	 * @return javax.swing.JTextField	
+	 * This method initializes codeTextField
+	 *
+	 * @return javax.swing.JTextField
 	 */
 	private JTextField getCodeTextField() {
 		if (codeTextField == null) {
-			codeTextField = new VoLimitedTextField(1, 20);			
+			codeTextField = new VoLimitedTextField(1, 20);
 			if (!insert) {
 				codeTextField.setText(ward.getCode());
 				codeTextField.setEnabled(false);
@@ -485,11 +479,11 @@ public class WardEdit extends JDialog {
 		}
 		return codeTextField;
 	}
-	
+
 	/**
-	 * This method initializes telTextField	
-	 * 	
-	 * @return javax.swing.JTextField	
+	 * This method initializes telTextField
+	 *
+	 * @return javax.swing.JTextField
 	 */
 	private JTextField getTelTextField() {
 		if (telTextField == null) {
@@ -500,11 +494,11 @@ public class WardEdit extends JDialog {
 		}
 		return telTextField;
 	}
-	
+
 	/**
-	 * This method initializes faxTextField	
-	 * 	
-	 * @return javax.swing.JTextField	
+	 * This method initializes faxTextField
+	 *
+	 * @return javax.swing.JTextField
 	 */
 	private JTextField getFaxTextField() {
 		if (faxTextField == null) {
@@ -515,11 +509,11 @@ public class WardEdit extends JDialog {
 		}
 		return faxTextField;
 	}
-	
+
 	/**
-	 * This method initializes emailTextField	
-	 * 	
-	 * @return javax.swing.JTextField	
+	 * This method initializes emailTextField
+	 *
+	 * @return javax.swing.JTextField
 	 */
 	private JTextField getEmailTextField() {
 		if (emailTextField == null) {
@@ -530,13 +524,13 @@ public class WardEdit extends JDialog {
 		}
 		return emailTextField;
 	}
-	
+
 	/**
-	 * This method initializes bedsTextField	
-	 * 	
-	 * @return javax.swing.JTextField	
+	 * This method initializes bedsTextField
+	 *
+	 * @return javax.swing.JTextField
 	 */
-	private JTextField getBedsTextField() {	
+	private JTextField getBedsTextField() {
 		if (bedsTextField == null) {
 			bedsTextField = new VoLimitedTextField(4, 20);
 			if (!insert) {
@@ -545,11 +539,11 @@ public class WardEdit extends JDialog {
 		}
 		return bedsTextField;
 	}
-	
+
 	/**
-	 * This method initializes nursTextField	
-	 * 	
-	 * @return javax.swing.JTextField	
+	 * This method initializes nursTextField
+	 *
+	 * @return javax.swing.JTextField
 	 */
 	private JTextField getNursTextField() {
 		if (nursTextField == null) {
@@ -560,11 +554,11 @@ public class WardEdit extends JDialog {
 		}
 		return nursTextField;
 	}
-	
+
 	/**
-	 * This method initializes docsTextField	
-	 * 	
-	 * @return javax.swing.JTextField	
+	 * This method initializes docsTextField
+	 *
+	 * @return javax.swing.JTextField
 	 */
 	private JTextField getDocsTextField() {
 		if (docsTextField == null) {
@@ -575,14 +569,14 @@ public class WardEdit extends JDialog {
 		}
 		return docsTextField;
 	}
-	
+
 	/**
 	 * This method initializes isPharmacyCheck
-	 * 
+	 *
 	 * @return javax.swing.JCheckBox
 	 */
 	private JCheckBox getIsPharmacyCheck() {
-		if (isPharmacyCheck==null) {
+		if (isPharmacyCheck == null) {
 			isPharmacyCheck = new JCheckBox(MessageBundle.getMessage("angal.ward.wardwithpharmacy"));
 			if (!insert) {
 				isPharmacyCheck.setSelected(ward.isPharmacy());
@@ -590,10 +584,10 @@ public class WardEdit extends JDialog {
 		}
 		return isPharmacyCheck;
 	}
-	
+
 	/**
 	 * This method initializes isFemaleCheck
-	 * 
+	 *
 	 * @return javax.swing.JCheckBox
 	 */
 	private JCheckBox getIsMaleCheck() {
@@ -605,10 +599,10 @@ public class WardEdit extends JDialog {
 		}
 		return isMaleCheck;
 	}
-	
+
 	/**
 	 * This method initializes isFemaleCheck
-	 * 
+	 *
 	 * @return javax.swing.JCheckBox
 	 */
 	private JCheckBox getIsFemaleCheck() {
@@ -620,4 +614,4 @@ public class WardEdit extends JDialog {
 		}
 		return isFemaleCheck;
 	}
-} 
+}


### PR DESCRIPTION
Update JavaDoc based on IntelliJ's Analyze JavaDoc option.

Before changes:  8 errors, 184 warnings
After changes: 78 warnings (all are missing the description associated with a method parameter or return value)

Examples of changes:

- Remove empty JavaDoc block comments
- Remove "@return void"
- Remove dangling JavaDoc comments; those are comments that start with "/**" but aren't closed; just add a space so it is "/* *"
- Grammar and spelling