### PR TITLE
Chore: remove redundant cast where cast is the same as the variable is defined

### DIFF
--- a/src/main/java/org/isf/admtype/gui/AdmissionTypeBrowser.java
+++ b/src/main/java/org/isf/admtype/gui/AdmissionTypeBrowser.java
@@ -170,8 +170,7 @@ public class AdmissionTypeBrowser extends ModalJFrame implements LaboratoryTypeL
 						return;
 					} else {
 						selectedrow = jTable.getSelectedRow();
-						admissionType = (AdmissionType) (((AdmissionTypeBrowserModel) model)
-								.getValueAt(selectedrow, -1));
+						admissionType = (AdmissionType) (model.getValueAt(selectedrow, -1));
 						AdmissionTypeBrowserEdit newrecord = new AdmissionTypeBrowserEdit(myFrame,admissionType, false);
 						newrecord.addAdmissionTypeListener(AdmissionTypeBrowser.this);
 						newrecord.setVisible(true);
@@ -219,8 +218,7 @@ public class AdmissionTypeBrowser extends ModalJFrame implements LaboratoryTypeL
 								JOptionPane.PLAIN_MESSAGE);
 						return;
 					} else {
-						AdmissionType dis = (AdmissionType) (((AdmissionTypeBrowserModel) model)
-								.getValueAt(jTable.getSelectedRow(), -1));
+						AdmissionType dis = (AdmissionType) (model.getValueAt(jTable.getSelectedRow(), -1));
 						int n = JOptionPane.showConfirmDialog(null,
 								MessageBundle.getMessage("angal.admtype.deleterow")+ " \""+dis.getDescription() + "\" ?",
 								MessageBundle.getMessage("angal.hospital"), JOptionPane.YES_NO_OPTION);

--- a/src/main/java/org/isf/dicomtype/gui/DicomTypeBrowser.java
+++ b/src/main/java/org/isf/dicomtype/gui/DicomTypeBrowser.java
@@ -168,8 +168,7 @@ public class DicomTypeBrowser extends ModalJFrame implements DicomTypeListener {
 						return;
 					} else {
 						selectedrow = jTable.getSelectedRow();
-						dicomType = (DicomType) (((DicomTypeBrowserModel) model)
-								.getValueAt(selectedrow, -1));
+						dicomType = (DicomType) (model.getValueAt(selectedrow, -1));
 						DicomTypeEdit newrecord = new DicomTypeEdit(myFrame,dicomType, false);
 						newrecord.addDicomTypeListener(DicomTypeBrowser.this);
 						newrecord.setVisible(true);
@@ -217,8 +216,7 @@ public class DicomTypeBrowser extends ModalJFrame implements DicomTypeListener {
 								JOptionPane.PLAIN_MESSAGE);
 						return;
 					} else {
-						DicomType dicomType = (DicomType) (((DicomTypeBrowserModel) model)
-								.getValueAt(jTable.getSelectedRow(), -1));
+						DicomType dicomType = (DicomType) (model.getValueAt(jTable.getSelectedRow(), -1));
                         int n = JOptionPane.showConfirmDialog(null,
                                 MessageBundle.getMessage("angal.dicomtype.deleterow") + " \" "+dicomType.getDicomTypeDescription() + "\" ?",
                                 MessageBundle.getMessage("angal.hospital"), JOptionPane.YES_NO_OPTION);

--- a/src/main/java/org/isf/disctype/gui/DischargeTypeBrowser.java
+++ b/src/main/java/org/isf/disctype/gui/DischargeTypeBrowser.java
@@ -170,8 +170,7 @@ public class DischargeTypeBrowser extends ModalJFrame implements DischargeTypeLi
 						return;
 					} else {
 						selectedrow = jTable.getSelectedRow();
-						dischargeType = (DischargeType) (((DischargeTypeBrowserModel) model)
-								.getValueAt(selectedrow, -1));
+						dischargeType = (DischargeType) (model.getValueAt(selectedrow, -1));
 						DischargeTypeBrowserEdit newrecord = new DischargeTypeBrowserEdit(myFrame,dischargeType, false);
 						newrecord.addDischargeTypeListener(DischargeTypeBrowser.this);
 						newrecord.setVisible(true);
@@ -219,8 +218,7 @@ public class DischargeTypeBrowser extends ModalJFrame implements DischargeTypeLi
 								JOptionPane.PLAIN_MESSAGE);
 						return;
 					} else {
-						DischargeType dis = (DischargeType) (((DischargeTypeBrowserModel) model)
-								.getValueAt(jTable.getSelectedRow(), -1));
+						DischargeType dis = (DischargeType) (model.getValueAt(jTable.getSelectedRow(), -1));
                         int n = JOptionPane.showConfirmDialog(null,
                                 MessageBundle.getMessage("angal.disctype.deleterow") + " \" "+dis.getDescription() + "\" ?",
                                 MessageBundle.getMessage("angal.hospital"), JOptionPane.YES_NO_OPTION);

--- a/src/main/java/org/isf/distype/gui/DiseaseTypeBrowser.java
+++ b/src/main/java/org/isf/distype/gui/DiseaseTypeBrowser.java
@@ -169,8 +169,7 @@ public class DiseaseTypeBrowser extends ModalJFrame implements DiseaseTypeListen
 						return;
 					} else {
 						selectedrow = jTable.getSelectedRow();
-						diseaseType = (DiseaseType) (((DiseaseTypeBrowserModel) model)
-								.getValueAt(selectedrow, -1));
+						diseaseType = (DiseaseType) (model.getValueAt(selectedrow, -1));
 						DiseaseTypeBrowserEdit newrecord = new DiseaseTypeBrowserEdit(myFrame,diseaseType, false);
 						newrecord.addDiseaseTypeListener(DiseaseTypeBrowser.this);
 						newrecord.setVisible(true);
@@ -218,8 +217,7 @@ public class DiseaseTypeBrowser extends ModalJFrame implements DiseaseTypeListen
 								JOptionPane.PLAIN_MESSAGE);
 						return;
 					} else {
-						DiseaseType dis = (DiseaseType) (((DiseaseTypeBrowserModel) model)
-								.getValueAt(jTable.getSelectedRow(), -1));
+						DiseaseType dis = (DiseaseType) (model.getValueAt(jTable.getSelectedRow(), -1));
 						int n = JOptionPane.showConfirmDialog(null,
 								MessageBundle.getMessage("angal.distype.deletediseasetype") + " \" "+dis.getDescription() + "\" ?",
 								MessageBundle.getMessage("angal.hospital"), JOptionPane.YES_NO_OPTION);

--- a/src/main/java/org/isf/dlvrrestype/gui/DeliveryResultTypeBrowser.java
+++ b/src/main/java/org/isf/dlvrrestype/gui/DeliveryResultTypeBrowser.java
@@ -171,8 +171,7 @@ public class DeliveryResultTypeBrowser extends ModalJFrame implements DeliveryRe
 						return;
 					} else {
 						selectedrow = jTable.getSelectedRow();
-						deliveryresultType = (DeliveryResultType) (((DeliveryResultTypeBrowserModel) model)
-								.getValueAt(selectedrow, -1));
+						deliveryresultType = (DeliveryResultType) (model.getValueAt(selectedrow, -1));
 						DeliveryResultTypeBrowserEdit newrecord = new DeliveryResultTypeBrowserEdit(myFrame,deliveryresultType, false);
 						newrecord.addDeliveryResultTypeListener(DeliveryResultTypeBrowser.this);
 						newrecord.setVisible(true);
@@ -220,8 +219,7 @@ public class DeliveryResultTypeBrowser extends ModalJFrame implements DeliveryRe
 								JOptionPane.PLAIN_MESSAGE);
 						return;
 					} else {
-						DeliveryResultType dis = (DeliveryResultType) (((DeliveryResultTypeBrowserModel) model)
-								.getValueAt(jTable.getSelectedRow(), -1));
+						DeliveryResultType dis = (DeliveryResultType) (model.getValueAt(jTable.getSelectedRow(), -1));
 						int n = JOptionPane.showConfirmDialog(null,
 								MessageBundle.getMessage("angal.dlvrrestype.deletedeliveryresulttype") + "\" " + dis.getDescription() + "\" ?",
 								MessageBundle.getMessage("angal.hospital"), JOptionPane.YES_NO_OPTION);

--- a/src/main/java/org/isf/dlvrtype/gui/DeliveryTypeBrowser.java
+++ b/src/main/java/org/isf/dlvrtype/gui/DeliveryTypeBrowser.java
@@ -169,8 +169,7 @@ public class DeliveryTypeBrowser extends ModalJFrame implements DeliveryTypeList
 						return;
 					} else {
 						selectedrow = jTable.getSelectedRow();
-						deliveryType = (DeliveryType) (((DeliveryTypeBrowserModel) model)
-								.getValueAt(selectedrow, -1));
+						deliveryType = (DeliveryType) (model.getValueAt(selectedrow, -1));
 						DeliveryTypeBrowserEdit newrecord = new DeliveryTypeBrowserEdit(myFrame,deliveryType, false);
 						newrecord.addDeliveryTypeListener(DeliveryTypeBrowser.this);
 						newrecord.setVisible(true);
@@ -218,8 +217,7 @@ public class DeliveryTypeBrowser extends ModalJFrame implements DeliveryTypeList
 								JOptionPane.PLAIN_MESSAGE);
 						return;
 					} else {
-						DeliveryType dis = (DeliveryType) (((DeliveryTypeBrowserModel) model)
-								.getValueAt(jTable.getSelectedRow(), -1));
+						DeliveryType dis = (DeliveryType) (model.getValueAt(jTable.getSelectedRow(), -1));
 						int n = JOptionPane.showConfirmDialog(null,
 								MessageBundle.getMessage("angal.dlvrtype.deletedeliverytype") + " \" "+dis.getDescription() + "\" ?",
 								MessageBundle.getMessage("angal.hospital"), JOptionPane.YES_NO_OPTION);

--- a/src/main/java/org/isf/exatype/gui/ExamTypeBrowser.java
+++ b/src/main/java/org/isf/exatype/gui/ExamTypeBrowser.java
@@ -176,8 +176,7 @@ public class ExamTypeBrowser extends ModalJFrame implements ExamTypeListener{
 						return;
 					} else {
 						selectedrow = jTable.getSelectedRow();
-						examType = (ExamType) (((ExamTypeBrowserModel) model)
-								.getValueAt(selectedrow, -1));
+						examType = (ExamType) (model.getValueAt(selectedrow, -1));
 						ExamTypeEdit newrecord = new ExamTypeEdit(myFrame,examType, false);
 						newrecord.addExamTypeListener(ExamTypeBrowser.this);
 						newrecord.setVisible(true);
@@ -225,8 +224,7 @@ public class ExamTypeBrowser extends ModalJFrame implements ExamTypeListener{
 								JOptionPane.PLAIN_MESSAGE);
 						return;
 					} else {
-						ExamType dis = (ExamType) (((ExamTypeBrowserModel) model)
-								.getValueAt(jTable.getSelectedRow(), -1));
+						ExamType dis = (ExamType) (model.getValueAt(jTable.getSelectedRow(), -1));
 						int n = JOptionPane.showConfirmDialog(null,
 								MessageBundle.getMessage("angal.exatype.deleteexamtype")+"\" "+dis.getDescription() + "\" ?",
 								MessageBundle.getMessage("angal.hospital"), JOptionPane.YES_NO_OPTION);

--- a/src/main/java/org/isf/lab/gui/LabBrowser.java
+++ b/src/main/java/org/isf/lab/gui/LabBrowser.java
@@ -248,7 +248,7 @@ public class LabBrowser extends ModalJFrame implements LabListener, LabEditListe
 							
 							if (ok != JOptionPane.YES_OPTION) return;
 						} else {
-							laboratory = (Laboratory) (((LabBrowsingModel) model).getValueAt(selectedrow, -1));
+							laboratory = (Laboratory) (model.getValueAt(selectedrow, -1));
 							labId = laboratory.getCode();
 						}
 					}
