### PR TITLE
OP-943 honor the Excel file extension and use matching exporting code

### DIFF
--- a/src/main/java/org/isf/medicals/gui/MedicalBrowser.java
+++ b/src/main/java/org/isf/medicals/gui/MedicalBrowser.java
@@ -446,10 +446,10 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener {
 			if (iRetVal == JFileChooser.APPROVE_OPTION) {
 				File exportFile = fcExcel.getSelectedFile();
 				if (!exportFile.getName().endsWith(".xls") && !exportFile.getName().endsWith(".xlsx")) {
-					if (fcExcel.getFileFilter().getDescription().contains("*.xls")) {
-						exportFile = new File(exportFile.getAbsoluteFile() + ".xls");
-					} else {
+					if (fcExcel.getFileFilter().getDescription().contains("*.xlsx")) {
 						exportFile = new File(exportFile.getAbsoluteFile() + ".xlsx");
+					} else {
+						exportFile = new File(exportFile.getAbsoluteFile() + ".xls");
 					}
 				}
 				ExcelExporter xlsExport = new ExcelExporter();

--- a/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
@@ -975,10 +975,10 @@ public class MovStockBrowser extends ModalJFrame {
 			if (iRetVal == JFileChooser.APPROVE_OPTION) {
 				File exportFile = fcExcel.getSelectedFile();
 				if (!exportFile.getName().endsWith(".xls") && !exportFile.getName().endsWith(".xlsx")) {
-					if (fcExcel.getFileFilter().getDescription().contains("*.xls")) {
-						exportFile = new File(exportFile.getAbsoluteFile() + ".xls");
-					} else {
+					if (fcExcel.getFileFilter().getDescription().contains("*.xlsx")) {
 						exportFile = new File(exportFile.getAbsoluteFile() + ".xlsx");
+					} else {
+						exportFile = new File(exportFile.getAbsoluteFile() + ".xls");
 					}
 				}
 				ExcelExporter xlsExport = new ExcelExporter();

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
@@ -1645,10 +1645,10 @@ public class WardPharmacy extends ModalJFrame implements
 					try {
 						File exportFile = fcExcel.getSelectedFile();
 						if (!exportFile.getName().endsWith(".xls") && !exportFile.getName().endsWith(".xlsx")) {
-							if (fcExcel.getFileFilter().getDescription().contains("*.xls")) {
-								exportFile = new File(exportFile.getAbsoluteFile() + ".xls");
-							} else {
+							if (fcExcel.getFileFilter().getDescription().contains("*.xlsx")) {
 								exportFile = new File(exportFile.getAbsoluteFile() + ".xlsx");
+							} else {
+								exportFile = new File(exportFile.getAbsoluteFile() + ".xls");
 							}
 						}
 


### PR DESCRIPTION
This is the hotfix version.

See OP-943

Fixes the `contains()` test by using the longer string to test; `.xls` is also a part of `.xlsx`. Sorry.