### PR TITLE
Chore: remove TODO left in the code

### DIFF
--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
@@ -1637,7 +1637,7 @@ public class WardPharmacy extends ModalJFrame implements
 							} else if (index == 1) {
 								xlsExport.exportTableToExcelOLD(jTableIncomes, exportFile);
 							} else if (index == 2) {
-								// TODO: ignore the last column in the table as it is a button object
+								// ignore the last column in the table as it is a button object
 								xlsExport.exportTableToExcelOLD(jTableDrugs, exportFile, 3);
 							}
 						}


### PR DESCRIPTION
What the TODO was referencing is already done; needs to be removed.