### PR TITLE
OP-251 OP-158 changes not needed since Java8

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,4 +21,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package --file pom.xml -Djava.awt.headless=true

--- a/pom.xml
+++ b/pom.xml
@@ -320,11 +320,16 @@
 			<artifactId>jgoodies-looks</artifactId>
 			<version>2.7.0</version>
 		</dependency>
-
 		<dependency>
 			<groupId>com.jgoodies</groupId>
 			<artifactId>jgoodies-validation</artifactId>
 			<version>2.5.1</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.1</version>
+			<scope>test</scope>
 		</dependency>
 	  	<!-- <dependency>
 			<groupId>org.apache.poi</groupId>

--- a/src/main/java/org/isf/menu/gui/Menu.java
+++ b/src/main/java/org/isf/menu/gui/Menu.java
@@ -51,7 +51,7 @@ public class Menu {
 		checkJavaVersion();
 		JFrame.setDefaultLookAndFeelDecorated(false);
 		new SplashWindow3("rsc" + File.separator + "images" + File.separator + "Splash.jpg", null, 3000);
-		WaitCursorEventQueue waitQueue = new WaitCursorEventQueue(10);
+		WaitCursorEventQueue waitQueue = new WaitCursorEventQueue(70);
 		Toolkit.getDefaultToolkit().getSystemEventQueue().push(waitQueue);
 	}
 

--- a/src/main/java/org/isf/menu/gui/Menu.java
+++ b/src/main/java/org/isf/menu/gui/Menu.java
@@ -51,7 +51,7 @@ public class Menu {
 		checkJavaVersion();
 		JFrame.setDefaultLookAndFeelDecorated(false);
 		new SplashWindow3("rsc" + File.separator + "images" + File.separator + "Splash.jpg", null, 3000);
-		WaitCursorEventQueue waitQueue = new WaitCursorEventQueue(10, Toolkit.getDefaultToolkit().getSystemEventQueue());
+		WaitCursorEventQueue waitQueue = new WaitCursorEventQueue(10);
 		Toolkit.getDefaultToolkit().getSystemEventQueue().push(waitQueue);
 	}
 

