### PR TITLE
OP-983 fix index out of bounds when filtering the list

### DIFF
--- a/src/main/java/org/isf/exa/gui/ExamBrowser.java
+++ b/src/main/java/org/isf/exa/gui/ExamBrowser.java
@@ -394,6 +394,8 @@ public class ExamBrowser extends ModalJFrame implements ExamListener {
 			model = new ExamBrowsingModel(pSelection);
 		}
 		model.fireTableDataChanged();
+		sorter = new TableRowSorter<>(model);
+		table.setRowSorter(sorter);
 		table.updateUI();
 	}
 


### PR DESCRIPTION
See OP-983

Needed to recreate the `sorter` object and reattach it to the `table` when a change was made