### PR TITLE
Chore: remove GregorianCalendar usage

### DIFF
--- a/src/main/java/org/isf/opd/gui/OpdEdit.java
+++ b/src/main/java/org/isf/opd/gui/OpdEdit.java
@@ -31,7 +31,6 @@ import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.EventListener;
@@ -507,8 +506,7 @@ public class OpdEdit extends JDialog {
 
 						try {
 							if (insert) {    // Insert
-								opd.setProgYear(opdManager.getProgYear(LocalDate.now().getYear()) + 1);
-
+								opd.setProgYear(getOpdProgYear(visitDate));
 								// remember for later use
 								RememberDates.setLastOpdVisitDate(visitDate);
 
@@ -535,6 +533,19 @@ public class OpdEdit extends JDialog {
 			);
 		}
 		return okButton;
+	}
+
+	private int getOpdProgYear(LocalDateTime date) {
+		int opdNum = 0;
+		if (date == null) {
+			date = LocalDateTime.now();
+		}
+		try {
+			opdNum = opdManager.getProgYear(date.getYear()) + 1;
+		} catch (OHServiceException e) {
+			OHServiceExceptionUtil.showMessages(e);
+		}
+		return opdNum;
 	}
 	
 	/**

--- a/src/main/java/org/isf/opd/gui/OpdEdit.java
+++ b/src/main/java/org/isf/opd/gui/OpdEdit.java
@@ -31,11 +31,10 @@ import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.EventListener;
-import java.util.GregorianCalendar;
 import java.util.List;
 
 import javax.swing.BorderFactory;
@@ -508,8 +507,7 @@ public class OpdEdit extends JDialog {
 
 						try {
 							if (insert) {    // Insert
-								GregorianCalendar date = new GregorianCalendar();
-								opd.setProgYear(opdManager.getProgYear(date.get(Calendar.YEAR)) + 1);
+								opd.setProgYear(opdManager.getProgYear(LocalDate.now().getYear()) + 1);
 
 								// remember for later use
 								RememberDates.setLastOpdVisitDate(visitDate);


### PR DESCRIPTION
This is when creating a new OPD entry when `OPDEXTENDED=no` in the settings file