### PR TITLE
OP-723 fix fetching wards in clinical sheet; row number needs adjustment

### DIFF
--- a/src/main/java/org/isf/admission/gui/PatientFolderBrowser.java
+++ b/src/main/java/org/isf/admission/gui/PatientFolderBrowser.java
@@ -775,7 +775,8 @@ public class PatientFolderBrowser extends ModalJFrame
 				if (row < admList.size()) {
 					return admList.get(row).getWard().getDescription();
 				} else if (row < opdList.size() + admList.size()) {
-					return opdList.get(row).getWard().getDescription();
+					int z = row - admList.size();
+					return opdList.get(z).getWard().getDescription();
 				} else {
 					return MessageBundle.getMessage("angal.admission.patientfolder.examination.txt");
 				}


### PR DESCRIPTION
See OP-723

After fix: Admission/Patient -> pick patient with multiple OPD and Wards -> Clinical Sheet should look like:
![image](https://user-images.githubusercontent.com/1105445/194907358-7fd7db91-c7bf-43ab-97e9-881c7169b101.png)
