### PR TITLE
Chore: combine recent dependabot jar updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,10 @@
 		<oh.version>1.12.0-SNAPSHOT</oh.version>
 		<java.version>1.8</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring.framework.version>5.3.21</spring.framework.version>
+		<spring.framework.version>5.3.22</spring.framework.version>
+		<spring.boot.version>2.7.1</spring.boot.version>
+		<spring.cloud.starter.openfeign.version>3.1.3</spring.cloud.starter.openfeign.version>
 		<license.maven.plugin.version>4.1</license.maven.plugin.version>
-		<spring-cloud-starter-openfeign>3.1.3</spring-cloud-starter-openfeign>
 	</properties>
 
 	<build>
@@ -332,7 +333,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
-			<version>${spring-cloud-starter-openfeign}</version>
+			<version>${spring.cloud.starter.openfeign.version}</version>
 			<scope>runtime</scope>
 			<exclusions>
 				<exclusion>
@@ -373,7 +374,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot</artifactId>
-			<version>2.7.0</version>
+			<version>${spring.boot.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Update jars to match Core project and use the same version properties strings as are found in the Core pom.xml