### PR TITLE
Chore: information is plural

### DIFF
--- a/rsc/txtPrinter.properties
+++ b/rsc/txtPrinter.properties
@@ -1,4 +1,4 @@
-# This file contains text printing informations
+# This file contains text printing information
 # MODE = TXT, PDF or ZPL
 USE_DEFAULT_PRINTER=yes
 PRINT_AS_PAID=no

--- a/rsc/xmpp.properties
+++ b/rsc/xmpp.properties
@@ -1,3 +1,3 @@
-# This file contains Xmpp Server informations
+# This file contains Xmpp Server information
 DOMAIN=127.0.0.1
 PORT=5222


### PR DESCRIPTION
`information` is plural; no need to add `s`.

There is another [PR](https://github.com/informatici/openhospital-doc/pull/37) that fixed the documentation.