### PR TITLE
OP-905 improve resizing and wrapping of button bar

### DIFF
--- a/src/main/java/org/isf/accounting/gui/BillBrowser.java
+++ b/src/main/java/org/isf/accounting/gui/BillBrowser.java
@@ -95,6 +95,7 @@ import org.isf.utils.time.TimeTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.lgooddatepicker.zinternaltools.WrapLayout;
 import com.toedter.calendar.JMonthChooser;
 import com.toedter.calendar.JYearChooser;
 
@@ -726,7 +727,7 @@ public class BillBrowser extends ModalJFrame implements PatientBillListener {
 
 	private JPanel getJPanelButtons() {
 		if (jPanelButtons == null) {
-			jPanelButtons = new JPanel();
+			jPanelButtons = new JPanel(new WrapLayout());
 			if (MainMenu.checkUserGrants("btnbillnew")) {
 				jPanelButtons.add(getJButtonNew());
 			}

--- a/src/main/java/org/isf/admission/gui/AdmittedPatientBrowser.java
+++ b/src/main/java/org/isf/admission/gui/AdmittedPatientBrowser.java
@@ -101,6 +101,8 @@ import org.isf.utils.time.TimeTools;
 import org.isf.ward.manager.WardBrowserManager;
 import org.isf.ward.model.Ward;
 
+import com.github.lgooddatepicker.zinternaltools.WrapLayout;
+
 /**
  * This class shows a list of all known patients and for each if (and where) they are actually admitted,
  * you can:
@@ -367,6 +369,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 		}
 		
 		initComponents();
+		setMinimumSize(new Dimension(1020, 570));
 		pack();
 		setLocationRelativeTo(null);
 		setVisible(true);
@@ -691,7 +694,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 	}
 
 	private JPanel getButtonPanel() {
-		JPanel buttonPanel = new JPanel();
+		JPanel buttonPanel = new JPanel(new WrapLayout());
 		if (MainMenu.checkUserGrants("btnadmnew")) {
 			buttonPanel.add(getButtonNew());
 		}

--- a/src/main/java/org/isf/lab/gui/LabBrowser.java
+++ b/src/main/java/org/isf/lab/gui/LabBrowser.java
@@ -26,7 +26,6 @@ import static org.isf.utils.Constants.DATE_TIME_FORMATTER;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.Toolkit;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -137,26 +136,12 @@ public class LabBrowser extends ModalJFrame implements LabListener, LabEditListe
 	public LabBrowser() {
 		super();
 		myFrame = this;
-		initialize();
+		this.setTitle(MessageBundle.getMessage("angal.lab.laboratorybrowser.title"));
+		this.setContentPane(getJContentPane());
+		setSize(new Dimension(1345, 650));
 		setResizable(false);
 		setVisible(true);
-	}
-
-	/**
-	 * This method initializes this Frame, sets the correct Dimensions
-	 */
-	private void initialize() {
-		Toolkit kit = Toolkit.getDefaultToolkit();
-		Dimension screensize = kit.getScreenSize();
-		final int pfrmBase = 20;
-		final int pfrmWidth = 14;
-		final int pfrmHeight = 12;
-		this.setBounds((screensize.width - screensize.width * pfrmWidth
-				/ pfrmBase) / 2, (screensize.height - screensize.height
-				* pfrmHeight / pfrmBase) / 2, screensize.width * pfrmWidth
-				/ pfrmBase, screensize.height * pfrmHeight / pfrmBase);
-		this.setContentPane(getJContentPane());
-		this.setTitle(MessageBundle.getMessage("angal.lab.laboratorybrowser.title"));
+		setLocationRelativeTo(null);
 	}
 
 	/**

--- a/src/main/java/org/isf/medicals/gui/MedicalBrowser.java
+++ b/src/main/java/org/isf/medicals/gui/MedicalBrowser.java
@@ -26,7 +26,6 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.io.File;
@@ -80,6 +79,8 @@ import org.isf.utils.time.TimeTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.lgooddatepicker.zinternaltools.WrapLayout;
+
 /**
  * This class shows a complete extended list of medical drugs,
  * supplies-sundries, diagnostic kits -reagents, laboratory chemicals. It is
@@ -122,10 +123,6 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener {
 
 	}
 
-	private static final int DEFAULT_WIDTH = 500;
-	private static final int DEFAULT_HEIGHT = 400;
-	private int pfrmWidth;
-	private int pfrmHeight;
 	private int selectedrow;
 	private JComboBox pbox;
 	private List<Medical> pMedicals;
@@ -165,13 +162,8 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener {
 	public MedicalBrowser() {
 		me = this;
 		setTitle(MessageBundle.getMessage("angal.medicals.pharmaceuticalbrowser.title"));
-		setSize(DEFAULT_WIDTH, DEFAULT_HEIGHT);
-		Toolkit kit = Toolkit.getDefaultToolkit();
-		Dimension screensize = kit.getScreenSize();
-		pfrmWidth = 940; //screensize.width / 2;
-		pfrmHeight = screensize.height / 2;
-		setBounds((screensize.width - pfrmWidth) / 2, screensize.height / 4, pfrmWidth,
-				pfrmHeight);
+		setPreferredSize(new Dimension(1220, 550));
+		setMinimumSize(new Dimension(940, 550));
 		setContentPane(getContentpane());
 		pack();
 		setVisible(true);
@@ -180,8 +172,7 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener {
 	}
 
 	private JPanel getContentpane() {
-		JPanel contentPane = new JPanel();
-		contentPane.setLayout(new BorderLayout());
+		JPanel contentPane = new JPanel(new BorderLayout());
 		contentPane.add(getScrollPane(), BorderLayout.CENTER);
 		contentPane.add(getJButtonPanel(), BorderLayout.SOUTH);
 		return contentPane;
@@ -214,7 +205,7 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener {
 	}
 
 	private JPanel getJButtonPanel() {
-		JPanel buttonPanel = new JPanel();
+		JPanel buttonPanel = new JPanel(new WrapLayout());
 		buttonPanel.add(new JLabel(MessageBundle.getMessage("angal.medicals.selecttype")));
 		buttonPanel.add(getComboBoxMedicalType());
 		buttonPanel.add(getSearchBox());
@@ -764,11 +755,7 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener {
 			} else if (c == 5) {
 				return minQuantity;
 			} else if (c == 6) {
-				if (actualQty == 0) {
-					return true;
-				} else {
-					return false;
-				}
+				return actualQty == 0;
 			}
 			return null;
 		}

--- a/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
@@ -31,7 +31,6 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
-import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
@@ -99,6 +98,8 @@ import org.isf.ward.manager.WardBrowserManager;
 import org.isf.ward.model.Ward;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.github.lgooddatepicker.zinternaltools.WrapLayout;
 
 /**
  * ------------------------------------------
@@ -198,19 +199,11 @@ public class MovStockBrowser extends ModalJFrame {
 		} catch (OHServiceException e) {
 			OHServiceExceptionUtil.showMessages(e);
 		}
-
-		Toolkit kit = Toolkit.getDefaultToolkit();
-		Dimension screensize = kit.getScreenSize();
-		final int pfrmBase = 30;
-		final int pfrmWidth = 24;
-		final int pfrmHeight = 22;
-		this.setBounds((screensize.width - screensize.width * pfrmWidth
-				/ pfrmBase) / 2, (screensize.height - screensize.height
-				* pfrmHeight / pfrmBase) / 2, screensize.width * pfrmWidth
-				/ pfrmBase, screensize.height * pfrmHeight / pfrmBase);
 		setContentPane(getContentpane());
 
 		updateTotals();
+		setPreferredSize(new Dimension(1150, 655));
+		setMinimumSize(new Dimension(775, 655));
 		pack();
 		setVisible(true);
 		setLocationRelativeTo(null);
@@ -218,8 +211,7 @@ public class MovStockBrowser extends ModalJFrame {
 	}
 
 	private JPanel getContentpane() {
-		contentPane = new JPanel();
-		contentPane.setLayout(new BorderLayout());
+		contentPane = new JPanel(new BorderLayout());
 		contentPane.add(getFilterPanel(), BorderLayout.WEST);
 		contentPane.add(getTablesPanel(), BorderLayout.CENTER);
 		contentPane.add(getButtonPanel(), BorderLayout.SOUTH);
@@ -236,7 +228,7 @@ public class MovStockBrowser extends ModalJFrame {
 	}
 
 	private JPanel getButtonPanel() {
-		buttonPanel = new JPanel();
+		buttonPanel = new JPanel(new WrapLayout());
 		if (MainMenu.checkUserGrants("btnpharmstockcharge")) {
 			buttonPanel.add(getChargeButton());
 		}

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
@@ -110,6 +110,8 @@ import org.isf.ward.model.Ward;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.lgooddatepicker.zinternaltools.WrapLayout;
+
 public class WardPharmacy extends ModalJFrame implements
 		WardPharmacyEdit.MovementWardListeners,
 		WardPharmacyNew.MovementWardListeners,
@@ -252,6 +254,7 @@ public class WardPharmacy extends ModalJFrame implements
 			editAllowed = true;
 		}
 		initComponents();
+		setMinimumSize(new Dimension(700, 450));
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 		setLocationRelativeTo(null);
 		setVisible(true);
@@ -286,7 +289,7 @@ public class WardPharmacy extends ModalJFrame implements
 
 	private JPanel getJPanelButtons() {
 		if (jPanelButtons == null) {
-			jPanelButtons = new JPanel(new FlowLayout());
+			jPanelButtons = new JPanel(new WrapLayout());
 			jPanelButtons.add(getJButtonNew());
 			if (editAllowed) {
 				jPanelButtons.add(getJButtonEdit());

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
@@ -254,7 +254,7 @@ public class WardPharmacy extends ModalJFrame implements
 			editAllowed = true;
 		}
 		initComponents();
-		setMinimumSize(new Dimension(700, 450));
+		pack();
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 		setLocationRelativeTo(null);
 		setVisible(true);
@@ -281,10 +281,8 @@ public class WardPharmacy extends ModalJFrame implements
 
 	private void initComponents() {
 		add(getJPanelWardAndRange(), BorderLayout.NORTH);
-		// add(getJTabbedPaneWard(), BorderLayout.CENTER);
 		add(getJPanelButtons(), BorderLayout.SOUTH);
 		setTitle(MessageBundle.getMessage("angal.medicalstock.wardpharmacy.title"));
-		setSize(800, 450);
 	}
 
 	private JPanel getJPanelButtons() {

--- a/src/main/java/org/isf/opd/gui/OpdBrowser.java
+++ b/src/main/java/org/isf/opd/gui/OpdBrowser.java
@@ -147,7 +147,7 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 	private List<Opd> pSur;
 	private JTable jTable = null;
 	private OpdBrowsingModel model;
-	private int[] pColumnWidth = {50, 50, 130, 70, 150, 30, 30, 195, 195, 50 };
+	private int[] pColumnWidth = {50, 100, 130, 70, 150, 30, 30, 195, 195, 50 };
 	private boolean[] columnResizable = { false, false, false, false, true, false, false, true, true, false };
 	private boolean[] columnsVisible = { true, true, true, GeneralData.OPDEXTENDED, GeneralData.OPDEXTENDED, true, true, true, true, true };
 	private int[] columnsAlignment = { SwingConstants.LEFT, SwingConstants.LEFT, SwingConstants.LEFT, SwingConstants.CENTER, SwingConstants.LEFT, SwingConstants.CENTER, SwingConstants.CENTER, SwingConstants.LEFT, SwingConstants.LEFT, SwingConstants.LEFT };
@@ -215,6 +215,7 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 		super();
 		myFrame = this;
 		initialize();
+		setMinimumSize(new Dimension(1340, 540));
         setVisible(true);
 	}
 

--- a/src/main/java/org/isf/opd/gui/OpdBrowser.java
+++ b/src/main/java/org/isf/opd/gui/OpdBrowser.java
@@ -29,7 +29,6 @@ import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
-import java.awt.Toolkit;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
@@ -110,7 +109,6 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 
 	private JPanel jButtonPanel = null;
 	private JPanel jContainPanel = null;
-	private int pfrmHeight;
 	private JButton jNewButton = null;
 	private JButton jEditButton = null;
 	private JButton jCloseButton = null;
@@ -215,7 +213,7 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 		super();
 		myFrame = this;
 		initialize();
-		setMinimumSize(new Dimension(1340, 540));
+		setMinimumSize(new Dimension(1340, 550));
         setVisible(true);
 	}
 
@@ -256,19 +254,11 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 	 * This method initializes this
 	 */
 	private void initialize() {
-		Toolkit kit = Toolkit.getDefaultToolkit();
-		Dimension screensize = kit.getScreenSize();
-		final int pfrmBase = 20;
-		final int pfrmWidth = 17;
-		final int pfrmHeight = 12;
-		this.setBounds((screensize.width - screensize.width * pfrmWidth / pfrmBase) / 2,
-				(screensize.height - screensize.height * pfrmHeight / pfrmBase) / 2,
-				screensize.width * pfrmWidth / pfrmBase + 50,
-				screensize.height * pfrmHeight / pfrmBase + 20);
 		this.setTitle(MessageBundle.getMessage("angal.opd.opdoutpatientdepartment.title"));
 		this.setContentPane(getJContainPanel());
 		rowCounter.setText(rowCounterText + pSur.size());
 		validate();
+		pack();
 		this.setLocationRelativeTo(null);
 	}
 
@@ -437,7 +427,7 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 			filterButtonPanel.add(getFilterButton());
 			filterButtonPanel.setPreferredSize(new Dimension(300, 30));
 			jSelectionPanel = new JPanel();
-			jSelectionPanel.setPreferredSize(new Dimension(300, pfrmHeight));
+			jSelectionPanel.setPreferredSize(new Dimension(300, 25));
 			jSelectionPanel.add(diseaseLabelPanel);
 			jSelectionPanel.add(getJSelectionDiseasePanel());
 			jSelectionPanel.add(Box.createVerticalGlue());

--- a/src/main/java/org/isf/patvac/gui/PatVacBrowser.java
+++ b/src/main/java/org/isf/patvac/gui/PatVacBrowser.java
@@ -27,7 +27,6 @@ import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
-import java.awt.Toolkit;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.time.LocalDate;
@@ -67,6 +66,8 @@ import org.isf.vaccine.manager.VaccineBrowserManager;
 import org.isf.vaccine.model.Vaccine;
 import org.isf.vactype.manager.VaccineTypeBrowserManager;
 import org.isf.vactype.model.VaccineType;
+
+import com.github.lgooddatepicker.zinternaltools.WrapLayout;
 
 /**
  * ------------------------------------------
@@ -139,17 +140,11 @@ public class PatVacBrowser extends ModalJFrame {
 	 * This method initializes this Frame, sets the correct Dimensions
 	 */
 	private void initialize() {
-		Toolkit kit = Toolkit.getDefaultToolkit();
-		Dimension screensize = kit.getScreenSize();
-		final int pfrmBase = 20;
-		final int pfrmWidth = 17;
-		final int pfrmHeight = 12;
-		this.setBounds((screensize.width - screensize.width * pfrmWidth / pfrmBase) / 2,
-				(screensize.height - screensize.height * pfrmHeight / pfrmBase) / 2,
-				screensize.width * pfrmWidth / pfrmBase + 50,
-				screensize.height * pfrmHeight / pfrmBase + 20);
 		setTitle(MessageBundle.getMessage("angal.patvac.patientvaccinebrowser.title"));
 		this.setContentPane(getJContentPane());
+		setPreferredSize(new Dimension(1680, 670));
+		setMinimumSize(new Dimension(880, 510));
+		pack();
 		updateRowCounter();
 		this.setLocationRelativeTo(null);
 	}
@@ -180,7 +175,7 @@ public class PatVacBrowser extends ModalJFrame {
 	 */
 	private JPanel getJButtonPanel() {
 		if (jButtonPanel == null) {
-			jButtonPanel = new JPanel();
+			jButtonPanel = new JPanel(new WrapLayout());
 			if (MainMenu.checkUserGrants("btnpatientvaccinenew")) {
 				jButtonPanel.add(getButtonNew(), null);
 			}

--- a/src/main/java/org/isf/stat/gui/DiseasesListLauncher.java
+++ b/src/main/java/org/isf/stat/gui/DiseasesListLauncher.java
@@ -54,7 +54,7 @@ public class DiseasesListLauncher extends ModalJFrame {
 	 */
 	public DiseasesListLauncher() {
 		super();
-		this.setResizable(true);
+		this.setResizable(false);
 		initialize();
 		setVisible(true);
 	}

--- a/src/main/java/org/isf/stat/gui/ExamsList1Launcher.java
+++ b/src/main/java/org/isf/stat/gui/ExamsList1Launcher.java
@@ -54,7 +54,7 @@ public class ExamsList1Launcher extends ModalJFrame {
 	 */
 	public ExamsList1Launcher() {
 		super();
-		this.setResizable(true);
+		this.setResizable(false);
 		initialize();
 		setVisible(true);
 	}

--- a/src/main/java/org/isf/stat/reportlauncher/gui/ReportLauncher.java
+++ b/src/main/java/org/isf/stat/reportlauncher/gui/ReportLauncher.java
@@ -128,7 +128,7 @@ public class ReportLauncher extends ModalJFrame{
 	 */
 	public ReportLauncher() {
 		super();
-		this.setResizable(true);
+		this.setResizable(false);
 		initialize();
 		setVisible(true);
 	}

--- a/src/main/java/org/isf/visits/gui/VisitView.java
+++ b/src/main/java/org/isf/visits/gui/VisitView.java
@@ -210,6 +210,7 @@ public class VisitView extends ModalJFrame {
 		showGui(ward != null);
 
 		setSize(1350, 600);
+		setResizable(false);
 	}
 
 	private JPanel dayCalendar() {


### PR DESCRIPTION
This PR attempts to address all the top level windows from the main startup menu.    The changes include adding wrapping to button bars and setting minimum window sizes where needed.   In addition a few windows are no longer re-sizable.  I also took this opportunity to remove explicit bounds setting for the windows using Toolkit.

The nice formatting that I attempted is lost; so here is screenshot
![image](https://user-images.githubusercontent.com/1105445/173136000-da22595a-c8f7-4905-80d7-7553a1e8fa4e.png)




Text only version:

Windows in order of the menu                          Changes
OPD                                                                   2
Pharmacy
      Pharmaceuticals                                          1, 2, 4
      Pharmaceutical Stock                                  1, 2, 4
      Pharmaceutical Stock Ward                         2, 4
Admission/Patient                                              2, 4
Laboratory                                                          5    setResizable(false) already set
Accounting
      New Bill                                                        setResizable(false) already set
      Bill Manager                                                 minimum size already set
Statistics                                                             3
Vaccines                                                             1, 2, 4
Worksheet                                                          3 (layout too complex)
Reports
     Exams                                                           3 (no reason to resize)
     Disease                                                         3 (no reason to resize)        


(1) setPreferredSize
(2) setMinimumSIze
(3) setResizable(false)
(4) wrap button bar
(5) setSize