### PR TITLE
Chore: combine all recent dependabot jar updates to match changes in Core repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<oh.version>1.12.0-SNAPSHOT</oh.version>
 		<java.version>11</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring.framework.version>5.3.23</spring.framework.version>
+		<spring.framework.version>5.3.24</spring.framework.version>
 		<spring.boot.version>2.7.5</spring.boot.version>
 		<license.maven.plugin.version>4.1</license.maven.plugin.version>
 	</properties>
@@ -270,12 +270,12 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.3</version>
+			<version>2.0.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-reload4j</artifactId>
-			<version>2.0.3</version>
+			<version>2.0.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.igniterealtime.smack</groupId>


### PR DESCRIPTION
Note this doesn't include the update to Spring 6 but does increment the Spring 5 version to latest 5.3.24