### PR TITLE
Chore: fix the comparison

### DIFF
--- a/src/main/java/org/isf/dicom/gui/ShowPreLoadDialog.java
+++ b/src/main/java/org/isf/dicom/gui/ShowPreLoadDialog.java
@@ -90,7 +90,7 @@ class ShowPreLoadDialog extends JDialog {
 
 		public ShowPreLoadDialog(JFrame owner, int numfiles, FileDicom fileDicom, List<Date> dates) {
 			super(owner, true);
-			if (numfiles > 0) 
+			if (numfiles > 1)
 				setTitle("Loading multiple images: " + numfiles);
 			else
 				setTitle("Load image");


### PR DESCRIPTION
Comparing to zero means that the title always read, Loading multiple images: ", even when there was a single image.