### PR TITLE
OP-974 transactional methods in manager not catching runtime exceptions

### DIFF
--- a/src/main/java/org/isf/accounting/gui/BillBrowser.java
+++ b/src/main/java/org/isf/accounting/gui/BillBrowser.java
@@ -71,7 +71,6 @@ import org.isf.accounting.gui.totals.UserTotal;
 import org.isf.accounting.manager.BillBrowserManager;
 import org.isf.accounting.model.Bill;
 import org.isf.accounting.model.BillPayments;
-import org.isf.accounting.service.AccountingIoOperations;
 import org.isf.generaldata.GeneralData;
 import org.isf.generaldata.MessageBundle;
 import org.isf.hospital.manager.HospitalBrowsingManager;

--- a/src/main/java/org/isf/accounting/gui/BillBrowser.java
+++ b/src/main/java/org/isf/accounting/gui/BillBrowser.java
@@ -206,7 +206,7 @@ public class BillBrowser extends ModalJFrame implements PatientBillListener {
 	private int year;
 
 	//Bills & Payments
-	private BillBrowserManager billManager = new BillBrowserManager(Context.getApplicationContext().getBean(AccountingIoOperations.class));
+	private BillBrowserManager billManager = Context.getApplicationContext().getBean(BillBrowserManager.class);
 	private List<Bill> billPeriod;
 	private List<BillPayments> paymentsPeriod;
 	private List<Bill> billFromPayments;

--- a/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
+++ b/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
@@ -305,7 +305,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 	private List<PricesOthers> othPrices;
 
 	//Items and Payments (ALL)
-	private BillBrowserManager billManager = new BillBrowserManager(Context.getApplicationContext().getBean(AccountingIoOperations.class));
+	private BillBrowserManager billManager = Context.getApplicationContext().getBean(BillBrowserManager.class);
 	private PatientBrowserManager patManager = Context.getApplicationContext().getBean(PatientBrowserManager.class);
 
 	//Prices, Items and Payments for the tables

--- a/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
+++ b/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
@@ -69,7 +69,6 @@ import org.isf.accounting.manager.BillBrowserManager;
 import org.isf.accounting.model.Bill;
 import org.isf.accounting.model.BillItems;
 import org.isf.accounting.model.BillPayments;
-import org.isf.accounting.service.AccountingIoOperations;
 import org.isf.generaldata.GeneralData;
 import org.isf.generaldata.MessageBundle;
 import org.isf.generaldata.TxtPrinter;
@@ -1026,7 +1025,6 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 							user);                                       //User
 
 					try {
-						BillBrowserManager billManager = Context.getApplicationContext().getBean(BillBrowserManager.class);
 						billManager.updateBill(updateBill, billItems, payItems);
 					} catch (OHServiceException ex) {
 						OHServiceExceptionUtil.showMessages(ex, PatientBillEdit.this);

--- a/src/main/java/org/isf/admission/gui/AdmittedPatientBrowser.java
+++ b/src/main/java/org/isf/admission/gui/AdmittedPatientBrowser.java
@@ -946,7 +946,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 
 			if (patient != null) {
 				Patient pat = patient.getPatient();
-				BillBrowserManager billManager = new BillBrowserManager(Context.getApplicationContext().getBean(AccountingIoOperations.class));
+				BillBrowserManager billManager = Context.getApplicationContext().getBean(BillBrowserManager.class);
 				List<Bill> patientPendingBills;
 				try {
 					patientPendingBills = billManager.getPendingBills(pat.getCode());

--- a/src/main/java/org/isf/admission/gui/PatientFolderBrowser.java
+++ b/src/main/java/org/isf/admission/gui/PatientFolderBrowser.java
@@ -66,7 +66,6 @@ import org.isf.generaldata.GeneralData;
 import org.isf.generaldata.MessageBundle;
 import org.isf.lab.manager.LabManager;
 import org.isf.lab.model.Laboratory;
-import org.isf.lab.service.LabIoOperations;
 import org.isf.medstockmovtype.gui.MedicalsrMovPatList;
 import org.isf.menu.gui.MainMenu;
 import org.isf.menu.manager.Context;
@@ -890,7 +889,7 @@ public class PatientFolderBrowser extends ModalJFrame
 		private static final long serialVersionUID = -8245833681073162426L;
 
 		public LabBrowserModel() {
-			LabManager lbm = Context.getApplicationContext().getBean(LabManager.class, Context.getApplicationContext().getBean(LabIoOperations.class));
+			LabManager lbm = Context.getApplicationContext().getBean(LabManager.class);
 			try {
 				labList = lbm.getLaboratory(patient);
 				getOlderDate(labList, "examDate");

--- a/src/main/java/org/isf/lab/gui/LabBrowser.java
+++ b/src/main/java/org/isf/lab/gui/LabBrowser.java
@@ -53,7 +53,6 @@ import org.isf.lab.gui.LabNew.LabListener;
 import org.isf.lab.manager.LabManager;
 import org.isf.lab.model.Laboratory;
 import org.isf.lab.model.LaboratoryForPrint;
-import org.isf.lab.service.LabIoOperations;
 import org.isf.menu.gui.MainMenu;
 import org.isf.menu.manager.Context;
 import org.isf.patient.gui.SelectPatient;
@@ -490,7 +489,7 @@ public class LabBrowser extends ModalJFrame implements LabListener, LabEditListe
 	class LabBrowsingModel extends DefaultTableModel {
 
 		private static final long serialVersionUID = 1L;
-		private LabManager manager = Context.getApplicationContext().getBean(LabManager.class, Context.getApplicationContext().getBean(LabIoOperations.class));
+		private LabManager manager = Context.getApplicationContext().getBean(LabManager.class);
 
 		public LabBrowsingModel(String exam, LocalDate dateFrom, LocalDate dateTo) {
 			try {

--- a/src/main/java/org/isf/lab/gui/LabEdit.java
+++ b/src/main/java/org/isf/lab/gui/LabEdit.java
@@ -64,7 +64,6 @@ import org.isf.lab.manager.LabRowManager;
 import org.isf.lab.model.Laboratory;
 import org.isf.lab.model.LaboratoryForPrint;
 import org.isf.lab.model.LaboratoryRow;
-import org.isf.lab.service.LabIoOperations;
 import org.isf.menu.manager.Context;
 import org.isf.patient.manager.PatientBrowserManager;
 import org.isf.patient.model.Patient;
@@ -153,7 +152,7 @@ public class LabEdit extends ModalJFrame {
 	private static final int BUTTON_PANEL_HEIGHT = 40;
 
 	private ExamRowBrowsingManager rowManager = Context.getApplicationContext().getBean(ExamRowBrowsingManager.class);
-	private LabManager labManager = Context.getApplicationContext().getBean(LabManager.class, Context.getApplicationContext().getBean(LabIoOperations.class));
+	private LabManager labManager = Context.getApplicationContext().getBean(LabManager.class);
 	private LabRowManager lRowManager = Context.getApplicationContext().getBean(LabRowManager.class);
 
 	private List<ExamRow> eRows = null;
@@ -409,8 +408,7 @@ public class LabEdit extends ModalJFrame {
 	private JComboBox getMatComboBox() {
 		return Optional.ofNullable(matComboBox)
 				.orElseGet(() -> {
-					LabManager labMan = Context.getApplicationContext().getBean(LabManager.class);
-					List<String> materialList = labMan.getMaterialList();
+					List<String> materialList = labManager.getMaterialList();
 					return MatComboBox.withMaterialsAndMaterialFromLabSelected(materialList, lab, insert, labManager::getMaterialTranslated);
 				});
 	}

--- a/src/main/java/org/isf/lab/gui/LabEditExtended.java
+++ b/src/main/java/org/isf/lab/gui/LabEditExtended.java
@@ -503,8 +503,7 @@ public class LabEditExtended extends ModalJFrame {
 	private JComboBox getMatComboBox() {
 		return Optional.ofNullable(matComboBox)
 				.orElseGet(() -> {
-					LabManager labMan = Context.getApplicationContext().getBean(LabManager.class);
-					List<String> materialList = labMan.getMaterialList();
+					List<String> materialList = labManager.getMaterialList();
 					return MatComboBox.withMaterialsAndMaterialFromLabSelected(materialList, lab, insert, labManager::getMaterialTranslated);
 				});
 	}

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacyNew.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacyNew.java
@@ -60,7 +60,6 @@ import org.isf.examination.manager.ExaminationBrowserManager;
 import org.isf.generaldata.GeneralData;
 import org.isf.generaldata.MessageBundle;
 import org.isf.medicals.model.Medical;
-import org.isf.medicalstock.manager.MovStockInsertingManager;
 import org.isf.medicalstockward.manager.MovWardBrowserManager;
 import org.isf.medicalstockward.model.MedicalWard;
 import org.isf.medicalstockward.model.MovementWard;
@@ -265,8 +264,6 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 		return jRadioUse;
 	}
 
-	private MovStockInsertingManager movManager = Context.getApplicationContext().getBean(MovStockInsertingManager.class);
-	
 	class StockMovModel extends DefaultTableModel {
 
 		private static final long serialVersionUID = 1L;


### PR DESCRIPTION
See [OP-974](https://openhospital.atlassian.net/browse/OP-974).
Paired with https://github.com/informatici/openhospital-core/pull/776.

- [x] Managers must be taken from ApplicationContext in order to make transactions work.
- [x] No need to inject autowired in managers
- [x] Remove unused fields
- [x] Always share managers in the same class? (partially done, new issue will come)

Cc: @emecas, @vir8wh47, @robertoc223388