### PR TITLE
Chore: use contains() instead of indexOf()

### DIFF
--- a/src/main/java/org/isf/dicom/gui/FileDicomFilter.java
+++ b/src/main/java/org/isf/dicom/gui/FileDicomFilter.java
@@ -31,28 +31,23 @@ import javax.swing.filechooser.FileView;
  * @author Pietro Castellucci
  * @version 1.0.0
  */
-public class FileDicomFilter
-        extends javax.swing.filechooser.FileFilter
-{
+public class FileDicomFilter extends javax.swing.filechooser.FileFilter {
 
-    /**
-     * Whether the given file is accepted by this filter.
-     */
-    public boolean accept(File f)
-    {
+	/**
+	 * Whether the given file is accepted by this filter.
+	 */
+	public boolean accept(File f) {
+		return (f.getName().toLowerCase().endsWith(".dcm")
+				|| f.isDirectory()
+				|| (!f.getName().contains(".")));
+	}
 
-        return  (f.getName().toLowerCase().endsWith(".dcm") ||
-                 f.isDirectory()||
-                (f.getName().indexOf(".")<0));
-    }
-
-    /**
-     * The description of this filter. For example: "JPG and GIF Images"
-     *
-     * @see FileView#getName
-     */
-    public String getDescription()
-    {
-        return "DICOM Images";
-    }
+	/**
+	 * The description of this filter. For example: "JPG and GIF Images"
+	 *
+	 * @see FileView#getName
+	 */
+	public String getDescription() {
+		return "DICOM Images";
+	}
 }

--- a/src/main/java/org/isf/utils/jobjects/OhTableModel.java
+++ b/src/main/java/org/isf/utils/jobjects/OhTableModel.java
@@ -57,6 +57,7 @@ public class OhTableModel<T> implements TableModel{
 		}
 //		Collections.copy(this.filteredList, this.dataList);
 	}
+
 	public  OhTableModel(List<T> dataList, boolean allowSearchByCode) {
 		this.allowSearchByCode=allowSearchByCode;
 		this.dataList=dataList;
@@ -67,7 +68,6 @@ public class OhTableModel<T> implements TableModel{
 			this.filteredList.add(t);			
 		}
 	}
-	
 	
 	public T filter(String searchQuery) throws OHException{
 
@@ -87,7 +87,7 @@ public class OhTableModel<T> implements TableModel{
 				}
 				strItem = strItem.toLowerCase();
 				searchQuery = searchQuery.toLowerCase();
-				if (strItem.indexOf(searchQuery)>=0){
+				if (strItem.contains(searchQuery)) {
 					filteredList.add((T) object);
 				}
 			}
@@ -105,7 +105,7 @@ public class OhTableModel<T> implements TableModel{
 				
 				strItem = strItem.toLowerCase();
 				searchQuery = searchQuery.toLowerCase();
-				if (strItem.indexOf(searchQuery)>=0){
+				if (strItem.contains(searchQuery)) {
 					filteredList.add((T) object);
 				}
 			}
@@ -123,7 +123,7 @@ public class OhTableModel<T> implements TableModel{
 				
 				strItem = strItem.toLowerCase();
 				searchQuery = searchQuery.toLowerCase();
-				if (strItem.indexOf(searchQuery)>=0){
+				if (strItem.contains(searchQuery)) {
 					filteredList.add((T) object);
 				}
 			}
@@ -141,7 +141,7 @@ public class OhTableModel<T> implements TableModel{
 				
 				strItem = strItem.toLowerCase();
 				searchQuery = searchQuery.toLowerCase();
-				if (strItem.indexOf(searchQuery)>=0){
+				if (strItem.contains(searchQuery)) {
 					filteredList.add((T) object);
 				}
 			}
@@ -157,7 +157,6 @@ public class OhTableModel<T> implements TableModel{
 	@Override
 	public void addTableModelListener(TableModelListener l) {
 		// TODO Auto-generated method stub
-		
 	}
 
 	@Override
@@ -180,7 +179,6 @@ public class OhTableModel<T> implements TableModel{
 		case 1:
 			columnLabel= MessageBundle.getMessage("angal.common.description");
 			break;
-
 		default:
 			break;
 		}
@@ -246,7 +244,6 @@ public class OhTableModel<T> implements TableModel{
 	public T getObjectAt(int rowIndex){
 		if (rowIndex>=0 && rowIndex<this.filteredList.size()){
 			return this.filteredList.get(rowIndex);
-			
 		}
 		return null;
 	}
@@ -260,13 +257,11 @@ public class OhTableModel<T> implements TableModel{
 	@Override
 	public void removeTableModelListener(TableModelListener l) {
 		// TODO Auto-generated method stub
-		
 	}
 
 	@Override
 	public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
 		// TODO Auto-generated method stub
-		
 	}
 
 	public String getSearchQuery() {

--- a/src/main/java/org/isf/utils/jobjects/OhTableModelExam.java
+++ b/src/main/java/org/isf/utils/jobjects/OhTableModelExam.java
@@ -58,12 +58,11 @@ public class OhTableModelExam<T> implements TableModel{
 				String strItem = exam.getCode() + exam.getDescription();				
 				strItem = strItem.toLowerCase();
 				searchQuery = searchQuery.toLowerCase();
-				if (strItem.indexOf(searchQuery)>=0){
+				if (strItem.contains(searchQuery)) {
 					filteredList.add((Exam) object);
 				}
 			}
-
-		}	
+		}
 		return filteredList.size();
 	}
 	
@@ -71,7 +70,6 @@ public class OhTableModelExam<T> implements TableModel{
 	@Override
 	public void addTableModelListener(TableModelListener l) {
 		// TODO Auto-generated method stub
-		
 	}
 
 	@Override
@@ -94,7 +92,6 @@ public class OhTableModelExam<T> implements TableModel{
 		case 1:
 			columnLabel= MessageBundle.getMessage("angal.common.description");
 			break;
-
 		default:
 			break;
 		}

--- a/src/main/java/org/isf/utils/jobjects/OhTableOperationModel.java
+++ b/src/main/java/org/isf/utils/jobjects/OhTableOperationModel.java
@@ -65,7 +65,7 @@ public class OhTableOperationModel<T> implements TableModel{
 				String strItem=price.getOperation().getCode()+price.getOpResult();
 				strItem = strItem.toLowerCase();
 				searchQuery = searchQuery.toLowerCase();
-				if (strItem.indexOf(searchQuery)>=0){
+				if (strItem.contains(searchQuery)) {
 					filteredList.add((T) object);
 				}
 			}
@@ -76,7 +76,6 @@ public class OhTableOperationModel<T> implements TableModel{
 	@Override
 	public void addTableModelListener(TableModelListener l) {
 		// TODO Auto-generated method stub
-		
 	}
 
 	@Override
@@ -144,7 +143,6 @@ public class OhTableOperationModel<T> implements TableModel{
 					catch (Exception ex){
 						value=opdObj.getOpDate().getTime().toString();
 					}
-					
 					break;
 				case 1:
                     Operation ope = null;
@@ -182,13 +180,11 @@ public class OhTableOperationModel<T> implements TableModel{
 	@Override
 	public void removeTableModelListener(TableModelListener l) {
 		// TODO Auto-generated method stub
-		
 	}
 
 	@Override
 	public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
 		// TODO Auto-generated method stub
-		
 	}
 
 }


### PR DESCRIPTION
Found with IntelliJ Analyze migration aids inspection.

Use `contains()` instead of `indexOf()`; if nothing else it is more descriptive of the purpose of the test.

I got carried away and did some "reformatting" in the process.