### PR TITLE
OP-942 Better handling of multiple updates

### DIFF
--- a/src/main/java/org/isf/medicals/gui/MedicalBrowser.java
+++ b/src/main/java/org/isf/medicals/gui/MedicalBrowser.java
@@ -400,12 +400,6 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener {
 			} else {
 				selectedrow = table.convertRowIndexToModel(table.getSelectedRow());
 				medical = (Medical) (((MedicalBrowsingModel) model).getValueAt(selectedrow, -1));
-				// get the latest version of the medical just in case it has been previously updated; thus the lock variable will be correct
-				try {
-					medical = medicalBrowsingManager.getMedical(medical.getCode());
-				} catch(OHServiceException exception) {
-					LOGGER.error(exception.getMessage(), exception);
-				}
 				// Select Dates
 				GoodFromDateToDateChooser dataRange = new GoodFromDateToDateChooser(MedicalBrowser.this);
 				dataRange.setTitle(MessageBundle.getMessage("angal.messagedialog.question.title"));
@@ -483,12 +477,6 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener {
 			} else {
 				selectedrow = table.convertRowIndexToModel(table.getSelectedRow());
 				medical = (Medical) (((MedicalBrowsingModel) model).getValueAt(selectedrow, -1));
-				// get the latest version of the medical just in case it has been previously updated; thus the lock variable will be correct
-				try {
-					medical = medicalBrowsingManager.getMedical(this.medical.getCode());
-				} catch(OHServiceException exception) {
-					LOGGER.error(exception.getMessage(), exception);
-				}
 				int answer = MessageDialog.yesNo(MedicalBrowser.this, "angal.medicals.deletemedical.fmt.msg", medical.getDescription());
 				if (answer == JOptionPane.YES_OPTION) {
 					boolean deleted;
@@ -518,12 +506,6 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener {
 			} else {
 				selectedrow = table.convertRowIndexToModel(table.getSelectedRow());
 				medical = (Medical) (((MedicalBrowsingModel) model).getValueAt(selectedrow, -1));
-				// get the latest version of the medical just in case it has been previously updated; thus the lock variable will be correct
-				try {
-					medical = medicalBrowsingManager.getMedical(medical.getCode());
-				} catch(OHServiceException exception) {
-					LOGGER.error(exception.getMessage(), exception);
-				}
 				MedicalEdit editrecord = new MedicalEdit(medical, false, me);
 				editrecord.addMedicalListener(MedicalBrowser.this);
 				editrecord.setVisible(true);

--- a/src/main/java/org/isf/medicals/gui/MedicalEdit.java
+++ b/src/main/java/org/isf/medicals/gui/MedicalEdit.java
@@ -308,11 +308,19 @@ public class MedicalEdit extends JDialog {
 							}
 						}
 						if (result) {
+							Medical updatedMedical = null;
+							try {
+								updatedMedical = medicalBrowsingManager.getMedical(oldMedical.getCode());
+							} catch (OHServiceException exception) {
+								LOGGER.error(exception.getMessage(), exception);
+								updatedMedical = medical;
+							}
 							medical.setType((MedicalType) typeComboBox.getSelectedItem());
 							medical.setDescription(descriptionTextField.getText());
 							medical.setProdCode(codeTextField.getText());
 							medical.setPcsperpck(pcsperpckField.getValue());
 							medical.setMinqty(minQtiField.getValue());
+							medical.setLock(updatedMedical.getLock());
 							fireMedicalUpdated();
 							dispose();
 						}


### PR DESCRIPTION
See OP-942

After seeing the fix in https://github.com/informatici/openhospital-gui/pull/1287 and the related discussion I went back and found a better solution for this issue that better honors the lock variable.

After update immediately set the lock variable in the current in memory table to the value just changed.

If this is OK I will redo the hotfix version too.