--- a/src/main/java/org/isf/utils/jobjects/CursorManager.java
+++ b/src/main/java/org/isf/utils/jobjects/CursorManager.java
@@ -26,68 +26,71 @@ import java.awt.EventQueue;
 import java.awt.Toolkit;
 import java.awt.event.InputEvent;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.Stack;
 
 class CursorManager {
-  private final DelayTimer waitTimer;
-  private final Stack<DispatchedEvent> dispatchedEvents;
-  private boolean needsCleanup;
 
-  public CursorManager(DelayTimer waitTimer) {
-    this.dispatchedEvents = new Stack<DispatchedEvent>();
-    this.waitTimer = waitTimer;
-  }
-  private void cleanUp() {
-    if (((DispatchedEvent) dispatchedEvents.peek()).resetCursor()) {
-      clearQueueOfInputEvents();
-    }
-  }
-  private void clearQueueOfInputEvents() {
-    final WaitCursorEventQueue waitCursorEventQueue = (WaitCursorEventQueue) Toolkit.getDefaultToolkit().getSystemEventQueue();
-    final EventQueue parentQueue = waitCursorEventQueue.getParentQueue();
-    synchronized(parentQueue){
-      synchronized(waitCursorEventQueue) {
-        for (AWTEvent nonInputEvent : gatherNonInputEvents(waitCursorEventQueue))
-            waitCursorEventQueue.postEvent(nonInputEvent);
-      }
-    }
-  }
-  private ArrayList<AWTEvent> gatherNonInputEvents(EventQueue systemQueue) {
-    ArrayList<AWTEvent> events = new ArrayList<AWTEvent>();
-    while (systemQueue.peekEvent() != null) {
-      try {
-        AWTEvent nextEvent = systemQueue.getNextEvent();
-        if (!(nextEvent instanceof InputEvent)) {
-          events.add(nextEvent);
-        }
-      } catch (InterruptedException ie) {
-        Thread.currentThread().interrupt();
-      }
-    }
-    return events;
-  }
-  public void push(Object source) {
-    if (needsCleanup) {
-      waitTimer.stopTimer();
-      cleanUp(); 
-      //this corrects the state when a modal dialog 
-      //opened last time round
-    }
-    dispatchedEvents.push(new DispatchedEvent(source));
-    needsCleanup = true;
-  }
-  public void pop() {
-    cleanUp();
-    dispatchedEvents.pop();
-    if (!dispatchedEvents.isEmpty()) {
-      //this will be stopped if getNextEvent() is called - 
-      //used to watch for modal dialogs closing
-      waitTimer.startTimer(); 
-    } else {
-      needsCleanup = false;
-    }
-  }
-  public void setCursor() {
-    ((DispatchedEvent) dispatchedEvents.peek()).setCursor();
-  }
+	private final DelayTimer waitTimer;
+	private final Stack<DispatchedEvent> dispatchedEvents;
+	private boolean needsCleanup;
+
+	public CursorManager(DelayTimer waitTimer) {
+		this.dispatchedEvents = new Stack<DispatchedEvent>();
+		this.waitTimer = waitTimer;
+	}
+	private void cleanUp() {
+		if (((DispatchedEvent) dispatchedEvents.peek()).resetCursor()) {
+			clearQueueOfInputEvents();
+		}
+	}
+	private void clearQueueOfInputEvents() {
+		EventQueue q = Toolkit.getDefaultToolkit().getSystemEventQueue();
+		try {
+			ArrayList<AWTEvent> nonInputEvents = gatherNonInputEvents(q);
+			for (Iterator<AWTEvent> it = nonInputEvents.iterator(); it.hasNext();) {
+				q.postEvent((AWTEvent) it.next());
+			}
+
+		} finally {
+		}
+	}
+	private ArrayList<AWTEvent> gatherNonInputEvents(EventQueue systemQueue) {
+		ArrayList<AWTEvent> events = new ArrayList<AWTEvent>();
+		while (systemQueue.peekEvent() != null) {
+			try {
+				AWTEvent nextEvent = systemQueue.getNextEvent();
+				if (!(nextEvent instanceof InputEvent)) {
+					events.add(nextEvent);
+				}
+			} catch (InterruptedException ie) {
+				Thread.currentThread().interrupt();
+			}
+		}
+		return events;
+	}
+	public void push(Object source) {
+		if (needsCleanup) {
+			waitTimer.stopTimer();
+			cleanUp();
+			// this corrects the state when a modal dialog
+			// opened last time round
+		}
+		dispatchedEvents.push(new DispatchedEvent(source));
+		needsCleanup = true;
+	}
+	public void pop() {
+		cleanUp();
+		dispatchedEvents.pop();
+		if (!dispatchedEvents.isEmpty()) {
+			// this will be stopped if getNextEvent() is called -
+			// used to watch for modal dialogs closing
+			waitTimer.startTimer();
+		} else {
+			needsCleanup = false;
+		}
+	}
+	public void setCursor() {
+		((DispatchedEvent) dispatchedEvents.peek()).setCursor();
+	}
 }

