### PR TITLE
Chore: put project description all on one line so it doesn't wrap in header comment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,8 +220,7 @@
 						<project.inceptionYear>2006</project.inceptionYear>
 						<project.name>Open Hospital</project.name>
 						<project.url>www.open-hospital.org</project.url>
-						<project.description>Open Hospital is a free and open source
-							software for healthcare data management.</project.description>
+						<project.description>Open Hospital is a free and open source software for healthcare data management.</project.description>
 					</properties>
 				</configuration>
 				<dependencies>


### PR DESCRIPTION
Fixing this will make all the license headers look the same.