### PR TITLE
Chore: fix bad quote location

### DIFF
--- a/src/main/java/org/isf/exatype/gui/ExamTypeEdit.java
+++ b/src/main/java/org/isf/exatype/gui/ExamTypeEdit.java
@@ -297,7 +297,7 @@ public class ExamTypeEdit extends JDialog {
 	 */
 	private JLabel getJCodeLabel() {
 		if (jCodeLabel == null) {
-			jCodeLabel = new JLabel(MessageBundle.formatMessage("angal.common.codemaxchars.fmt.txt, 2"));
+			jCodeLabel = new JLabel(MessageBundle.formatMessage("angal.common.codemaxchars.fmt.txt", 2));
 		}
 		return jCodeLabel;
 	}


### PR DESCRIPTION
When checking for strings that should be in a resource bundle, found this misplaced quote.