### PR TITLE
OP-544 fix some of the JRadioButton shortcut keys

### DIFF
--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -386,6 +386,10 @@ angal.medicalstockward.chooselot.btn                                            
 angal.medicalstockward.chooselot.btn.key                                         = C
 angal.opd.examination.btn                                                        = Examination
 angal.opd.examination.btn.key                                                    = E
+angal.operation.major.btn                                                        = Major
+angal.operation.major.btn.key                                                    = A
+angal.operation.minor.btn                                                        = Minor
+angal.operation.minor.btn.key                                                    = M
 angal.operationrowlist.add.btn                                                   = Add
 angal.operationrowlist.add.btn.key                                               = A
 angal.priceslist.copy.btn                                                        = Copy
@@ -412,6 +416,10 @@ angal.therapy.edittherapy.btn                                                   
 angal.therapy.edittherapy.btn.key                                                = E
 angal.therapy.removetherapy.btn                                                  = Remove Therapy
 angal.therapy.removetherapy.btn.key                                              = R
+angal.patient.male.btn                                                           = Male
+angal.patient.male.btn.key                                                       = M
+angal.patient.female.btn                                                         = Female
+angal.patient.female.btn.key                                                     = E
 angal.patientphoto.file.btn                                                      = File
 angal.patientphoto.file.btn.key                                                  = F
 angal.patientphoto.newphoto.btn                                                  = New Photo
@@ -1328,8 +1336,6 @@ angal.medicalstockwardedit.title                                                
 angal.medicalstockwardedit.tooltip.associateapatientwiththismovement             = Associate a Patient with this movement
 angal.medicalstockwardedit.tooltip.removepatientassociationwiththismovement      = Remove Patient association with this movement
 angal.medstockmovtype.type                                                       = Type
-angal.operation.major                                                            = Major
-angal.operation.minor                                                            = Minor
 angal.operation.operationalreadypresent                                          = Operation already present
 angal.operation.operationcontext                                                 = Context
 angal.operation.selecttype                                                       = Select type

--- a/src/main/java/org/isf/operation/gui/OperationEdit.java
+++ b/src/main/java/org/isf/operation/gui/OperationEdit.java
@@ -366,8 +366,8 @@ public class OperationEdit extends JDialog {
 			radioButtonPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
 			if (major == null) {
 
-				major = getRadioButton(MessageBundle.getMessage("angal.operation.major"), 'a', true); //$NON-NLS-1$
-				minor = getRadioButton(MessageBundle.getMessage("angal.operation.minor"), 'm', true); //$NON-NLS-1$
+				major = getRadioButton("angal.operation.major.btn", "angal.operation.major.btn.key", true);
+				minor = getRadioButton("angal.operation.minor.btn", "angal.operation.minor.btn.key", true);
 
 				ButtonGroup radioGroup = new ButtonGroup();
 
@@ -392,9 +392,10 @@ public class OperationEdit extends JDialog {
 		return radioButtonPanel;
 	}
 
-	private JRadioButton getRadioButton(String label, char mn, boolean active) {
+	private JRadioButton getRadioButton(String text, String key, boolean active) {
+		String label = MessageBundle.getMessage(text);
 		JRadioButton rb = new JRadioButton(label);
-		rb.setMnemonic(KeyEvent.VK_A + (mn - 'A'));
+		rb.setMnemonic(MessageBundle.getMnemonic(key));
 		rb.setSelected(active);
 		rb.setName(label);
 		return rb;

--- a/src/main/java/org/isf/patient/gui/PatientInsert.java
+++ b/src/main/java/org/isf/patient/gui/PatientInsert.java
@@ -525,29 +525,29 @@ public class PatientInsert extends JDialog implements ActionListener{
 	 * @return javax.swing.JPanel	
 	 */
 	private JPanel getSexPanel() {
-		if (sexPanel == null) {			
+		if (sexPanel == null) {
 			sexPanel = new JPanel();
-			sexGroup=new ButtonGroup();
-			JRadioButton radiom= new JRadioButton(MessageBundle.getMessage("angal.common.male.txt"));
-			JRadioButton radiof= new JRadioButton(MessageBundle.getMessage("angal.common.female.txt"));
-			radiom.setMnemonic(KeyEvent.VK_A+('M'-'A')); 
-			radiof.setMnemonic(KeyEvent.VK_A+('F'-'A')); 
+			sexGroup = new ButtonGroup();
+			JRadioButton radiom = new JRadioButton(MessageBundle.getMessage("angal.patient.male.btn"));
+			radiom.setMnemonic(MessageBundle.getMnemonic("angal.patient.male.btn.key"));
+			JRadioButton radiof = new JRadioButton(MessageBundle.getMessage("angal.patient.female.btn"));
+			radiof.setMnemonic(MessageBundle.getMnemonic("angal.patient.female.btn.key"));
 			sexPanel.add(getJSexLabelPanel(), null);
 			sexPanel.add(radiom, radiom.getName());
-			if (insert){
+			if (insert) {
 				radiom.setSelected(true);
-			}
-			else{
-				if (patient.getSex()=='F')
+			} else {
+				if (patient.getSex() == 'F') {
 					radiof.setSelected(true);
-				else radiom.setSelected(true);
-			}			
+				} else {
+					radiom.setSelected(true);
+				}
+			}
 			radiom.addActionListener(this);
 			radiof.addActionListener(this);
 			sexGroup.add(radiom);
 			sexGroup.add(radiof);
 			sexPanel.add(radiof);
-			
 		}
 		return sexPanel;
 	}

--- a/src/main/java/org/isf/patient/gui/PatientInsertExtended.java
+++ b/src/main/java/org/isf/patient/gui/PatientInsertExtended.java
@@ -899,10 +899,10 @@ public class PatientInsertExtended extends JDialog {
 		if (jSexPanel == null) {
 			jSexPanel = new JPanel();
 			sexGroup = new ButtonGroup();
-			radiom = new JRadioButton(MessageBundle.getMessage("angal.common.male.txt"));
-			radiof = new JRadioButton(MessageBundle.getMessage("angal.common.female.txt"));
-			radiom.setMnemonic(KeyEvent.VK_A + ('M' - 'A'));
-			radiof.setMnemonic(KeyEvent.VK_A + ('F' - 'A'));
+			JRadioButton radiom = new JRadioButton(MessageBundle.getMessage("angal.patient.male.btn"));
+			radiom.setMnemonic(MessageBundle.getMnemonic("angal.patient.male.btn.key"));
+			JRadioButton radiof = new JRadioButton(MessageBundle.getMessage("angal.patient.female.btn"));
+			radiof.setMnemonic(MessageBundle.getMnemonic("angal.patient.female.btn.key"));
 			jSexPanel.add(getJSexLabelPanel(), null);
 			jSexPanel.add(radiom, radiom.getName());
 			if (!insert) {


### PR DESCRIPTION
This fixes `OperationEdit` and `PatientInsert` and only starts to touch on` PatientInsertExtended` which still has duplicated shortcut key issues.

See OP-544.