### PR TITLE
Chore: remove unneeded colon after Required Fields msg

### DIFF
--- a/src/main/java/org/isf/supplier/gui/SupplierEdit.java
+++ b/src/main/java/org/isf/supplier/gui/SupplierEdit.java
@@ -184,7 +184,7 @@ public class SupplierEdit extends JDialog {
 			emailLabel = new JLabel(MessageBundle.getMessage("angal.supplier.email") + ':');
 			noteLabel = new JLabel(MessageBundle.getMessage("angal.supplier.note") + ':');
 			isDeletedLabel = new JLabel(MessageBundle.getMessage("angal.supplier.deleted") + ':');
-			requiredLabel= new JLabel(MessageBundle.getMessage("angal.supplier.requiredfields") + ':');
+			requiredLabel= new JLabel(MessageBundle.getMessage("angal.supplier.requiredfields"));
 			dataPanel = new JPanel(new SpringLayout());
 			dataPanel.add(idLabel);
 			dataPanel.add(getIdTextField());


### PR DESCRIPTION
Got carried away with search/replace adding the colons; the Required Field message doesn't need it