### PR TITLE
OP-917 fix rendering of Rectify button

### DIFF
--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
@@ -1486,8 +1486,6 @@ public class WardPharmacy extends ModalJFrame implements
 					WardPharmacyRectify wardRectify = new WardPharmacyRectify(WardPharmacy.this, wardSelected, medic);
 					wardRectify.addMovementWardListener(WardPharmacy.this);
 					wardRectify.setVisible(true);
-					TableCellRenderer buttonRenderer = new JTableButtonRenderer();
-					jTableDrugs.getColumn("").setCellRenderer(buttonRenderer);
 				});
 				return button;
 			}
@@ -1530,9 +1528,6 @@ public class WardPharmacy extends ModalJFrame implements
 					wardRectify.addMovementWardListener(WardPharmacy.this);
 					wardRectify.setVisible(true);
 				}
-
-				TableCellRenderer buttonRenderer = new JTableButtonRenderer();
-				jTableDrugs.getColumn("").setCellRenderer(buttonRenderer);
 			});
 		}
 		return jRectifyButton;

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
@@ -118,13 +118,15 @@ public class WardPharmacy extends ModalJFrame implements
 	@Override
 	public void movementInserted(AWTEvent e) {
 		jTableOutcomes.setModel(new OutcomesModel());
-		jTableDrugs.setModel(new DrugsModel());
+		jTableDrugs = null;
+		jScrollPaneDrugs.setViewportView(getJTableDrugs());
 	}
 
 	@Override
 	public void movementUpdated(AWTEvent e) {
 		jTableOutcomes.setModel(new OutcomesModel());
-		jTableDrugs.setModel(new DrugsModel());
+		jTableDrugs = null;
+		jScrollPaneDrugs.setViewportView(getJTableDrugs());
 	}
 	
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
@@ -118,15 +118,13 @@ public class WardPharmacy extends ModalJFrame implements
 	@Override
 	public void movementInserted(AWTEvent e) {
 		jTableOutcomes.setModel(new OutcomesModel());
-		jTableDrugs = null;
-		jScrollPaneDrugs.setViewportView(getJTableDrugs());
+		jTableDrugs.setModel(new DrugsModel());
 	}
 
 	@Override
 	public void movementUpdated(AWTEvent e) {
 		jTableOutcomes.setModel(new OutcomesModel());
-		jTableDrugs = null;
-		jScrollPaneDrugs.setViewportView(getJTableDrugs());
+		jTableDrugs.setModel(new DrugsModel());
 	}
 	
 	private static final long serialVersionUID = 1L;
@@ -513,6 +511,7 @@ public class WardPharmacy extends ModalJFrame implements
 		if (jTableDrugs == null) {
 			DefaultTableModel modelDrugs = new DrugsModel();
 			jTableDrugs = new JTable(modelDrugs);
+			jTableDrugs.setAutoCreateColumnsFromModel(false);
 			TableCellRenderer buttonRenderer = new JTableButtonRenderer();
 			jTableDrugs.getColumn("").setCellRenderer(buttonRenderer);
 			for (int i = 0; i < columnWidthDrugs.length; i++) {


### PR DESCRIPTION
See OP-917  this addresses only the Pharmacy → Pharmaceutical Stock Ward → Drugs [tab] after the New button is used.

This is a bit heavy handed but after trying multiple options of reevaluate, invalidate, repaint, resetting the column widths, etc. nothing else worked.