### PR TITLE
OP-497 Standardized on slf4j.Logger

### DIFF
--- a/src/main/java/org/isf/lab/gui/LabNew.java
+++ b/src/main/java/org/isf/lab/gui/LabNew.java
@@ -35,8 +35,6 @@ import java.util.ArrayList;
 import java.util.EventListener;
 import java.util.GregorianCalendar;
 import java.util.Locale;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
@@ -86,8 +84,12 @@ import org.isf.utils.exception.gui.OHServiceExceptionUtil;
 import org.isf.utils.jobjects.CustomJDateChooser;
 import org.isf.utils.jobjects.OhTableModelExam;
 import org.isf.utils.time.RememberDates;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LabNew extends JDialog implements SelectionListener {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(LabNew.class);
 
 //LISTENER INTERFACE --------------------------------------------------------
 	private EventListenerList labListener = new EventListenerList();
@@ -422,7 +424,7 @@ public class LabNew extends JDialog implements SelectionListener {
 					exaRowArray = examRowManager.getExamRowByExamCode(selectedExam.getCode());
 				} catch (OHServiceException ex) {
 					exaRowArray = null;
-					Logger.getLogger(LabNew.class.getName()).log(Level.SEVERE, null, ex);
+					LOGGER.error(ex.getMessage(), ex);
 				}
 				if (exaRowArray != null) {
 					for (ExamRow exaRow : exaRowArray) {
@@ -465,7 +467,7 @@ public class LabNew extends JDialog implements SelectionListener {
 					exaRowArray = examRowManager.getExamRowByExamCode(selectedExam.getCode());
 				} catch (OHServiceException ex) {
 					exaRowArray = null;
-					Logger.getLogger(LabNew.class.getName()).log(Level.SEVERE, null, ex);
+	                LOGGER.error(ex.getMessage(), ex);
 				}
                 if (exaRowArray != null) {
 	                for (ExamRow exaRow : exaRowArray) {

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacyNew.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacyNew.java
@@ -35,8 +35,6 @@ import java.util.Comparator;
 import java.util.EventListener;
 import java.util.GregorianCalendar;
 import java.util.Optional;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
@@ -75,8 +73,12 @@ import org.isf.utils.exception.gui.OHServiceExceptionUtil;
 import org.isf.utils.time.TimeTools;
 import org.isf.ward.manager.WardBrowserManager;
 import org.isf.ward.model.Ward;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WardPharmacyNew extends JDialog implements SelectionListener {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(WardPharmacyNew.class);
 
 //LISTENER INTERFACE --------------------------------------------------------
     private EventListenerList movementWardListeners = new EventListenerList();
@@ -939,7 +941,7 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
                         try {
                             wardList = wbm.getWards();
                         } catch (OHServiceException ex) {
-                            Logger.getLogger(WardPharmacyNew.class.getName()).log(Level.SEVERE, null, ex);
+	                        LOGGER.error(ex.getMessage(), ex);
                         }
 			wardBox.addItem("");
 			if (wardList != null) {

--- a/src/main/java/org/isf/operation/gui/OperationRowAdm.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowAdm.java
@@ -37,8 +37,6 @@ import java.util.ArrayList;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Locale;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -68,6 +66,8 @@ import org.isf.utils.jobjects.OhDefaultCellRenderer;
 import org.isf.utils.jobjects.OhTableOperationModel;
 import org.isf.utils.jobjects.VoFloatTextField;
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author hp
@@ -75,6 +75,9 @@ import org.joda.time.DateTime;
 public class OperationRowAdm extends JPanel implements AdmissionBrowser.AdmissionListener {
 
 	private static final long serialVersionUID = 1L;
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(OperationRowAdm.class);
+
 	private JLabel labelDate;
 	private JTextField textFieldUnit;
 	private CustomJDateChooser textDate;
@@ -309,7 +312,7 @@ public class OperationRowAdm extends JPanel implements AdmissionBrowser.Admissio
 		try {
 			opeList.addAll(opeManager.getOperationAdm());
 		} catch (OHServiceException ex) {
-			Logger.getLogger(OperationRowAdm.class.getName()).log(Level.SEVERE, null, ex);
+			LOGGER.error(ex.getMessage(), ex);
 		}
 		comboOpe.addItem(null);
 		for (org.isf.operation.model.Operation elem : opeList) {

--- a/src/main/java/org/isf/operation/gui/OperationRowOpd.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowOpd.java
@@ -37,8 +37,6 @@ import java.util.ArrayList;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Locale;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -67,12 +65,17 @@ import org.isf.utils.jobjects.OhDefaultCellRenderer;
 import org.isf.utils.jobjects.OhTableOperationModel;
 import org.isf.utils.jobjects.VoFloatTextField;
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.toedter.calendar.JDateChooser;
 
 public class OperationRowOpd extends JPanel implements OpdEditExtended.SurgeryListener{
 
 	private static final long serialVersionUID = 1L;
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(OperationRowOpd.class);
+
 	private JLabel labelDate;
 	private JTextField textFieldUnit;
 	private JDateChooser textDate;
@@ -307,7 +310,7 @@ public class OperationRowOpd extends JPanel implements OpdEditExtended.SurgeryLi
 		try {
 			opeList.addAll(opeManager.getOperationOpd());
 		} catch (OHServiceException ex) {
-			Logger.getLogger(OperationRowAdm.class.getName()).log(Level.SEVERE, null, ex);
+			LOGGER.error(ex.getMessage(), ex);
 		}
 		comboOpe.addItem(null);
 		for (org.isf.operation.model.Operation elem : opeList) {


### PR DESCRIPTION
See OP-497.

Note the spacing appears to be inconsistent and that is because these files use multiple formatting techniques.  A reformat of the entire file to match standards is the real answer.