### PR TITLE
Chore: use date constant strings in org.isf.utils.Constants instead of strings or local constants

### DIFF
--- a/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
@@ -23,6 +23,7 @@ package org.isf.medicalstock.gui;
 
 import static org.isf.utils.Constants.DATE_FORMAT_DD_MM_YY;
 import static org.isf.utils.Constants.DATE_FORMAT_DD_MM_YY_HH_MM;
+import static org.isf.utils.Constants.DATE_FORMAT_YYYYMMDD;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -1009,8 +1010,8 @@ public class MovStockBrowser extends ModalJFrame {
 				!wardBox.getSelectedItem().equals(MessageBundle.getMessage("angal.common.all.txt"))) {
 			filename.append('_').append(wardBox.getSelectedItem());
 		}
-		filename.append('_').append(TimeTools.formatDateTime(movDateFrom.getCompleteDate(), "yyyyMMdd"))
-				.append('_').append(TimeTools.formatDateTime(movDateTo.getCompleteDate(), "yyyyMMdd"));
+		filename.append('_').append(TimeTools.formatDateTime(movDateFrom.getCompleteDate(), DATE_FORMAT_YYYYMMDD))
+				.append('_').append(TimeTools.formatDateTime(movDateTo.getCompleteDate(), DATE_FORMAT_YYYYMMDD));
 		return filename.toString();
 	}
 

--- a/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
@@ -22,6 +22,7 @@
 package org.isf.medicalstock.gui;
 
 import static org.isf.utils.Constants.DATE_FORMAT_DD_MM_YYYY;
+import static org.isf.utils.Constants.DATE_FORMAT_DD_MM_YYYY_HH_MM_SS;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -93,7 +94,6 @@ public class MovStockMultipleCharging extends JDialog {
 	private static final long serialVersionUID = 1L;
 	private static final Logger LOGGER = LoggerFactory.getLogger(MovStockMultipleCharging.class);
 
-	private static final String DATE_FORMAT_DD_MM_YYYY_HH_MM_SS = "dd/MM/yyyy HH:mm:ss"; //$NON-NLS-1$
 	private static final int CODE_COLUMN_WIDTH = 100;
 	private static final int UNITS = 0;
 	private static final int PACKETS = 1;

--- a/src/main/java/org/isf/medicalstock/gui/MovStockMultipleDischarging.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockMultipleDischarging.java
@@ -22,6 +22,7 @@
 package org.isf.medicalstock.gui;
 
 import static org.isf.utils.Constants.DATE_FORMAT_DD_MM_YYYY;
+import static org.isf.utils.Constants.DATE_FORMAT_DD_MM_YYYY_HH_MM_SS;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -89,7 +90,6 @@ import org.isf.xmpp.manager.Interaction;
 public class MovStockMultipleDischarging extends JDialog {
 
 	private static final long serialVersionUID = 1L;
-	private static final String DATE_FORMAT_DD_MM_YYYY_HH_MM_SS = "dd/MM/yyyy HH:mm:ss"; //$NON-NLS-1$
 	private static final int CODE_COLUMN_WIDTH = 100;
 	private static final int UNITS = 0;
 	private static final int PACKETS = 1;

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
@@ -24,6 +24,7 @@ package org.isf.medicalstockward.gui;
 import static org.isf.utils.Constants.DATE_FORMAT_DD_MM_YY;
 import static org.isf.utils.Constants.DATE_FORMAT_DD_MM_YYYY;
 import static org.isf.utils.Constants.DATE_FORMAT_DD_MM_YYYY_HH_MM_SS;
+import static org.isf.utils.Constants.DATE_FORMAT_YYYYMMDD;
 
 import java.awt.AWTEvent;
 import java.awt.BorderLayout;
@@ -1677,8 +1678,8 @@ public class WardPharmacy extends ModalJFrame implements
 
 			filename.append("_").append(jComboBoxMedicals.getSelectedItem());
 		}
-		filename.append("_").append(TimeTools.formatDateTime(jCalendarFrom.getLocalDateTime(), "yyyyMMdd"))
-				.append("_").append(TimeTools.formatDateTime(jCalendarTo.getLocalDateTime(), "yyyyMMdd"));
+		filename.append("_").append(TimeTools.formatDateTime(jCalendarFrom.getLocalDateTime(), DATE_FORMAT_YYYYMMDD))
+				.append("_").append(TimeTools.formatDateTime(jCalendarTo.getLocalDateTime(), DATE_FORMAT_YYYYMMDD));
 
 		return filename.toString();
 	}

--- a/src/main/java/org/isf/operation/gui/OperationRowBase.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowBase.java
@@ -21,6 +21,8 @@
  */
 package org.isf.operation.gui;
 
+import static org.isf.utils.Constants.DATE_FORMAT_DD_MM_YY;
+
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -271,7 +273,7 @@ abstract class OperationRowBase extends JPanel {
 		if (jCalendarDate == null) {
 			jCalendarDate = new CustomJDateChooser();
 			jCalendarDate.setLocale(new Locale(GeneralData.LANGUAGE));
-			jCalendarDate.setDateFormatString("dd/MM/yy"); //$NON-NLS-1$
+			jCalendarDate.setDateFormatString(DATE_FORMAT_DD_MM_YY);
 			jCalendarDate.setDate(new Date());
 		}
 		return jCalendarDate;


### PR DESCRIPTION
Think this should be the last of the hard coded date/time string patterns.