### PR TITLE
OP-1028 include test for missing hour value too

### DIFF
--- a/src/main/java/org/isf/opd/gui/OpdEditExtended.java
+++ b/src/main/java/org/isf/opd/gui/OpdEditExtended.java
@@ -1838,7 +1838,7 @@ public class OpdEditExtended extends ModalJFrame implements PatientInsertExtende
 				boolean isNextVisit = false;
 				LocalDateTime nextVisitDateTime = opdNextVisitDate.getLocalDateTimePermissive();
 				if (nextVisitDateTime != null) {
-					if (nextVisitDateTime.getMinute() == 0) {
+					if (nextVisitDateTime.getMinute() == 0 && nextVisitDateTime.getHour() == 0) {
 						MessageDialog.error(OpdEditExtended.this, "angal.opd.pleasechooseavalidtimeforthenextvisit.msg");
 						return;
 					}


### PR DESCRIPTION
See OP-1028

Reproduce by blanking out the time widget for a new visit.