### PR TITLE
OP-981 dicom series for jpegs

### DIFF
--- a/rsc/dicom.properties.dist
+++ b/rsc/dicom.properties.dist
@@ -1,5 +1,6 @@
 #dicom.manager.impl=org.isf.dicom.manager.FileSystemDicomManager 	# filesystem storage
-#dicom.manager.impl=org.isf.dicom.manager.SqlDicomManager			# database storage
+#dicom.manager.impl=org.isf.dicom.manager.SqlDicomManager		# database storage
+
 #dicom.max.size=1024B, 2048B, 1M, 16M, 256M, 512M, 1024M, 1G		# image size examples
 dicom.manager.impl=org.isf.dicom.manager.DICOM_STORAGE
 dicom.storage.filesystem=OH_PATH_SUBSTITUTE/DICOM_DIR

--- a/rsc/dicom.properties.dist
+++ b/rsc/dicom.properties.dist
@@ -1,5 +1,5 @@
 #dicom.manager.impl=org.isf.dicom.manager.FileSystemDicomManager 	# filesystem storage
-#dicom.manager.impl=org.isf.dicom.manager.SqlDicomManager		# database storage
+#dicom.manager.impl=org.isf.dicom.manager.SqlDicomManager			# database storage
 #dicom.max.size=1024B, 2048B, 1M, 16M, 256M, 512M, 1024M, 1G		# image size examples
 dicom.manager.impl=org.isf.dicom.manager.DICOM_STORAGE
 dicom.storage.filesystem=OH_PATH_SUBSTITUTE/DICOM_DIR

--- a/rsc/dicom.properties.dist
+++ b/rsc/dicom.properties.dist
@@ -1,6 +1,5 @@
 #dicom.manager.impl=org.isf.dicom.manager.FileSystemDicomManager 	# filesystem storage
 #dicom.manager.impl=org.isf.dicom.manager.SqlDicomManager		# database storage
-
 #dicom.max.size=1024B, 2048B, 1M, 16M, 256M, 512M, 1024M, 1G		# image size examples
 dicom.manager.impl=org.isf.dicom.manager.DICOM_STORAGE
 dicom.storage.filesystem=OH_PATH_SUBSTITUTE/DICOM_DIR

--- a/src/main/java/org/isf/dicom/gui/DicomViewGui.java
+++ b/src/main/java/org/isf/dicom/gui/DicomViewGui.java
@@ -486,7 +486,7 @@ public class DicomViewGui extends JPanel {
 						MessageBundle.formatMessage("angal.dicom.thefileisnotindicomformat.fmt.msg", dett.getFileName()),
 						OHSeverityLevel.ERROR));
 			}
-			imageInputStream.close();
+			//imageInputStream.close();
 			this.attributes = null;
 		} catch (Exception exception) {
 			LOGGER.error(exception.getMessage(), exception);


### PR DESCRIPTION
See OP-981.

Fixed also an unwanted exception due to imageInputStream already closed by the `read()`.

Paired with https://github.com/informatici/openhospital-core/pull/857.