### PR TITLE
OP-927 update date and time choosers for SMS Manager and New SMS

### DIFF
--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -1332,11 +1332,11 @@ angal.sms.deletetheselectedsms.msg                                              
 angal.sms.doyouwanttosplitinmoremessages                                                               = Do you want to split in more messages
 angal.sms.newsms.title                                                                                 = New SMS
 angal.sms.number                                                                                       = Number
+angal.sms.pleaseenteravaliddateandtime.msg                                                             = Please enter a valid date and time.
 angal.sms.pleaseinsertatextmessage.msg                                                                 = Please insert a text message.
 angal.sms.pleaseinsertavalidtelephonenumber.msg                                                        = Please insert a valid telephone number.
 angal.sms.scheduleddate                                                                                = Scheduled Date
 angal.sms.scheduleddate.col                                                                            = Sched. Date
-angal.sms.scheduledtime                                                                                = Scheduled Time
 angal.sms.sent.col                                                                                     = Sent
 angal.sms.smsmanager.title                                                                             = SMS Manager
 angal.sms.themessageislongerthencharacters.fmt.msg                                                     = The message is longer then {0} characters.

--- a/src/main/java/org/isf/sms/gui/SmsBrowser.java
+++ b/src/main/java/org/isf/sms/gui/SmsBrowser.java
@@ -21,8 +21,7 @@
  */
 package org.isf.sms.gui;
 
-import static org.isf.utils.Constants.DATE_FORMAT_DD_MM_YY;
-import static org.isf.utils.Constants.DATE_FORMAT_YYYY_MM_DD_HH_MM;
+import static org.isf.utils.Constants.DATE_FORMAT_DD_MM_YYYY_HH_MM;
 import static org.isf.utils.Constants.TIME_FORMAT_HH_MM;
 
 import java.awt.BorderLayout;
@@ -33,11 +32,11 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -50,17 +49,15 @@ import javax.swing.WindowConstants;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
 
-import org.isf.generaldata.GeneralData;
 import org.isf.generaldata.MessageBundle;
 import org.isf.menu.manager.Context;
 import org.isf.sms.manager.SmsManager;
 import org.isf.sms.model.Sms;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.gui.OHServiceExceptionUtil;
-import org.isf.utils.jobjects.CustomJDateChooser;
+import org.isf.utils.jobjects.GoodDateChooser;
 import org.isf.utils.jobjects.MessageDialog;
 import org.isf.utils.jobjects.ModalJFrame;