@@ -278,7 +278,7 @@ public class LabBrowser extends ModalJFrame implements LabListener, LabEditListe
 								JOptionPane.PLAIN_MESSAGE);
 						return;
 					} 
-					laboratory = (Laboratory) (((LabBrowsingModel) model).getValueAt(selectedrow, -1));
+					laboratory = (Laboratory) (model.getValueAt(selectedrow, -1));
 					if (GeneralData.LABEXTENDED) {
 						LabEditExtended editrecord = new LabEditExtended(myFrame, laboratory, false);
 						editrecord.addLabEditExtendedListener(LabBrowser.this);
@@ -347,8 +347,7 @@ public class LabBrowser extends ModalJFrame implements LabListener, LabEditListe
 								JOptionPane.PLAIN_MESSAGE);
 						return;
 					} else {
-						Laboratory lab = (Laboratory) (((LabBrowsingModel) model)
-								.getValueAt(jTable.getSelectedRow(), -1));
+						Laboratory lab = (Laboratory) (model.getValueAt(jTable.getSelectedRow(), -1));
 						
 						int n = JOptionPane.showConfirmDialog(LabBrowser.this,
 								getLabMessage(lab),

--- a/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
@@ -252,7 +252,7 @@ public class MovStockBrowser extends ModalJFrame {
 			public void actionPerformed(ActionEvent e) {
 				Medical medical = null;
 				if (movTable.getSelectedRow() > -1) {
-					Movement movement = (Movement) (((MovBrowserModel) model).getValueAt(movTable.getSelectedRow(), -1));
+					Movement movement = (Movement) (model.getValueAt(movTable.getSelectedRow(), -1));
 					medical = movement.getMedical();
 				}
 

--- a/src/main/java/org/isf/medstockmovtype/gui/MedicaldsrstockmovTypeBrowser.java
+++ b/src/main/java/org/isf/medstockmovtype/gui/MedicaldsrstockmovTypeBrowser.java
@@ -169,8 +169,7 @@ public class MedicaldsrstockmovTypeBrowser extends ModalJFrame implements Medica
 						return;
 					} else {
 						selectedrow = jTable.getSelectedRow();
-						medicaldsrstockmovType = (MovementType) (((MedicaldsrstockmovTypeBrowserModel) model)
-								.getValueAt(selectedrow, -1));
+						medicaldsrstockmovType = (MovementType) (model.getValueAt(selectedrow, -1));
 						MedicaldsrstockmovTypeBrowserEdit newrecord = new MedicaldsrstockmovTypeBrowserEdit(myFrame,medicaldsrstockmovType, false);
 						newrecord.addMedicaldsrstockmovTypeListener(MedicaldsrstockmovTypeBrowser.this);
 						newrecord.setVisible(true);
@@ -218,8 +217,7 @@ public class MedicaldsrstockmovTypeBrowser extends ModalJFrame implements Medica
 								JOptionPane.PLAIN_MESSAGE);
 						return;
 					} else {
-						MovementType dis = (MovementType) (((MedicaldsrstockmovTypeBrowserModel) model)
-								.getValueAt(jTable.getSelectedRow(), -1));
+						MovementType dis = (MovementType) (model.getValueAt(jTable.getSelectedRow(), -1));
 						int n = JOptionPane.showConfirmDialog(null,
 								MessageBundle.getMessage("angal.medstockmovtype.deletemovementtype")+" \" "+dis.getDescription() + "\" ?",
 								MessageBundle.getMessage("angal.hospital"), JOptionPane.YES_NO_OPTION);

--- a/src/main/java/org/isf/medtype/gui/MedicalTypeBrowser.java
+++ b/src/main/java/org/isf/medtype/gui/MedicalTypeBrowser.java
@@ -164,8 +164,7 @@ public class MedicalTypeBrowser extends ModalJFrame implements MedicalTypeListen
 						return;
 					} else {
 						selectedrow = jTable.getSelectedRow();
-						medicalType = (MedicalType) (((MedicalTypeBrowserModel) model)
-								.getValueAt(selectedrow, -1));
+						medicalType = (MedicalType) (model.getValueAt(selectedrow, -1));
 						MedicalTypeBrowserEdit newrecord = new MedicalTypeBrowserEdit(myFrame,medicalType, false);
 						newrecord.addMedicalTypeListener(MedicalTypeBrowser.this);
 						newrecord.setVisible(true);
@@ -215,8 +214,7 @@ public class MedicalTypeBrowser extends ModalJFrame implements MedicalTypeListen
 								JOptionPane.PLAIN_MESSAGE);
 						return;
 					} else {
-						MedicalType dis = (MedicalType) (((MedicalTypeBrowserModel) model)
-								.getValueAt(jTable.getSelectedRow(), -1));
+						MedicalType dis = (MedicalType) (model.getValueAt(jTable.getSelectedRow(), -1));
 						int n = JOptionPane.showConfirmDialog(null,
 								MessageBundle.getMessage("angal.medtype.deletemedicaltype")+" \" "+dis.getDescription() + "\" ?",
 								MessageBundle.getMessage("angal.hospital"), JOptionPane.YES_NO_OPTION);

--- a/src/main/java/org/isf/opd/gui/OpdBrowser.java
+++ b/src/main/java/org/isf/opd/gui/OpdBrowser.java
@@ -361,7 +361,7 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 						return;
 					} else {
 						selectedrow = jTable.getSelectedRow();
-						Opd opd = (Opd)(((OpdBrowsingModel) model).getValueAt(selectedrow, -1));
+						Opd opd = (Opd)(model.getValueAt(selectedrow, -1));
 						if (GeneralData.OPDEXTENDED) {
 							OpdEditExtended editrecord = new OpdEditExtended(myFrame, opd, false);
 							editrecord.addSurgeryListener(OpdBrowser.this);
@@ -415,8 +415,7 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 								JOptionPane.PLAIN_MESSAGE);
 						return;
 					} else {
-						Opd opd = (Opd) (((OpdBrowsingModel) model)
-								.getValueAt(jTable.getSelectedRow(), -1));
+						Opd opd = (Opd) (model.getValueAt(jTable.getSelectedRow(), -1));
 						String dt="[not specified]";
 						try {
 							final DateFormat currentDateFormat = DateFormat.getDateInstance(DateFormat.SHORT, Locale.ITALIAN);

--- a/src/main/java/org/isf/opd/gui/OpdEditExtended.java
+++ b/src/main/java/org/isf/opd/gui/OpdEditExtended.java
@@ -1832,7 +1832,7 @@ public class OpdEditExtended extends ModalJFrame implements
 	 * set a specific border+title+matte to a panel
 	 */
 	private JPanel setMyMatteBorder(JPanel c, String title) {
-		c.setBorder(new TitledBorder(new MatteBorder(1, 20, 1, 1, (Color) new Color(153, 180, 209)), title, TitledBorder.LEADING, TitledBorder.TOP, null, null));
+		c.setBorder(new TitledBorder(new MatteBorder(1, 20, 1, 1, new Color(153, 180, 209)), title, TitledBorder.LEADING, TitledBorder.TOP, null, null));
 		return c;
 	}
 

--- a/src/main/java/org/isf/operation/gui/OperationRowOpd.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowOpd.java
@@ -384,7 +384,7 @@ public class OperationRowOpd extends JPanel implements OpdEditExtended.SurgeryLi
 	}
 
 	public void addToForm() {
-		OperationRow opeRow = (OperationRow) oprowData.get(tableData.getSelectedRow());
+		OperationRow opeRow = oprowData.get(tableData.getSelectedRow());
 		/* ** for combo operation **** */
 		ArrayList<Operation> opeList = new ArrayList<Operation>();
 		try {

--- a/src/main/java/org/isf/opetype/gui/OperationTypeBrowser.java
+++ b/src/main/java/org/isf/opetype/gui/OperationTypeBrowser.java
@@ -170,8 +170,7 @@ public class OperationTypeBrowser extends ModalJFrame implements OperationTypeLi
 						return;
 					} else {
 						selectedrow = jTable.getSelectedRow();
-						operationType = (OperationType) (((OperationTypeBrowserModel) model)
-								.getValueAt(selectedrow, -1));
+						operationType = (OperationType) (model.getValueAt(selectedrow, -1));
 						OperationTypeEdit newrecord = new OperationTypeEdit(myFrame,operationType, false);
 						newrecord.addOperationTypeListener(OperationTypeBrowser.this);
 						newrecord.setVisible(true);
@@ -219,8 +218,7 @@ public class OperationTypeBrowser extends ModalJFrame implements OperationTypeLi
 								JOptionPane.PLAIN_MESSAGE);
 						return;
 					} else {
-						OperationType dis = (OperationType) (((OperationTypeBrowserModel) model)
-								.getValueAt(jTable.getSelectedRow(), -1));
+						OperationType dis = (OperationType) (model.getValueAt(jTable.getSelectedRow(), -1));
 						int n = JOptionPane.showConfirmDialog(null,
 								MessageBundle.getMessage("angal.opetype.deleteoperationtype")+" \" "+dis.getDescription() + "\" ?",
 								MessageBundle.getMessage("angal.hospital"), JOptionPane.YES_NO_OPTION);

--- a/src/main/java/org/isf/patient/gui/PatientBrowser.java
+++ b/src/main/java/org/isf/patient/gui/PatientBrowser.java
@@ -202,8 +202,7 @@ public class PatientBrowser extends ModalJFrame implements PatientListener{
 						return;
 					} else {
 						selectedrow = jTable.getSelectedRow();
-						patient = (Patient) (((PatientBrowserModel) model)
-								.getValueAt(selectedrow, -1));
+						patient = (Patient) (model.getValueAt(selectedrow, -1));
 						PatientInsert editrecord = new PatientInsert(PatientBrowser.this, patient, false);
 						editrecord.addPatientListener(PatientBrowser.this);
 						editrecord.setVisible(true);
@@ -252,8 +251,7 @@ public class PatientBrowser extends ModalJFrame implements PatientListener{
 								JOptionPane.PLAIN_MESSAGE);
 						return;
 					} else {
-						Patient pat = (Patient) (((PatientBrowserModel) model)
-								.getValueAt(jTable.getSelectedRow(), -1));
+						Patient pat = (Patient) (model.getValueAt(jTable.getSelectedRow(), -1));
 						int n = JOptionPane.showConfirmDialog(null,
 								MessageBundle.getMessage("angal.patient.deletepatient") + " \" "+pat.getName() + "\" ?",
 								MessageBundle.getMessage("angal.hospital"), JOptionPane.YES_NO_OPTION);

--- a/src/main/java/org/isf/patvac/gui/PatVacBrowser.java
+++ b/src/main/java/org/isf/patvac/gui/PatVacBrowser.java
@@ -243,7 +243,7 @@ public class PatVacBrowser extends ModalJFrame {
 					} 
 					
 					selectedrow = jTable.getSelectedRow();
-					patientVaccine = (PatientVaccine) (((PatVacBrowsingModel) model).getValueAt(selectedrow, -1));
+					patientVaccine = (PatientVaccine) (model.getValueAt(selectedrow, -1));
 
 					PatientVaccine last = new PatientVaccine(patientVaccine.getCode(),
 								                  patientVaccine.getProgr(),
@@ -288,7 +288,7 @@ public class PatVacBrowser extends ModalJFrame {
 						return;
 					} 
 					selectedrow = jTable.getSelectedRow();
-					patientVaccine = (PatientVaccine) (((PatVacBrowsingModel) model).getValueAt(selectedrow, -1));
+					patientVaccine = (PatientVaccine) (model.getValueAt(selectedrow, -1));
                     int n = JOptionPane.showConfirmDialog(null,
 								MessageBundle.getMessage("angal.patvac.deleteselectedpatientvaccinerow") +
 								"\n"+ MessageBundle.getMessage("angal.patvac.vaccinedate")+" = " +  dateFormat.format( patientVaccine.getVaccineDate().getTime()) +

--- a/src/main/java/org/isf/pregtreattype/gui/PregnantTreatmentTypeBrowser.java
+++ b/src/main/java/org/isf/pregtreattype/gui/PregnantTreatmentTypeBrowser.java
@@ -171,8 +171,7 @@ public class PregnantTreatmentTypeBrowser extends ModalJFrame implements Pregnan
 						return;
 					} else {
 						selectedrow = jTable.getSelectedRow();
-						pregnantTreatmentType = (PregnantTreatmentType) (((PregnantTreatmentTypeBrowserModel) model)
-								.getValueAt(selectedrow, -1));
+						pregnantTreatmentType = (PregnantTreatmentType) (model.getValueAt(selectedrow, -1));
 						PregnantTreatmentTypeEdit newrecord = new PregnantTreatmentTypeEdit(myFrame,pregnantTreatmentType, false);
 						newrecord.addPregnantTreatmentTypeListener(PregnantTreatmentTypeBrowser.this);
 						newrecord.setVisible(true);
@@ -221,8 +220,7 @@ public class PregnantTreatmentTypeBrowser extends ModalJFrame implements Pregnan
 								JOptionPane.PLAIN_MESSAGE);
 						return;
 					} else {
-						PregnantTreatmentType dis = (PregnantTreatmentType) (((PregnantTreatmentTypeBrowserModel) model)
-								.getValueAt(jTable.getSelectedRow(), -1));
+						PregnantTreatmentType dis = (PregnantTreatmentType) (model.getValueAt(jTable.getSelectedRow(), -1));
 						int n = JOptionPane.showConfirmDialog(null,
 								MessageBundle.getMessage("angal.preagtreattype.deletetreatmenttype") + " \" "+dis.getDescription() + "\" ?",
 								MessageBundle.getMessage("angal.hospital"), JOptionPane.YES_NO_OPTION);

--- a/src/main/java/org/isf/vactype/gui/VaccineTypeBrowser.java
+++ b/src/main/java/org/isf/vactype/gui/VaccineTypeBrowser.java
@@ -172,8 +172,7 @@ public class VaccineTypeBrowser extends ModalJFrame implements VaccineTypeListen
 						return;
 					} else {
 						selectedrow = jTable.getSelectedRow();
-						vaccineType = (VaccineType) (((VaccineTypeBrowserModel) model)
-								.getValueAt(selectedrow, -1));
+						vaccineType = (VaccineType) (model.getValueAt(selectedrow, -1));
 						VaccineTypeEdit editrecord = new VaccineTypeEdit(myFrame,vaccineType, false);
 						editrecord.addVaccineTypeListener(VaccineTypeBrowser.this);
 						editrecord.setVisible(true);
@@ -221,8 +220,7 @@ public class VaccineTypeBrowser extends ModalJFrame implements VaccineTypeListen
 								JOptionPane.PLAIN_MESSAGE);
 						return;
 					} else {
-						VaccineType dis = (VaccineType) (((VaccineTypeBrowserModel) model)
-								.getValueAt(jTable.getSelectedRow(), -1));
+						VaccineType dis = (VaccineType) (model.getValueAt(jTable.getSelectedRow(), -1));
 						int n = JOptionPane.showConfirmDialog(null,
 								MessageBundle.getMessage("angal.vactype.deletevaccinetype")+"\" "+dis.getDescription() + "\" ?",
 								MessageBundle.getMessage("angal.hospital"), JOptionPane.YES_NO_OPTION);

--- a/src/main/java/org/isf/xmpp/gui/CommunicationFrame.java
+++ b/src/main/java/org/isf/xmpp/gui/CommunicationFrame.java
@@ -285,7 +285,7 @@ public class CommunicationFrame extends AbstractCommunicationFrame {
 				if (returnVal == JFileChooser.APPROVE_OPTION) {
 					File file = fileChooser.getSelectedFile();
 					logger.debug("Selected file: {}", file.toString());
-					String receiver = (String) (((RosterEntry) buddyList.getSelectedValue()).getName());
+					String receiver = ((RosterEntry) buddyList.getSelectedValue()).getName();
 					logger.debug("Receiver: {}", receiver);
 					interaction.sendFile(receiver, file, null);
 				}
@@ -295,7 +295,7 @@ public class CommunicationFrame extends AbstractCommunicationFrame {
 
 			@Override
 			public void actionPerformed(ActionEvent arg0) {
-				String user_name = (String) ((RosterEntry) buddyList.getSelectedValue()).getName();
+				String user_name = ((RosterEntry) buddyList.getSelectedValue()).getName();
 				String info = null;
 				try {
 					info = userBrowsingManager.getUsrInfo(user_name);


### PR DESCRIPTION
I only removed the most **obvious** redundant type casts: where the cast matched the type of the object exactly (either defined that way or returned from a method call).   There are many redundant casts that are more subtle.