--- a/src/main/java/org/isf/utils/jobjects/DelayTimer.java
+++ b/src/main/java/org/isf/utils/jobjects/DelayTimer.java
@@ -20,7 +20,18 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
-
+/**
+ * This class implements a delay timer that will call trigger() 
+ * on the DelayTimerCallback delay milliseconds after 
+ * startTimer() was called, if stopTimer() was not called first.  
+ * The timer will only throw events after startTimer() is called.  
+ * Until then, it does nothing.  It is safe to call stopTimer() 
+ * and startTimer() repeatedly.
+ *
+ * Note that calls to trigger() will happen on the timer thread.
+ *
+ * This class is multiple-thread safe. 
+ */
 public class DelayTimer extends Thread {
 	private final DelayTimerCallback callback;
 	private final Object mutex = new Object();

--- a/src/main/java/org/isf/utils/jobjects/WaitCursorEventQueue.java
+++ b/src/main/java/org/isf/utils/jobjects/WaitCursorEventQueue.java
@@ -24,6 +24,10 @@ package org.isf.utils.jobjects;
 import java.awt.AWTEvent;
 import java.awt.EventQueue;
 
+/**
+ * Suggested serving size:
+ * Toolkit.getDefaultToolkit().getSystemEventQueue().push(new WaitCursorEventQueue(70));
+ */
 public class WaitCursorEventQueue extends EventQueue implements DelayTimerCallback {
 	private final CursorManager cursorManager;
 	private final DelayTimer waitTimer;

--- a/src/main/java/org/isf/utils/jobjects/WaitCursorEventQueue.java
+++ b/src/main/java/org/isf/utils/jobjects/WaitCursorEventQueue.java
@@ -29,6 +29,12 @@ public class WaitCursorEventQueue extends EventQueue implements DelayTimerCallba
 	private final DelayTimer waitTimer;
 	private final EventQueue parentQueue;
 
+	public WaitCursorEventQueue(int delay) {
+		this.waitTimer = new DelayTimer(this, delay);
+		this.cursorManager = new CursorManager(waitTimer);
+		this.parentQueue = null;
+	}
+	
 	public WaitCursorEventQueue(int delay, EventQueue systemQueue) {
 		this.waitTimer = new DelayTimer(this, delay);
 		this.cursorManager = new CursorManager(waitTimer);

--- a/src/test/java/org/isf/utils/jobject/DelayTimerTest.java
+++ b/src/test/java/org/isf/utils/jobject/DelayTimerTest.java
@@ -1,0 +1,203 @@
+package org.isf.utils.jobject;
+
+import org.isf.utils.jobjects.DelayTimer;
+import org.isf.utils.jobjects.DelayTimerCallback;
+
+import junit.framework.TestCase;
+
+public class DelayTimerTest extends TestCase {
+  private static final int TIMEOUT = 100;
+  private static final int BUFFER = 20;
+  private static final int MORE_THAN_HALF = 60;
+  private DelayTimer timer;
+  private TestDelayTimerCallback callback;
+
+  public DelayTimerTest(String name) {
+    super(name);
+  }
+
+  public void setUp() {
+    callback = new TestDelayTimerCallback();
+    timer = new DelayTimer(callback, TIMEOUT);
+  }
+
+  public void tearDown() {
+    timer.quit();
+  }
+
+  private void sleep(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public void testNotStarted() {
+    sleep(TIMEOUT + BUFFER);
+    assertEquals("no trigger without start()", 0, 
+                 callback.getTriggerCount());
+  }
+
+  public void testNoTriggerIfTooShort() {
+    timer.startTimer();
+    assertEquals("no trigger if too fast", 0, 
+                 callback.getTriggerCount());
+    timer.stopTimer();
+    sleep(TIMEOUT + BUFFER);
+    assertEquals("no trigger after stop", 0, 
+                 callback.getTriggerCount());
+  }
+
+  public void testTimerRestarts() {
+    timer.startTimer();
+    sleep(MORE_THAN_HALF);
+    timer.startTimer();
+    sleep(MORE_THAN_HALF);
+    timer.stopTimer();
+    assertEquals("timer is restarted on calls to start()", 0, 
+                 callback.getTriggerCount());
+  }
+
+  public void testTimerTriggersThenStops() {
+    timer.startTimer();
+    sleep(TIMEOUT + BUFFER);
+    timer.stopTimer();
+    sleep(TIMEOUT + BUFFER);
+    assertEquals("timer triggered event", 1, 
+                 callback.getTriggerCount());
+  }
+
+  public void testTimerOnlyTriggersOneEvent() {
+    timer.startTimer();
+    sleep(TIMEOUT + BUFFER);
+    assertEquals("timer triggered event", 1, 
+                 callback.getTriggerCount());
+    sleep(TIMEOUT + BUFFER);
+    assertEquals("timer did not trigger another event", 1, 
+                 callback.getTriggerCount());
+    timer.stopTimer();
+  }
+
+  public void testTimerStopsTwice() {
+    timer.startTimer();
+    timer.stopTimer();
+    timer.stopTimer();
+    sleep(TIMEOUT + BUFFER);
+    assertEquals("timer did not trigger event", 0, 
+                 callback.getTriggerCount());
+  }
+
+  public void testTriggers() {
+    timer.startTimer();
+    sleep(TIMEOUT + BUFFER);
+    timer.stopTimer();
+    timer.stopTimer();
+    assertEquals("timer triggered only 1 event", 1, 
+                 callback.getTriggerCount());
+  }
+
+  public void testTriggerTrigger() {
+    timer.startTimer();
+    sleep(TIMEOUT + BUFFER);
+    assertEquals("timer triggered first event", 1, 
+                 callback.getTriggerCount());
+    timer.startTimer();
+    sleep(TIMEOUT + BUFFER);
+    assertEquals("timer triggered second event", 2, 
+                 callback.getTriggerCount());
+    sleep(TIMEOUT + BUFFER);
+    timer.stopTimer();
+    assertEquals("timer did not trigger another event", 2, 
+                 callback.getTriggerCount());
+  }
+
+  public void testStopTimerHappensAfterTrigger() {
+    FancyTestDelayTimerCallback callback = new FancyTestDelayTimerCallback();
+    timer = new DelayTimer(callback, TIMEOUT);
+
+    timer.startTimer();
+    sleep(TIMEOUT + BUFFER);
+    assertTrue("timer is in trigger", callback.inTrigger);
+    assertTrue("timer has not thrown exception", 
+               !callback.exception);
+    assertTrue("timer is not out of trigger", 
+               !callback.outOfTrigger);
+
+    Runnable runnable = new Runnable() {
+      public void run() {
+        timer.stopTimer();
+      }
+    };
+
+    Thread testThread = new Thread(runnable, "test thread");
+    testThread.start();
+
+    sleep(TIMEOUT + BUFFER);
+
+    assertTrue("stopTimer() has not returned", 
+               testThread.isAlive());
+    synchronized (callback) {
+      callback.notify();
+    }
+
+    sleep(TIMEOUT + BUFFER);
+
+    assertTrue("timer has not thrown exception", 
+               !callback.exception);
+    assertTrue("timer is out of trigger", callback.outOfTrigger);
+    assertTrue("stopTimer() has returned", !testThread.isAlive());
+  }
+
+  public void testMishMash() {
+    timer.startTimer();
+    sleep(MORE_THAN_HALF);
+    timer.startTimer();
+    sleep(MORE_THAN_HALF);
+    timer.stopTimer();
+    sleep(MORE_THAN_HALF);
+    timer.startTimer();
+    timer.stopTimer();
+    timer.stopTimer();
+    sleep(MORE_THAN_HALF);
+    timer.startTimer();
+    timer.startTimer();
+    assertEquals("no event yet", 0, callback.getTriggerCount());
+    sleep(TIMEOUT + BUFFER);
+    timer.stopTimer();
+    assertEquals("got event yet", 1, callback.getTriggerCount());
+  }
+
+  private class FancyTestDelayTimerCallback
+      implements DelayTimerCallback {
+    public boolean exception;
+    public boolean inTrigger;
+    public boolean outOfTrigger;
+
+    public synchronized void trigger() {
+      inTrigger = true;
+
+      try {
+        wait();
+      } catch (InterruptedException e) {
+        exception = true;
+        e.printStackTrace();
+      } finally {
+        outOfTrigger = true;
+      }
+    }
+  }
+
+  private class TestDelayTimerCallback
+      implements DelayTimerCallback {
+    private int triggerCount;
+
+    public int getTriggerCount() {
+      return triggerCount;
+    }
+
+    public void trigger() {
+      triggerCount++;
+    }
+  }
+}

--- a/src/test/java/org/isf/utils/jobject/WaitCursorEventQueueTest.java
+++ b/src/test/java/org/isf/utils/jobject/WaitCursorEventQueueTest.java
@@ -1,0 +1,512 @@
+package org.isf.utils.jobject;
+import java.awt.AWTEvent;
+import java.awt.Cursor;
+import java.awt.Dialog;
+import java.awt.Frame;
+import java.awt.Toolkit;
+import java.awt.event.InvocationEvent;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.SwingUtilities;
+
+import org.isf.utils.jobjects.WaitCursorEventQueue;
+
+import junit.framework.TestCase;
+
+public class WaitCursorEventQueueTest extends TestCase {
+  private static final int TIMEOUT = 200;
+  private static final int BUFFER = 30;
+  private static final Cursor BASE_CURSOR = Cursor.getPredefinedCursor(
+                                                Cursor.CROSSHAIR_CURSOR);
+  private CursorReportingDialog dialog;
+  private CursorReportingDialog dialog2;
+  private CursorReportingFrame frame;
+  private TestWaitCursorEventQueue eventQueue;
+
+  public WaitCursorEventQueueTest(String name) {
+    super(name);
+  }
+
+  public void setUp() {
+    eventQueue = new TestWaitCursorEventQueue(TIMEOUT);
+    Toolkit.getDefaultToolkit().getSystemEventQueue()
+       .push(eventQueue);
+    frame = new CursorReportingFrame();
+    frame.pack();
+    frame.setBounds(-1000, -1000, 100, 100);
+    frame.setVisible(true);
+    dialog = new CursorReportingDialog(frame);
+    dialog.pack();
+    dialog.setBounds(-1000, -1000, 100, 100);
+    dialog2 = new CursorReportingDialog(dialog);
+    dialog2.pack();
+    dialog2.setBounds(-1000, -1000, 100, 100);
+  }
+  public void tearDown() throws InvocationTargetException, 
+                                InterruptedException {
+    flushQueue();
+    eventQueue.close();
+    eventQueue = null;
+    flushQueue();
+    frame.dispose();
+    frame = null;
+    dialog.dispose();
+    dialog = null;
+  }
+  private void flushQueue() throws InvocationTargetException, 
+                                   InterruptedException {
+    SwingUtilities.invokeAndWait(new Runnable() {
+      public void run() {
+      }
+    });
+  }
+  private void postEvent(Object source, Runnable event) {
+    eventQueue.postEvent(new InvocationEvent(source, event));
+  }
+  private void hangOut(long timeout) {
+    try {
+      Thread.sleep(timeout);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+  public void testNoCursor() throws InvocationTargetException, 
+                                    InterruptedException {
+    DelayEvent event = new DelayEvent(TIMEOUT - BUFFER);
+    postEvent(frame, event);
+    postEvent(frame, event);
+    postEvent(frame, event);
+    postEvent(frame, event);
+    flushQueue();
+    assertEquals("no cursor set", 0, frame.getCursorSetCount());
+    assertEquals("no cursor reset", 0, 
+                 frame.getCursorResetCount());
+  }
+  public void testCursor() throws InvocationTargetException, 
+                                  InterruptedException {
+    DelayEvent event = new DelayEvent(TIMEOUT + BUFFER);
+    postEvent(frame, event);
+    flushQueue();
+    assertEquals("1 cursor set", 1, frame.getCursorSetCount());
+    assertEquals("1 cursor reset", 1, 
+                 frame.getCursorResetCount());
+  }
+  public void testDialog() throws InvocationTargetException, 
+                                  InterruptedException {
+    postEvent(frame, new DialogShowEvent(dialog, true, 0));
+    flushQueue();
+    hangOut(TIMEOUT + BUFFER);
+    assertEquals("dialog never got cursor", 0, 
+                 dialog.getCursorSetCount());
+    assertEquals("dialog never reset cursor", 0, 
+                 dialog.getCursorResetCount());
+    assertEquals("frame never got cursor", 0, 
+                 frame.getCursorSetCount());
+    assertEquals("frame never reset cursor", 0, 
+                 frame.getCursorResetCount());
+    postEvent(dialog, new DialogShowEvent(dialog, false, 0));
+    flushQueue();
+    hangOut(TIMEOUT + BUFFER);
+    assertEquals("dialog never got cursor", 0, 
+                 dialog.getCursorSetCount());
+    assertEquals("dialog never reset cursor", 0, 
+                 dialog.getCursorResetCount());
+    assertEquals("frame never got cursor", 0, 
+                 frame.getCursorSetCount());
+    assertEquals("frame never reset cursor", 0, 
+                 frame.getCursorResetCount());
+  }
+  public void testCursorAndDialog()
+                           throws InvocationTargetException, 
+                                  InterruptedException {
+    TestRunnable testAndShow = new TestRunnable() {
+      public void run() {
+        testsPassed &= (1 == frame.getCursorSetCount());
+        testsPassed &= (0 == frame.getCursorResetCount());
+        dialog.setVisible(true);
+      }
+    };
+    postEvent(frame, 
+              new DelayEvent(TIMEOUT + BUFFER, testAndShow));
+    flushQueue();
+    assertTrue("Delay worked", testAndShow.getTestsPassed());
+    hangOut(TIMEOUT + BUFFER);
+    assertEquals("dialog never got cursor", 0, 
+                 dialog.getCursorSetCount());
+    assertEquals("dialog never reset cursor", 0, 
+                 dialog.getCursorResetCount());
+    assertEquals("frame never got another cursor", 1, 
+                 frame.getCursorSetCount());
+    assertEquals("frame reset cursor", 1, 
+                 frame.getCursorResetCount());
+    postEvent(dialog, new DialogShowEvent(dialog, false, 0));
+    flushQueue();
+    hangOut(TIMEOUT + BUFFER);
+    assertEquals("dialog never got cursor", 0, 
+                 dialog.getCursorSetCount());
+    assertEquals("dialog never reset cursor", 0, 
+                 dialog.getCursorResetCount());
+    assertEquals("frame never got another cursor", 1, 
+                 frame.getCursorSetCount());
+    assertEquals("frame never reset another cursor", 1, 
+                 frame.getCursorResetCount());
+  }
+  public void testCursorAndDialogAndCursor()
+    throws InvocationTargetException, InterruptedException {
+    TestRunnable testAndShow = new TestRunnable() {
+      public void run() {
+        testsPassed &= (1 == frame.getCursorSetCount());
+        testsPassed &= (0 == frame.getCursorResetCount());
+        dialog.setVisible(true);
+        hangOut(TIMEOUT + BUFFER);
+      }
+    };
+    postEvent(frame, 
+              new DelayEvent(TIMEOUT + BUFFER, testAndShow));
+    flushQueue();
+    assertTrue("Delay worked", testAndShow.getTestsPassed());
+    hangOut(TIMEOUT + BUFFER);
+    assertEquals("dialog never got cursor", 0, 
+                 dialog.getCursorSetCount());
+    assertEquals("dialog never reset cursor", 0, 
+                 dialog.getCursorResetCount());
+    assertEquals("frame never got another cursor", 1, 
+                 frame.getCursorSetCount());
+    assertEquals("frame reset cursor", 1, 
+                 frame.getCursorResetCount());
+    postEvent(dialog, new DialogShowEvent(dialog, false, 0));
+    flushQueue();
+    hangOut(TIMEOUT + BUFFER);
+    assertEquals("dialog never got cursor", 0, 
+                 dialog.getCursorSetCount());
+    assertEquals("dialog never reset cursor", 0, 
+                 dialog.getCursorResetCount());
+    assertEquals("frame got another cursor", 2, 
+                 frame.getCursorSetCount());
+    assertEquals("frame reset another cursor", 2, 
+                 frame.getCursorResetCount());
+  }
+  /**
+   * This test checks the condition where the EventDispatchThread
+   * does not call EventQueue.getNextEvent() within TIMEOUT, 
+   * (presumably) because of thread contention, even when there 
+   * is not a dialog going down. Note that this case only actually 
+   * matters if there is a dialog currently up.
+   */
+  public void testDelayedGetNextEvent()
+                               throws InvocationTargetException, 
+                                      InterruptedException {
+    postEvent(frame, new DialogShowEvent(dialog, true, 0));
+    flushQueue();
+    hangOut(TIMEOUT + BUFFER);
+    eventQueue.setGetDelay(TIMEOUT + BUFFER);
+    postEvent(frame, new DelayEvent(TIMEOUT - BUFFER));
+    flushQueue();
+    hangOut(TIMEOUT + BUFFER);
+    assertEquals("frame got a cursor", 1, 
+                 frame.getCursorSetCount());
+    assertEquals("frame reset a cursor", 1, 
+                 frame.getCursorResetCount());
+    postEvent(dialog, new DialogShowEvent(dialog, false, 0));
+    flushQueue();
+    hangOut(TIMEOUT + BUFFER);
+    assertEquals("frame did not get another cursor", 1, 
+                 frame.getCursorSetCount());
+    assertEquals("frame did not reset another cursor", 1, 
+                 frame.getCursorResetCount());
+  }
+  public void testTwoDialogs() throws InvocationTargetException, 
+                                      InterruptedException {
+    TestRunnable testAndShow = new TestRunnable() {
+      public void run() {
+        testsPassed &= (1 == frame.getCursorSetCount());
+        testsPassed &= (0 == frame.getCursorResetCount());
+        dialog.setVisible(true);
+      }
+    };
+    postEvent(frame, 
+              new DelayEvent(TIMEOUT + BUFFER, testAndShow));
+    flushQueue();
+    assertTrue("Delay worked", testAndShow.getTestsPassed());
+    hangOut(TIMEOUT + BUFFER);
+    assertEquals("dialog never got cursor", 0, 
+                 dialog.getCursorSetCount());
+    assertEquals("dialog never reset cursor", 0, 
+                 dialog.getCursorResetCount());
+    assertEquals("frame never got another cursor", 1, 
+                 frame.getCursorSetCount());
+    assertEquals("frame reset cursor", 1, 
+                 frame.getCursorResetCount());
+    TestRunnable testAndShow2 = new TestRunnable() {
+      public void run() {
+        testsPassed &= (1 == dialog.getCursorSetCount());
+        testsPassed &= (0 == dialog.getCursorResetCount());
+        dialog2.setVisible(true);
+      }
+    };
+    postEvent(dialog, 
+              new DelayEvent(TIMEOUT + BUFFER, testAndShow2));
+    flushQueue();
+    assertTrue("Delay worked", testAndShow.getTestsPassed());
+    hangOut(TIMEOUT + BUFFER);
+    assertEquals("dialog2 never got cursor", 0, 
+                 dialog2.getCursorSetCount());
+    assertEquals("dialog2 never reset cursor", 0, 
+                 dialog2.getCursorResetCount());
+    assertEquals("dialog never got another cursor", 1, 
+                 dialog.getCursorSetCount());
+    assertEquals("dialog reset cursor", 1, 
+                 dialog.getCursorResetCount());
+    assertEquals("frame never got another cursor", 1, 
+                 frame.getCursorSetCount());
+    assertEquals("frame reset cursor", 1, 
+                 frame.getCursorResetCount());
+    postEvent(dialog2, new DelayEvent(TIMEOUT + BUFFER));
+    flushQueue();
+    hangOut(TIMEOUT + BUFFER);
+    assertEquals("dialog2 got cursor", 1, 
+                 dialog2.getCursorSetCount());
+    assertEquals("dialog2 reset cursor", 1, 
+                 dialog2.getCursorResetCount());
+    assertEquals("dialog never got another cursor", 1, 
+                 dialog.getCursorSetCount());
+    assertEquals("dialog reset cursor", 1, 
+                 dialog.getCursorResetCount());
+    assertEquals("frame never got another cursor", 1, 
+                 frame.getCursorSetCount());
+    assertEquals("frame reset cursor", 1, 
+                 frame.getCursorResetCount());
+    postEvent(dialog2, new DialogShowEvent(dialog2, false, 0));
+    flushQueue();
+    hangOut(TIMEOUT + BUFFER);
+    assertEquals("dialog2 never got another cursor", 1, 
+                 dialog2.getCursorSetCount());
+    assertEquals("dialog2 never reset another cursor", 1, 
+                 dialog2.getCursorResetCount());
+    assertEquals("dialog never got another cursor", 1, 
+                 dialog.getCursorSetCount());
+    assertEquals("dialog never reset another cursor", 1, 
+                 dialog.getCursorResetCount());
+    assertEquals("frame never got another cursor", 1, 
+                 frame.getCursorSetCount());
+    assertEquals("frame never reset another cursor", 1, 
+                 frame.getCursorResetCount());
+    postEvent(dialog, new DialogShowEvent(dialog, false, 0));
+    flushQueue();
+    hangOut(TIMEOUT + BUFFER);
+    assertEquals("dialog2 never got another cursor", 1, 
+                 dialog2.getCursorSetCount());
+    assertEquals("dialog2 never reset another cursor", 1, 
+                 dialog2.getCursorResetCount());
+    assertEquals("dialog never got another cursor", 1, 
+                 dialog.getCursorSetCount());
+    assertEquals("dialog never reset another cursor", 1, 
+                 dialog.getCursorResetCount());
+    assertEquals("frame never got another cursor", 1, 
+                 frame.getCursorSetCount());
+    assertEquals("frame never reset another cursor", 1, 
+                 frame.getCursorResetCount());
+  }
+  public void testCursorAndTwoDialogsAndCursor()
+    throws InvocationTargetException, InterruptedException {
+    postEvent(frame, new DialogShowEvent(dialog, true, 0));
+    flushQueue();
+    hangOut(TIMEOUT + BUFFER);
+    assertEquals("dialog never got cursor", 0, 
+                 dialog.getCursorSetCount());
+    assertEquals("dialog never reset cursor", 0, 
+                 dialog.getCursorResetCount());
+    assertEquals("frame never got cursor", 0, 
+                 frame.getCursorSetCount());
+    assertEquals("frame never reset cursor", 0, 
+                 frame.getCursorResetCount());
+    TestRunnable testAndShow = new TestRunnable() {
+      public void run() {
+        testsPassed &= (1 == dialog.getCursorSetCount());
+        testsPassed &= (0 == dialog.getCursorResetCount());
+        dialog2.setVisible(true);
+        hangOut(TIMEOUT + BUFFER);
+      }
+    };
+    postEvent(dialog, 
+              new DelayEvent(TIMEOUT + BUFFER, testAndShow));
+    flushQueue();
+    assertTrue("Delay worked", testAndShow.getTestsPassed());
+    hangOut(TIMEOUT + BUFFER);
+    assertEquals("dialog2 never got cursor", 0, 
+                 dialog2.getCursorSetCount());
+    assertEquals("dialog2 never reset cursor", 0, 
+                 dialog2.getCursorResetCount());
+    assertEquals("dialog never got another cursor", 1, 
+                 dialog.getCursorSetCount());
+    assertEquals("dialog reset cursor", 1, 
+                 dialog.getCursorResetCount());
+    assertEquals("frame never got cursor", 0, 
+                 frame.getCursorSetCount());
+    assertEquals("frame never reset cursor", 0, 
+                 frame.getCursorResetCount());
+    postEvent(dialog2, new DialogShowEvent(dialog2, false, 0));
+    flushQueue();
+    hangOut(TIMEOUT + BUFFER);
+    assertEquals("dialog2 never got cursor", 0, 
+                 dialog2.getCursorSetCount());
+    assertEquals("dialog2 never reset cursor", 0, 
+                 dialog2.getCursorResetCount());
+    assertEquals("dialog got another cursor", 2, 
+                 dialog.getCursorSetCount());
+    assertEquals("dialog reset another cursor", 2, 
+                 dialog.getCursorResetCount());
+    assertEquals("frame never got cursor", 0, 
+                 frame.getCursorSetCount());
+    assertEquals("frame never reset cursor", 0, 
+                 frame.getCursorResetCount());
+    postEvent(dialog, new DialogShowEvent(dialog, false, 0));
+    flushQueue();
+    hangOut(TIMEOUT + BUFFER);
+    assertEquals("dialog2 never got cursor", 0, 
+                 dialog2.getCursorSetCount());
+    assertEquals("dialog2 never reset cursor", 0, 
+                 dialog2.getCursorResetCount());
+    assertEquals("dialog never got another cursor", 2, 
+                 dialog.getCursorSetCount());
+    assertEquals("dialog never reset another cursor", 2, 
+                 dialog.getCursorResetCount());
+    assertEquals("frame never got cursor", 0, 
+                 frame.getCursorSetCount());
+    assertEquals("frame never reset cursor", 0, 
+                 frame.getCursorResetCount());
+  }
+
+  private class CursorReportingDialog extends Dialog {
+    private int cursorResetCount;
+    private int cursorSetCount;
+
+    public CursorReportingDialog(Frame owner) {
+      super(owner, true);
+      init();
+    }
+    public CursorReportingDialog(Dialog owner) {
+      super(owner, "", true);
+      init();
+    }
+
+    private void init() {
+      setCursor(BASE_CURSOR);
+      this.cursorSetCount = 0;
+      this.cursorResetCount = 0;
+    }
+    public int getCursorSetCount() {
+      return cursorSetCount;
+    }
+    public int getCursorResetCount() {
+      return cursorResetCount;
+    }
+    public void setCursor(Cursor cursor) {
+      super.setCursor(cursor);
+      if (BASE_CURSOR.equals(cursor)) {
+        cursorResetCount++;
+      } else {
+        cursorSetCount++;
+      }
+    }
+  }
+
+  private class CursorReportingFrame extends Frame {
+    private int cursorResetCount;
+    private int cursorSetCount;
+
+    public CursorReportingFrame() {
+      super();
+      setCursor(BASE_CURSOR);
+      cursorSetCount = 0;
+      cursorResetCount = 0;
+    }
+
+    public int getCursorSetCount() {
+      return cursorSetCount;
+    }
+    public int getCursorResetCount() {
+      return cursorResetCount;
+    }
+    public void setCursor(Cursor cursor) {
+      super.setCursor(cursor);
+      if (BASE_CURSOR.equals(cursor)) {
+        cursorResetCount++;
+      } else {
+        cursorSetCount++;
+      }
+    }
+  }
+
+  private abstract class TestRunnable implements Runnable {
+    protected boolean testsPassed = true;
+
+    public boolean getTestsPassed() {
+      return testsPassed;
+    }
+  }
+
+  private class DelayEvent implements Runnable {
+    private Runnable callback;
+    private int delay;
+
+    public DelayEvent(int delay) {
+      this(delay, null);
+    }
+    public DelayEvent(int delay, Runnable callback) {
+      this.delay = delay;
+      this.callback = callback;
+    }
+
+    public void run() {
+      try {
+        Thread.sleep(delay);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+      if (callback != null) {
+        callback.run();
+      }
+    }
+  }
+
+  private class DialogShowEvent implements Runnable {
+    private Dialog dialog;
+    private boolean visible;
+    private int delay;
+
+    public DialogShowEvent(Dialog dialog, boolean visible, 
+                           int delay) {
+      this.dialog = dialog;
+      this.visible = visible;
+      this.delay = delay;
+    }
+
+    public void run() {
+      dialog.setVisible(visible);
+      if (delay > 0) {
+        hangOut(delay);
+      }
+    }
+  }
+
+  private class TestWaitCursorEventQueue
+      extends WaitCursorEventQueue {
+    private int getDelay;
+
+    public TestWaitCursorEventQueue(int delay) {
+      super(delay);
+    }
+
+    public AWTEvent getNextEvent() throws InterruptedException {
+      if (getDelay > 0) {
+        hangOut(getDelay);
+        getDelay = 0;
+      }
+      return super.getNextEvent();
+    }
+    public void setGetDelay(int getDelay) {
+      this.getDelay = getDelay;
+    }
+  }
+}	


### PR DESCRIPTION
Trying to revert changes in OP-158 since now Java8 has been adopted for the project and so the underneath EventQueue management is changed.

Gui events deadlocks happening with Java6 should no longer happen (see OP-158 for more details).