### PR TITLE
OP-996 use correct variable in updateMedial() call

### DIFF
--- a/src/main/java/org/isf/medicals/gui/MedicalEdit.java
+++ b/src/main/java/org/isf/medicals/gui/MedicalEdit.java
@@ -240,9 +240,9 @@ public class MedicalEdit extends JDialog {
 			okButton.addActionListener(new java.awt.event.ActionListener() {
 				@Override
 				public void actionPerformed(java.awt.event.ActionEvent e) {
-					Medical newMedical = null;
 					boolean result = false;
 					if (insert) { // inserting
+						Medical newMedical = null;
 						try {
 							newMedical = (Medical) medical.clone();
 							newMedical.setType((MedicalType) typeComboBox.getSelectedItem());
@@ -298,7 +298,7 @@ public class MedicalEdit extends JDialog {
 
 										if (ok == JOptionPane.OK_OPTION) {
 											try {
-												result = medicalBrowsingManager.updateMedical(newMedical, true);
+												result = medicalBrowsingManager.updateMedical(oldMedical, true);
 											} catch (OHServiceException e2) {
 												OHServiceExceptionUtil.showMessages(e2);
 											}


### PR DESCRIPTION
See OP-996

Also moved definition of `newMedical` to make the scope of the variable more clear.