### PR TITLE
OP-630: fixing rendering issue on Therapy dialog

### DIFF
--- a/src/main/java/org/isf/therapy/gui/TherapyEntryForm.java
+++ b/src/main/java/org/isf/therapy/gui/TherapyEntryForm.java
@@ -165,6 +165,7 @@ public class TherapyEntryForm extends JDialog {
 			radioButtonSet.get(0).setSelected(true);
 			endDateLabel.setText(dateFormat.format(new Date()));
 		}
+		this.pack();
 	}
 
 	private void initComponents() {

--- a/src/main/java/org/isf/visits/gui/VisitView.java
+++ b/src/main/java/org/isf/visits/gui/VisitView.java
@@ -161,6 +161,7 @@ public class VisitView extends ModalJFrame {
 		setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 		setLocationRelativeTo(null);
 		addWindowListener(new FreeMemoryAdapter());
+		this.pack();
 	}
 
 	public VisitView() {
@@ -811,6 +812,9 @@ public class VisitView extends ModalJFrame {
 		getAddVisitFirstButton().setVisible(show);
 		getVisitDateChooserPanel().setVisible(show);
 		getTodayVisit().setVisible(show);
+
+		// call repack, as we are showing more components
+		this.pack();
 	}
 
 	public Ward getWard() {


### PR DESCRIPTION
Need to call pack() on the dialog before showing it, especially when we are adding components to the panel / dialog.
This will cause the window to be calculated & painted properly. Otherwise some components wont be shown properly.