### PR TITLE
Chore update to slf4j-reload4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,8 +265,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.33</version>
+			<artifactId>slf4j-reload4j</artifactId>
+			<version>1.7.36</version>
 		</dependency>
 		<dependency>
 			<groupId>org.igniterealtime.smack</groupId>


### PR DESCRIPTION
Change slf4j-log4j12 to slf4j-reload4j which is the new name; see Reload4j 1.2.18 as a replacement for log4j 1.2.17 at https://www.slf4j.org/log4shell.html