### PR TITLE
Chore: remove self assignment of variable

### DIFF
--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacyRectify.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacyRectify.java
@@ -203,7 +203,6 @@ public class WardPharmacyRectify extends JDialog {
 	public WardPharmacyRectify(JFrame owner, Ward ward, Medical medical) {
 		super(owner, true);
 		wardSelected = ward;
-		medical= medical;
 		try {
 			wardDrugs = wardManager.getMedicalsWard(wardSelected.getCode().charAt(0), false);
 		} catch (OHServiceException e) {


### PR DESCRIPTION
Found with SpotBugs and I reported as a review comment on [PR 175](https://github.com/informatici/openhospital-gui/pull/175).

The method parameter is assigned to itself and then used only once in the last line of the method.