-import org.isf.utils.time.Converters;
 
 /**
  * @author Mwithi
@@ -83,7 +80,7 @@ public class SmsBrowser extends ModalJFrame {
 			MessageBundle.getMessage("angal.sms.sent.col").toUpperCase()
 	};
 	private Object[] columnClasses = {Date.class, Date.class, String.class, String.class, Date.class};
-	private int[] columnPreferredSize = {110, 110, 150, 100, 110};
+	private int[] columnPreferredSize = {130, 130, 150, 200, 130};
 	private boolean[] columnResizable = {false, false, false, true, false};
 	private int width;
 	private int eight;
@@ -96,8 +93,8 @@ public class SmsBrowser extends ModalJFrame {
 
 	private SmsTableModel model;
 	private JPanel jFilterPanel;
-	private CustomJDateChooser jFromDateChooser;
-	private CustomJDateChooser jToDateChooser;
+	private GoodDateChooser jFromDateChooser;
+	private GoodDateChooser jToDateChooser;
 
 	private LocalDateTime dateFrom;
 	private LocalDateTime dateTo;
@@ -159,31 +156,31 @@ public class SmsBrowser extends ModalJFrame {
 		return jDateToLabel;
 	}
 	
-	private CustomJDateChooser getJFromDateChooser() {
+	private GoodDateChooser getJFromDateChooser() {
 		if (jFromDateChooser == null) {
-			jFromDateChooser = new CustomJDateChooser();
-			jFromDateChooser.setLocale(new Locale(GeneralData.LANGUAGE));
-			jFromDateChooser.setDate(dateTimeAtStartOfToday);
-			jFromDateChooser.setDateFormatString(DATE_FORMAT_DD_MM_YY);
-			jFromDateChooser.addPropertyChangeListener("date", propertyChangeEvent -> {
-				dateFrom = Converters.convertToLocalDateTime((Date) propertyChangeEvent.getNewValue());
-				updateModel(dateFrom, dateTo);
-				updateGUI();
+			jFromDateChooser = new GoodDateChooser(LocalDate.now());
+			jFromDateChooser.addDateChangeListener(dateChangeEvent -> {
+				LocalDate newDate = dateChangeEvent.getNewDate();
+				if (newDate != null) {
+					dateFrom = newDate.atStartOfDay();
+					updateModel(dateFrom, dateTo);
+					updateGUI();
+				}
 			});
 		}
 		return jFromDateChooser;
 	}
 	
-	private CustomJDateChooser getJToDateChooser() {
+	private GoodDateChooser getJToDateChooser() {
 		if (jToDateChooser == null) {
-			jToDateChooser = new CustomJDateChooser();
-			jToDateChooser.setLocale(new Locale(GeneralData.LANGUAGE));
-			jToDateChooser.setDate(dateTimeAtEndOfToday);
-			jToDateChooser.setDateFormatString(DATE_FORMAT_DD_MM_YY);
-			jToDateChooser.addPropertyChangeListener("date", propertyChangeEvent -> {
-				dateTo = Converters.convertToLocalDateTime((Date) propertyChangeEvent.getNewValue());
-				updateModel(dateFrom, dateTo);
-				updateGUI();
+			jToDateChooser = new GoodDateChooser(LocalDate.now());
+			jToDateChooser.addDateChangeListener(dateChangeEvent -> {
+				LocalDate newDate = dateChangeEvent.getNewDate();
+				if (newDate != null) {
+					dateTo = newDate.atTime(LocalTime.MAX);
+					updateModel(dateFrom, dateTo);
+					updateGUI();
+				}
 			});
 		}
 		return jToDateChooser;
@@ -386,16 +383,16 @@ public class SmsBrowser extends ModalJFrame {
 		}
 	}
 	
-	public String formatDateTime(LocalDateTime smsDateSent) {
-		DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DATE_FORMAT_YYYY_MM_DD_HH_MM);
+	private String formatDateTime(LocalDateTime smsDateSent) {
+		DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DATE_FORMAT_DD_MM_YYYY_HH_MM);
 		if (smsDateSent != null) {
 			return dateTimeFormatter.format(smsDateSent);
 		}
 		return null;
 	}
 	
-	public String formatTodayDateTime(LocalDateTime smsDateSent) {
-		DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DATE_FORMAT_YYYY_MM_DD_HH_MM);
+	private String formatTodayDateTime(LocalDateTime smsDateSent) {
+		DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DATE_FORMAT_DD_MM_YYYY_HH_MM);
 		DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern(TIME_FORMAT_HH_MM);
 		if (smsDateSent != null) {
 			if (smsDateSent.isAfter(dateTimeAtStartOfToday) && smsDateSent.isBefore(dateTimeAtEndOfToday)) {

--- a/src/main/java/org/isf/sms/gui/SmsEdit.java
+++ b/src/main/java/org/isf/sms/gui/SmsEdit.java
@@ -21,9 +21,6 @@
  */
 package org.isf.sms.gui;
 
-import static org.isf.utils.Constants.DATE_FORMAT_DD_MM_YY;
-import static org.isf.utils.Constants.TIME_FORMAT_HH_MM;
-
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -33,10 +30,7 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
-import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
-import java.util.Date;
-import java.util.Locale;
 
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -51,7 +45,6 @@ import javax.swing.JTextField;
 import javax.swing.WindowConstants;
 import javax.swing.border.EmptyBorder;
 
-import org.isf.generaldata.GeneralData;
 import org.isf.generaldata.MessageBundle;
 import org.isf.menu.manager.Context;
 import org.isf.menu.manager.UserBrowsingManager;
