### PR TITLE
fix: workaround dcm4che repo service disruption

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,17 @@
 		    <groupId>net.sf.jasperreports</groupId>
 		    <artifactId>jasperreports</artifactId>
 		    <version>6.16.0</version>
+		    <exclusions>
+		    	<exclusion>
+		    		<groupId>com.lowagie</groupId>
+		    		<artifactId>itext</artifactId>
+		    	</exclusion>
+		    </exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.lowagie</groupId>
+			<artifactId>itext</artifactId>
+			<version>2.1.7</version>
 		</dependency>
 		<dependency>
 		    <groupId>net.sf.jasperreports</groupId>
@@ -266,16 +277,6 @@
 		    <groupId>org.rxtx</groupId>
 		    <artifactId>rxtx</artifactId>
 		    <version>2.1.7</version>
-		</dependency>
-		<dependency>
-			<groupId>dcm4che</groupId>
-			<artifactId>dcm4che-core</artifactId>
-			<version>2.0.26</version>
-		</dependency>
-		<dependency>
-			<groupId>dcm4che</groupId>
-			<artifactId>dcm4che-imageio</artifactId>
-			<version>2.0.26</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -327,14 +328,13 @@
 			<artifactId>jgoodies-looks</artifactId>
 			<version>2.7.0</version>
 		</dependency>
-
 		<dependency>
 			<groupId>com.jgoodies</groupId>
 			<artifactId>jgoodies-validation</artifactId>
 			<version>2.5.1</version>
 		</dependency>
   </dependencies>
-  <repositories>
+  <!-- <repositories>
         <repository>
                 <id>dcm4che</id>
                 <name>Dcm4Che Repository</name>
@@ -343,5 +343,5 @@
                     <enabled>false</enabled>
                 </snapshots>
         </repository>
-	</repositories>
+	</repositories> -->
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 							<goal>copy-resources</goal>
 						</goals>
 						<configuration>
-							<outputDirectory>${basedir}/target/OpenHospital20/rsc</outputDirectory>
+							<outputDirectory>${project.basedir}/target/OpenHospital20/rsc</outputDirectory>
 							<resources>
 								<resource>
 									<directory>src/main/resources</directory>
@@ -59,7 +59,7 @@
 							<goal>copy-resources</goal>
 						</goals>
 						<configuration>
-							<outputDirectory>${basedir}/target/OpenHospital20/lib</outputDirectory>
+							<outputDirectory>${project.basedir}/target/OpenHospital20/lib</outputDirectory>
 							<resources>
 								<resource>
 									<directory>lib</directory>
@@ -74,7 +74,7 @@
 							<goal>copy-resources</goal>
 						</goals>
 						<configuration>
-							<outputDirectory>${basedir}/target/OpenHospital20/lib/native</outputDirectory>
+							<outputDirectory>${project.basedir}/target/OpenHospital20/lib/native</outputDirectory>
 							<resources>
 								<resource>
 									<directory>lib/native</directory>
@@ -92,7 +92,7 @@
 							<goal>copy-resources</goal>
 						</goals>
 						<configuration>
-							<outputDirectory>${basedir}/target/OpenHospital20/bundle</outputDirectory>
+							<outputDirectory>${project.basedir}/target/OpenHospital20/bundle</outputDirectory>
 							<resources>
 								<resource>
 									<directory>bundle</directory>
@@ -101,7 +101,7 @@
 						</configuration>
 					</execution>
 					<!-- <execution> <id>copy-doc</id> <phase>validate</phase> <goals> <goal>copy-resources</goal> 
-						</goals> <configuration> <outputDirectory>${basedir}/target/OpenHospital20/doc</outputDirectory> 
+						</goals> <configuration> <outputDirectory>${project.basedir}/target/OpenHospital20/doc</outputDirectory> 
 						<resources> <resource> <directory>doc</directory> </resource> </resources> 
 						</configuration> </execution> -->
 					<execution>
@@ -111,7 +111,7 @@
 							<goal>copy-resources</goal>
 						</goals>
 						<configuration>
-							<outputDirectory>${basedir}/target/OpenHospital20/rpt</outputDirectory>
+							<outputDirectory>${project.basedir}/target/OpenHospital20/rpt</outputDirectory>
 							<resources>
 								<resource>
 									<directory>rpt</directory>
@@ -126,10 +126,10 @@
 							<goal>copy-resources</goal>
 						</goals>
 						<configuration>
-							<outputDirectory>${basedir}/target/OpenHospital20</outputDirectory>
+							<outputDirectory>${project.basedir}/target/OpenHospital20</outputDirectory>
 							<resources>
 								<resource>
-									<directory>${basedir}</directory>
+									<directory>${project.basedir}</directory>
 									<include>oh.ico</include>
 									<include>README.md</include>
 									<include>startup.cmd</include>


### PR DESCRIPTION
Temporary workaround for dcm4che servers disruption.

These disruptions are frequent. OP-347 is aimed to permanently solve this kind of issues by getting rid of dcm4che libraries.

**NOTE**: delete/move previous downloaded libs in your .m2 local repository

**WARNING**: This PR is linked to https://github.com/informatici/openhospital-core/pull/359 and so checks will fail if not merged first. Test it locally. 