### PR TITLE
Chore: remove redundant interface declaration

### DIFF
--- a/src/main/java/org/isf/priceslist/gui/PriceModel.java
+++ b/src/main/java/org/isf/priceslist/gui/PriceModel.java
@@ -80,7 +80,7 @@ import org.isf.utils.treetable.TreeTableModel;
  * @author Scott Violet
  */
 
-public class PriceModel extends AbstractTreeTableModel implements TreeTableModel {
+public class PriceModel extends AbstractTreeTableModel {
 
      // Names of the columns.
     static protected String[] cNames = {"Name", "Prices"};


### PR DESCRIPTION
Remove the redundant interface declaration as `AbstractTreeTableModel` already implements `TreeTableModel `.

Found with Intellij's Analyze plugin looking for redundant code.