### PR TITLE
Chore: fix NPE when Cancel button in dialog is used

### DIFF
--- a/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
@@ -286,10 +286,10 @@ public class MovStockBrowser extends ModalJFrame {
 		stockLedgerButton.addActionListener(actionEvent -> {
 
 			StockLedgerDialog stockCardDialog = new StockLedgerDialog(MovStockBrowser.this, movDateFrom.getCompleteDate(), movDateTo.getCompleteDate());
-			LocalDateTime dateFrom = stockCardDialog.getLocalDateTimeTo();
-			LocalDateTime dateTo = stockCardDialog.getLocalDateTimeTo();
 
 			if (!stockCardDialog.isCancel()) {
+				LocalDateTime dateFrom = stockCardDialog.getLocalDateTimeTo();
+				LocalDateTime dateTo = stockCardDialog.getLocalDateTimeTo();
 				new GenericReportPharmaceuticalStockCard("ProductLedger_multi", dateFrom, dateTo, null, null, false);
 			}
 		});

--- a/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
@@ -266,15 +266,14 @@ public class MovStockBrowser extends ModalJFrame {
 					movDateFrom.getCompleteDate(),
 					movDateTo.getCompleteDate());
 			medical = stockCardDialog.getMedical();
-			LocalDateTime dateFrom = stockCardDialog.getLocalDateTimeFrom();
-			LocalDateTime dateTo = stockCardDialog.getLocalDateTimeTo();
-			boolean toExcel = stockCardDialog.isExcel();
-
 			if (!stockCardDialog.isCancel()) {
 				if (medical == null) {
 					MessageDialog.error(MovStockBrowser.this, "angal.medicalstock.chooseamedical.msg");
 					return;
 				}
+				LocalDateTime dateFrom = stockCardDialog.getLocalDateTimeFrom();
+				LocalDateTime dateTo = stockCardDialog.getLocalDateTimeTo();
+				boolean toExcel = stockCardDialog.isExcel();
 				new GenericReportPharmaceuticalStockCard("ProductLedger", dateFrom, dateTo, medical, null, toExcel);
 			}
 		});


### PR DESCRIPTION
Pharmacy -> Pharmaceutical Stock -> StockCard button -> Cancel button

Generates a NPE
<pre>
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException
	at org.isf.utils.time.Converters.convertToLocalDateTime(Converters.java:46)
	at org.isf.utils.jobjects.StockCardDialog.getLocalDateTimeFrom(StockCardDialog.java:155)
	at org.isf.medicalstock.gui.MovStockBrowser.lambda$getStockCardButton$0(MovStockBrowser.java:269)
	at java.desktop/javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1967)
</pre>

Execute the conversion of dates only when Cancel is not selected.

Similar problem with Pharmacy -> Pharmaceutical Stock -> Stock Ledger button -> Cancel button