@@ -62,8 +55,8 @@ import org.isf.sms.manager.SmsManager;
 import org.isf.sms.model.Sms;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.gui.OHServiceExceptionUtil;
-import org.isf.utils.jobjects.CustomJDateChooser;
-import org.isf.utils.jobjects.JDateAndTimeChooserDialog;
+import org.isf.utils.jobjects.GoodDateTimeSpinnerChooser;
+import org.isf.utils.jobjects.MessageDialog;
 
 /**
  * @author Mwithi
@@ -82,10 +75,7 @@ public class SmsEdit extends JDialog implements SelectionListener {
 	private JLabel jCharactersLabel;
 	private JLabel jLabelCount;
 	private JTextArea jTextArea;
-	private CustomJDateChooser jSchedDateChooser;
-	private JLabel jSchedTimeLabel;
-	private JTextField jSchedTimeTextField;
-	private JButton JTimeButton;
+	private GoodDateTimeSpinnerChooser jSchedDateChooser;
 	private JButton jPatientButton;
 
 	private int maxLength;
@@ -117,79 +107,54 @@ public class SmsEdit extends JDialog implements SelectionListener {
 		setLocationRelativeTo(null);
 		setVisible(true);
 	}
-	
+
 	private JPanel getJNorthPanel() {
 		if (jNorthPanel == null) {
 			jNorthPanel = new JPanel();
 			jNorthPanel.setBorder(new EmptyBorder(5, 5, 5, 5));
 			GridBagLayout panel = new GridBagLayout();
-			panel.columnWidths = new int[]{46, 110, 0, 0};
-			panel.rowHeights = new int[]{20, 0, 0, 0};
-			panel.columnWeights = new double[]{0.0, 0.0, 0.0, Double.MIN_VALUE};
-			panel.rowWeights = new double[]{0.0, 0.0, 0.0, Double.MIN_VALUE};
+			panel.columnWidths = new int[] { 46, 110, 0, 0 };
+			panel.rowHeights = new int[] { 20, 0, 0, 0 };
+			panel.columnWeights = new double[] { 0.0, 0.0, 0.0, Double.MIN_VALUE };
+			panel.rowWeights = new double[] { 0.0, 0.0, 0.0, Double.MIN_VALUE };
 			jNorthPanel.setLayout(panel);
-			{
-				JLabel jSchedDateLabel = new JLabel(MessageBundle.getMessage("angal.sms.scheduleddate")); //$NON-NLS-1$
-				GridBagConstraints gbcSchedDateLabel = new GridBagConstraints();
-				gbcSchedDateLabel.anchor = GridBagConstraints.WEST;
-				gbcSchedDateLabel.insets = new Insets(0, 0, 5, 5);
-				gbcSchedDateLabel.gridx = 0;
-				gbcSchedDateLabel.gridy = 0;
-				jNorthPanel.add(jSchedDateLabel, gbcSchedDateLabel);
-			}
-			{
-				GridBagConstraints gbcSchedDateChooser = new GridBagConstraints();
-				gbcSchedDateChooser.insets = new Insets(0, 0, 5, 5);
-				gbcSchedDateChooser.anchor = GridBagConstraints.NORTHWEST;
-				gbcSchedDateChooser.gridx = 1;
-				gbcSchedDateChooser.gridy = 0;
-				jNorthPanel.add(getJSchedDateChooser(), gbcSchedDateChooser);
-			}
-			GridBagConstraints gbcSchedTimeLabel = new GridBagConstraints();
-			gbcSchedTimeLabel.anchor = GridBagConstraints.EAST;
-			gbcSchedTimeLabel.insets = new Insets(0, 0, 5, 5);
-			gbcSchedTimeLabel.gridx = 0;
-			gbcSchedTimeLabel.gridy = 1;
-			jNorthPanel.add(getJSchedTimeLabel(), gbcSchedTimeLabel);
-			GridBagConstraints gbcSchedTimeTextField = new GridBagConstraints();
-			gbcSchedTimeTextField.anchor = GridBagConstraints.WEST;
-			gbcSchedTimeTextField.insets = new Insets(0, 0, 5, 5);
-			gbcSchedTimeTextField.gridx = 1;
-			gbcSchedTimeTextField.gridy = 1;
-			jNorthPanel.add(getJSchedTimeTextField(), gbcSchedTimeTextField);
-			GridBagConstraints gbcTimeButton = new GridBagConstraints();
-			gbcTimeButton.insets = new Insets(0, 0, 5, 0);
-			gbcTimeButton.gridx = 2;
-			gbcTimeButton.gridy = 1;
-			jNorthPanel.add(getJTimeButton(), gbcTimeButton);
-			{
-				JLabel jNumberLabel = new JLabel(MessageBundle.getMessage("angal.sms.number")); //$NON-NLS-1$
-				GridBagConstraints gbcNumberLabel = new GridBagConstraints();
-				gbcNumberLabel.anchor = GridBagConstraints.WEST;
-				gbcNumberLabel.insets = new Insets(0, 0, 0, 5);
-				gbcNumberLabel.gridx = 0;
-				gbcNumberLabel.gridy = 2;
-				jNorthPanel.add(jNumberLabel, gbcNumberLabel);
-			}
-			{
-				jNumberTextField = new JTextField();
-				GridBagConstraints gbcNumberTextField = new GridBagConstraints();
-				gbcNumberTextField.fill = GridBagConstraints.HORIZONTAL;
-				gbcNumberTextField.insets = new Insets(0, 0, 0, 5);
-				gbcNumberTextField.gridx = 1;
-				gbcNumberTextField.gridy = 2;
-				jNorthPanel.add(jNumberTextField, gbcNumberTextField);
-				jNumberTextField.setColumns(15);
-			}
-			{
-				GridBagConstraints gbcPatientButton = new GridBagConstraints();
-				gbcPatientButton.gridx = 2;
-				gbcPatientButton.gridy = 2;
-				jNorthPanel.add(getJPatientButton(), gbcPatientButton);
-			}
+
+			JLabel jSchedDateLabel = new JLabel(MessageBundle.getMessage("angal.sms.scheduleddate")); //$NON-NLS-1$
+			GridBagConstraints gbcSchedDateLabel = new GridBagConstraints();
+			gbcSchedDateLabel.anchor = GridBagConstraints.WEST;
+			gbcSchedDateLabel.insets = new Insets(0, 0, 5, 5);
+			gbcSchedDateLabel.gridx = 0;
+			gbcSchedDateLabel.gridy = 0;
+			jNorthPanel.add(jSchedDateLabel, gbcSchedDateLabel);
+
+			GridBagConstraints gbcSchedDateChooser = new GridBagConstraints();
+			gbcSchedDateChooser.insets = new Insets(0, 0, 5, 5);
+			gbcSchedDateChooser.anchor = GridBagConstraints.NORTHWEST;
+			gbcSchedDateChooser.gridx = 1;
+			gbcSchedDateChooser.gridy = 0;
+			jNorthPanel.add(getJSchedDateChooser(), gbcSchedDateChooser);
+
+			JLabel jNumberLabel = new JLabel(MessageBundle.getMessage("angal.sms.number")); //$NON-NLS-1$
+			GridBagConstraints gbcNumberLabel = new GridBagConstraints();
+			gbcNumberLabel.anchor = GridBagConstraints.WEST;
+			gbcNumberLabel.insets = new Insets(0, 0, 0, 5);
+			gbcNumberLabel.gridx = 0;
+			gbcNumberLabel.gridy = 2;
+			jNorthPanel.add(jNumberLabel, gbcNumberLabel);
+			jNumberTextField = new JTextField();
+			GridBagConstraints gbcNumberTextField = new GridBagConstraints();
+			gbcNumberTextField.fill = GridBagConstraints.HORIZONTAL;
+			gbcNumberTextField.insets = new Insets(0, 0, 0, 5);
+			gbcNumberTextField.gridx = 1;
+			gbcNumberTextField.gridy = 2;
+			jNorthPanel.add(jNumberTextField, gbcNumberTextField);
+			jNumberTextField.setColumns(15);
+			GridBagConstraints gbcPatientButton = new GridBagConstraints();
+			gbcPatientButton.gridx = 2;
+			gbcPatientButton.gridy = 2;
+			jNorthPanel.add(getJPatientButton(), gbcPatientButton);
 		}
 		return jNorthPanel;
-		
 	}
 	
 	private JButton getJPatientButton() {
@@ -206,16 +171,9 @@ public class SmsEdit extends JDialog implements SelectionListener {
 		return jPatientButton;
 	}
 	
-	private CustomJDateChooser getJSchedDateChooser() {
+	private GoodDateTimeSpinnerChooser getJSchedDateChooser() {
 		if (jSchedDateChooser == null) {
-			jSchedDateChooser = new CustomJDateChooser();
-			jSchedDateChooser.setLocale(new Locale(GeneralData.LANGUAGE));
-			jSchedDateChooser.setDate(new Date());
-			jSchedDateChooser.setDateFormatString(DATE_FORMAT_DD_MM_YY);
-			jSchedDateChooser.addPropertyChangeListener("date", propertyChangeEvent -> {
-				Date date = (Date) propertyChangeEvent.getNewValue();
-				jSchedTimeTextField.setText(formatTime(date));
-			});
+			jSchedDateChooser = new GoodDateTimeSpinnerChooser(LocalDateTime.now());
 		}
 		return jSchedDateChooser;
 	}
@@ -260,7 +218,7 @@ public class SmsEdit extends JDialog implements SelectionListener {
 		if (jButtonPanel == null) {
 			jButtonPanel = new JPanel();
 			jButtonPanel.setBorder(new EmptyBorder(5, 5, 5, 5));
-			jButtonPanel.setLayout(new FlowLayout(FlowLayout.RIGHT));
+			jButtonPanel.setLayout(new FlowLayout(FlowLayout.CENTER));
 			jButtonPanel.add(getJOkButton());
 			jButtonPanel.add(getJCancelButton());
 		}
@@ -275,6 +233,11 @@ public class SmsEdit extends JDialog implements SelectionListener {
 				String number = jNumberTextField.getText().replaceAll(" ", "").trim();
 				String text = jTextArea.getText();
 				LocalDateTime schedDate = jSchedDateChooser.getLocalDateTime();
+				if (schedDate == null) {
+
+					MessageDialog.error(this, "angal.sms.pleaseenteravaliddateandtime.msg");
+					return;
+				}
 
 				Sms smsToSend = new Sms();
 				smsToSend.setSmsNumber(number);
@@ -366,47 +329,6 @@ public class SmsEdit extends JDialog implements SelectionListener {
 			jLabelCount.setForeground(Color.GRAY);
 		}
 		return jLabelCount;
-	}
-	private JLabel getJSchedTimeLabel() {
-		if (jSchedTimeLabel == null) {
-			jSchedTimeLabel = new JLabel(MessageBundle.getMessage("angal.sms.scheduledtime")); //$NON-NLS-1$
-		}
-		return jSchedTimeLabel;
-	}
-
-	private JTextField getJSchedTimeTextField() {
-		if (jSchedTimeTextField == null) {
-			jSchedTimeTextField = new JTextField();
-			jSchedTimeTextField.setColumns(5);
-			jSchedTimeTextField.setEditable(false);
-		}
-		return jSchedTimeTextField;
-	}
-	
-	private String formatTime(Date date) {
-		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(TIME_FORMAT_HH_MM);
-		return simpleDateFormat.format(date);
-	}
-
-	private JButton getJTimeButton() {
-		if (JTimeButton == null) {
-			JTimeButton = new JButton(""); //$NON-NLS-1$
-			JTimeButton.setIcon(new ImageIcon("./rsc/icons/clock_button.png")); //$NON-NLS-1$
-			JTimeButton.addActionListener(actionEvent -> {
-
-				JDateAndTimeChooserDialog schedDate = new JDateAndTimeChooserDialog(SmsEdit.this, jSchedDateChooser.getDate());
-				schedDate.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-				schedDate.setVisible(true);
-
-				Date date = schedDate.getDate();
-
-				if (date != null) {
-					jSchedDateChooser.setDate(date);
-					jSchedTimeTextField.setText(formatTime(date));
-				}
-			});
-		}
-		return JTimeButton;
 	}
 
 	@Override

--- a/src/main/java/org/isf/sms/gui/SmsEdit.java
+++ b/src/main/java/org/isf/sms/gui/SmsEdit.java
@@ -55,7 +55,7 @@ import org.isf.sms.manager.SmsManager;
 import org.isf.sms.model.Sms;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.gui.OHServiceExceptionUtil;
-import org.isf.utils.jobjects.GoodDateTimeSpinnerChooser;
+import org.isf.utils.jobjects.GoodDateTimeToggleChooser;
 import org.isf.utils.jobjects.MessageDialog;
 
 /**
@@ -75,7 +75,7 @@ public class SmsEdit extends JDialog implements SelectionListener {
 	private JLabel jCharactersLabel;
 	private JLabel jLabelCount;
 	private JTextArea jTextArea;
-	private GoodDateTimeSpinnerChooser jSchedDateChooser;
+	private GoodDateTimeToggleChooser jSchedDateChooser;
 	private JButton jPatientButton;
 
 	private int maxLength;
@@ -171,9 +171,9 @@ public class SmsEdit extends JDialog implements SelectionListener {
 		return jPatientButton;
 	}
 	
-	private GoodDateTimeSpinnerChooser getJSchedDateChooser() {
+	private GoodDateTimeToggleChooser getJSchedDateChooser() {
 		if (jSchedDateChooser == null) {
-			jSchedDateChooser = new GoodDateTimeSpinnerChooser(LocalDateTime.now());
+			jSchedDateChooser = new GoodDateTimeToggleChooser(LocalDateTime.now());
 		}
 		return jSchedDateChooser;
 	}

--- a/src/main/java/org/isf/utils/jobjects/GoodDateTimeToggleChooser.java
+++ b/src/main/java/org/isf/utils/jobjects/GoodDateTimeToggleChooser.java
@@ -1,0 +1,63 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2022 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.isf.utils.jobjects;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import javax.swing.BoxLayout;
+
+import com.github.lgooddatepicker.components.DateTimePicker;
+
+public class GoodDateTimeToggleChooser extends GoodDateTimeChooserBase {
+
+	public GoodDateTimeToggleChooser(LocalDateTime dateTime) {
+		this(dateTime, true);
+	}
+
+	public GoodDateTimeToggleChooser(LocalDateTime dateTime, boolean useDefaultTimeChangeListener) {
+		BoxLayout layout = new BoxLayout(this, BoxLayout.Y_AXIS);
+		this.setLayout(layout);
+
+		setBaseSettings();
+
+		timeSettings.setDisplayToggleTimeMenuButton(true);
+		timeSettings.setDisplaySpinnerButtons(false);
+
+		dateTimePicker = new DateTimePicker(dateSettings, timeSettings);
+		// This helps the manual editing of the year field not to reset to some *very* old year value
+		dateSettings.setDateRangeLimits(LocalDate.of(999, 12, 31), null);
+		if (dateTime != null) {
+			dateTimePicker.datePicker.setDate(dateTime.toLocalDate());
+			dateTimePicker.timePicker.setTime(dateTime.toLocalTime());
+		}
+
+		setIcon();
+
+		if (useDefaultTimeChangeListener) {
+			setDefaultListener();
+		}
+
+		add(dateTimePicker);
+	}
+
+}


### PR DESCRIPTION
See OP-927

Increased the width of the date fields so both the date and time are visible by default.
Also centered the buttons on the New dialog to match other dialogs.