### PR TITLE
Chore: remove test as LocalTime object must be in range of 0 to 24

### DIFF
--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -543,7 +543,6 @@ angal.hospital.savethechanges.msg                                               
 angal.hospital.thestartofvisitinghoursislaterthantheendhour.msg                                        = The start of the visiting hours is after the end hour.
 angal.hospital.thevisitdurationcannotbeblank.msg                                                       = The visit duration cannot be blank.
 angal.hospital.thevisitdurationmustbepositiveandlessthanthelengthofthevisitinghours.msg                = The visit duration must be postive and less than the length of the visiting hours.
-angal.hospital.thevisitinghourvaluesmustbeintherange0to24.msg                                          = The visiting hour values must be in the range of 0 to 24.
 angal.hospital.visitduration.txt                                                                       = Visit duration
 angal.hospital.visitendhour.txt                                                                        = Visit end hour
 angal.hospital.visitstarthour.txt                                                                      = Visit start hour

--- a/src/main/java/org/isf/hospital/gui/HospitalBrowser.java
+++ b/src/main/java/org/isf/hospital/gui/HospitalBrowser.java
@@ -272,10 +272,6 @@ public class HospitalBrowser extends ModalJFrame {
 			MessageDialog.error(null, "angal.hospital.thestartofvisitinghoursislaterthantheendhour.msg");
 			inError = true;
 		}
-		if (startTime.getHour() < 0 || endTime.getHour() > 24) {
-			MessageDialog.error(null, "angal.hospital.thevisitinghourvaluesmustbeintherange0to24.msg");
-			inError = true;
-		}
 		if (durationField.getText().isEmpty()) {
 			MessageDialog.error(null, "angal.hospital.thevisitdurationcannotbeblank.msg");
 			inError = true;


### PR DESCRIPTION
Because `startTime` and `endTime` are `LocalTime` objects the hour value ***must*** be in the range of 0 to 24 inclusive thus this test is not needed.