### PR TITLE
OP-1025 separate business logic from gui in patient bill edit

### DIFF
--- a/.ide-settings/eclipse/OpenHospital-Java-CodeStyle-Formatter.xml
+++ b/.ide-settings/eclipse/OpenHospital-Java-CodeStyle-Formatter.xml
@@ -198,7 +198,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>

--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -161,7 +161,6 @@ angal.admission.therapy.btn                                                     
 angal.admission.therapy.btn.key                                                                        = H
 angal.admission.thereismorethanonependingbillforthispatientcontinue.msg                                = There is more than one pending bill for this patient, continue?
 angal.admission.theselectedadmissionhasnoconcernwithmalnutrition.msg                                   = The selected admission has no concern with malnutrition.
-angal.admission.thispatienthasapendingbill.msg                                                         = This Patient has a pending bill.
 angal.admission.treatmenttype.border                                                                   = Treatment Type
 angal.admission.unknown                                                                                = unknown
 angal.admission.visitdate.border                                                                       = Visit Date
@@ -1130,6 +1129,7 @@ angal.newbill.item.title                                                        
 angal.newbill.list.txt                                                                                 = List
 angal.newbill.medical.btn                                                                              = Medical
 angal.newbill.medical.title                                                                            = Medical
+angal.newbill.multipleopenedbillsnotallowedpleasesolve.msg                                             = Multiple opened bills not allowed, please solve.
 angal.newbill.newdescription.txt                                                                       = new description
 angal.newbill.nopricelistselectedwillbeused.fmt.msg                                                    = No pricelist selected. {0} will be used.
 angal.newbill.operation.btn                                                                            = Operation

--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -1159,9 +1159,9 @@ angal.newbill.selectamedical.txt                                                
 angal.newbill.selectanexam.txt                                                                         = Select an exam:
 angal.newbill.selectanoperation.txt                                                                    = Select an operation:
 angal.newbill.selectapricelist.title                                                                   = Select a PriceList
-angal.newbill.somepriceshavebeenchangeddoyouwanttoupdatetheitemsprices.fmg.msg                         = Some prices have been changed : {0}\n\nDo you want to update the items prices?
+angal.newbill.somepriceshavebeenchangeddoyouwanttoupdatetheitemsprices.fmg.msg                         = Some prices have been changed : {0}\n\nDo you want to update the items' prices?
 angal.newbill.somepricesnotfound.fmt.msg                                                               = Some prices not found : {0}
-angal.newbill.somepricesnotfoundandsomeotherchangeddoyouwanttoupdatetheitemsprices.fmt.msg             = Some prices not found and some other changed:\nNot found : {0}\nChanged : {1}\n\nDo you want to update the existing items prices?
+angal.newbill.somepricesnotfoundandsomeotherchangeddoyouwanttoupdatetheitemsprices.fmt.msg             = Some prices not found and some other changed:\nNot found : {0}\nChanged : {1}\n\nDo you want to update the existing items' prices?
 angal.newbill.thedateisbeforethelastpayment.msg                                                        = The date is before the last payment.
 angal.newbill.thepricelistassociatedwiththisbillnolongerexists.msg                                     = The pricelist associated with this bill no longer exists.
 angal.newbill.thisbillwaslinkedtoapreviousadmissiondoyouwanttolinkittothecurrentadmissioninstead.msg   = This bill was linked to a previous admission. Do you want to link it to the current admission instead?
@@ -1754,4 +1754,4 @@ angal.xmpp.userinfo.fmt.txt                                                     
 angal.xmpp.usersinfo.border                                                                            = User's Info
 angal.xmpp.wantstosharewithyouthisreport.fmt.msg                                                       = \n*** {0} wants to share with you this report: {1}\n
 angal.xmpp.wouldliketosend.fmt.msg                                                                     = {0} would like to send: \n{1}
-angal.xmpp.youhaverejectedthefiletransfer.txt                                                          = you have rejected the file transfer
+angal.xmpp.youhaverejectedthefiletransfer.txt                                                          = You have rejected the file transfer.

--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -1159,6 +1159,9 @@ angal.newbill.selectamedical.txt                                                
 angal.newbill.selectanexam.txt                                                                         = Select an exam:
 angal.newbill.selectanoperation.txt                                                                    = Select an operation:
 angal.newbill.selectapricelist.title                                                                   = Select a PriceList
+angal.newbill.somepriceshavebeenchangeddoyouwanttoupdatetheitemsprices.fmg.msg                         = Some prices have been changed : {0}\n\nDo you want to update the items prices?
+angal.newbill.somepricesnotfound.fmt.msg                                                               = Some prices not found : {0}
+angal.newbill.somepricesnotfoundandsomeotherchangeddoyouwanttoupdatetheitemsprices.fmt.msg             = Some prices not found and some other changed:\nNot found : {0}\nChanged : {1}\n\nDo you want to update the existing items prices?
 angal.newbill.thedateisbeforethelastpayment.msg                                                        = The date is before the last payment.
 angal.newbill.thepricelistassociatedwiththisbillnolongerexists.msg                                     = The pricelist associated with this bill no longer exists.
 angal.newbill.thisbillwaslinkedtoapreviousadmissiondoyouwanttolinkittothecurrentadmissioninstead.msg   = This bill was linked to a previous admission. Do you want to link it to the current admission instead?

--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -1160,8 +1160,8 @@ angal.newbill.selectanexam.txt                                                  
 angal.newbill.selectanoperation.txt                                                                    = Select an operation:
 angal.newbill.selectapricelist.title                                                                   = Select a PriceList
 angal.newbill.somepriceshavebeenchangeddoyouwanttoupdatetheitemsprices.fmg.msg                         = Some prices have been changed : {0}\n\nDo you want to update the items' prices?
-angal.newbill.somepricesnotfound.fmt.msg                                                               = Some prices not found : {0}
-angal.newbill.somepricesnotfoundandsomeotherchangeddoyouwanttoupdatetheitemsprices.fmt.msg             = Some prices not found and some other changed:\nNot found : {0}\nChanged : {1}\n\nDo you want to update the existing items' prices?
+angal.newbill.somepricesnotfound.fmt.msg                                                               = Some prices not found: {0}
+angal.newbill.somepricesnotfoundandsomeotherchangeddoyouwanttoupdatetheitemsprices.fmt.msg             = Some prices not found and some other changed:\nNot found: {0}\nChanged: {1}\n\nDo you want to update the existing items' prices?
 angal.newbill.thedateisbeforethelastpayment.msg                                                        = The date is before the last payment.
 angal.newbill.thepricelistassociatedwiththisbillnolongerexists.msg                                     = The pricelist associated with this bill no longer exists.
 angal.newbill.thisbillwaslinkedtoapreviousadmissiondoyouwanttolinkittothecurrentadmissioninstead.msg   = This bill was linked to a previous admission. Do you want to link it to the current admission instead?

--- a/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
+++ b/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
@@ -1141,9 +1141,10 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 				}
 
 				if (insert) {
-					Bill newBill = new Bill(0, // Bill ID
+					Bill newBill = new Bill(
+									0, // Bill ID
 									thisBill.getDate(), // from calendar
-									null, // most recent payment, will be set later
+									null, // updateDate from most recent payment, will be set later
 									true, // is a PriceList? always true, non-pricelist not managed
 									thisBill.getPriceList(), // List
 									thisBill.getPriceList().getName(), // List name
@@ -1157,7 +1158,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 									thisBill.getAdmission()); // Admission
 
 					try {
-						billBrowserManager.newBill(newBill, billItems, payItems);
+						billBrowserManager.newBill(newBill, billItems, payItems); // TODO: to verify if when can just pass thisBill
 						thisBill.setId(newBill.getId());
 					} catch (OHServiceException ex) {
 						OHServiceExceptionUtil.showMessages(ex, PatientBillEdit.this);
@@ -1167,9 +1168,10 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 					dispose();
 
 				} else {
-					Bill updateBill = new Bill(thisBill.getId(), // Bill ID
+					Bill updateBill = new Bill(
+									thisBill.getId(), // Bill ID
 									thisBill.getDate(), // from calendar
-									null, // most recent payment, will be set later
+									null, // updateDate from most recent payment, will be set later
 									true, // is a PriceList? always true, non-pricelist not managed
 									thisBill.getPriceList(), // List
 									thisBill.getPriceList().getName(), // List name
@@ -1183,7 +1185,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 									thisBill.getAdmission()); // Admission
 
 					try {
-						billBrowserManager.updateBill(updateBill, billItems, payItems);
+						billBrowserManager.updateBill(updateBill, billItems, payItems); // TODO: to verify if when can just pass thisBill
 					} catch (OHServiceException ex) {
 						OHServiceExceptionUtil.showMessages(ex, PatientBillEdit.this);
 						return;

--- a/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
+++ b/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
@@ -267,10 +267,6 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 	private JButton jButtonPickPatient;
 	private JButton jButtonTrashPatient;
 
-	private static final Dimension PatientDimension = new Dimension(300, 20);
-	private static final Dimension LabelsDimension = new Dimension(60, 20);
-	private static final Dimension UserDimension = new Dimension(220, 20);
-	private static final Dimension WardDimension = new Dimension(195, 20);
 	private static final int PANEL_WIDTH = 450;
 	private static final int BUTTON_WIDTH = 190;
 	private static final int BUTTON_WIDTH_BILL = 190;
@@ -284,6 +280,16 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 	private static final int PAYMENT_HEIGHT = 150;
 	private static final int BALANCE_HEIGHT = 20;
 	private static final int BUTTON_HEIGHT = 25;
+	private static final Dimension PATIENT_DIMENSION = new Dimension(300, 20);
+	private static final Dimension LABELS_DIMENSION = new Dimension(60, 20);
+	private static final Dimension USER_DIMENSION = new Dimension(220, 20);
+	private static final Dimension WARD_DIMENSION = new Dimension(195, 20);
+	private static final Dimension TOTAL_TABLE_SIZE = new Dimension(PANEL_WIDTH, TOTAL_HEIGHT);
+	private static final Dimension BIGTOTAL_TABLE_SIZE = new Dimension(PANEL_WIDTH, BIG_TOTAL_HEIGHT);
+	private static final Dimension BALANCE_TABLE_SIZE = new Dimension(PANEL_WIDTH, BALANCE_HEIGHT);
+	private static final Dimension BUTTON_ITEM_SIZE = new Dimension(BUTTON_WIDTH_BILL, BUTTON_HEIGHT);
+	private static final Dimension BUTTON_PAYMENT_SIZE = new Dimension(BUTTON_WIDTH_PAYMENT, BUTTON_HEIGHT);
+	private static final Dimension BUTTON_ACTION_SIZE = new Dimension(BUTTON_WIDTH, BUTTON_HEIGHT);
 
 	private BigDecimal total = new BigDecimal(0);
 	private BigDecimal bigTotal = new BigDecimal(0);
@@ -625,7 +631,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 	private JLabel getJLabelPatient() {
 		if (jLabelPatient == null) {
 			jLabelPatient = new JLabel(MessageBundle.getMessage("angal.common.patient.txt"));
-			jLabelPatient.setPreferredSize(LabelsDimension);
+			jLabelPatient.setPreferredSize(LABELS_DIMENSION);
 		}
 		return jLabelPatient;
 	}
@@ -634,7 +640,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		if (jTextFieldPatient == null) {
 			jTextFieldPatient = new JTextField();
 			jTextFieldPatient.setText(""); //$NON-NLS-1$
-			jTextFieldPatient.setPreferredSize(PatientDimension);
+			jTextFieldPatient.setPreferredSize(PATIENT_DIMENSION);
 			jTextFieldPatient.setEditable(false);
 		}
 		setJTextFieldPatient();
@@ -704,7 +710,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 	private JLabel getJLabelWard() {
 		if (jLabelWard == null) {
 			jLabelWard = new JLabel();
-			jLabelWard.setPreferredSize(WardDimension); // TODO: improve Layouts avoiding fixed dimensions
+			jLabelWard.setPreferredSize(WARD_DIMENSION); // TODO: improve Layouts avoiding fixed dimensions
 			jLabelWard.setHorizontalAlignment(SwingConstants.RIGHT);
 		}
 		setJLabelWard();
@@ -765,7 +771,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 	private JLabel getJLabelDate() {
 		if (jLabelDate == null) {
 			jLabelDate = new JLabel(MessageBundle.getMessage("angal.common.date.txt"));
-			jLabelDate.setPreferredSize(LabelsDimension);
+			jLabelDate.setPreferredSize(LABELS_DIMENSION);
 		}
 		return jLabelDate;
 	}
@@ -788,7 +794,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 	private JLabel getJLabelUser() {
 		if (jLabelUser == null) {
 			jLabelUser = new JLabel(MainMenu.getUser().getUserName());
-			jLabelUser.setPreferredSize(UserDimension); // improve Layouts avoiding fixed dimensions
+			jLabelUser.setPreferredSize(USER_DIMENSION); // improve Layouts avoiding fixed dimensions
 			jLabelUser.setHorizontalAlignment(SwingConstants.RIGHT);
 			jLabelUser.setForeground(Color.BLUE);
 			jLabelUser.setFont(new Font(jLabelUser.getFont().getName(), Font.BOLD, jLabelUser.getFont().getSize() + 2));
@@ -876,9 +882,10 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			jScrollPaneBill = new JScrollPane();
 			jScrollPaneBill.setBorder(null);
 			jScrollPaneBill.setViewportView(getJTableBill());
-			jScrollPaneBill.setMaximumSize(new Dimension(PANEL_WIDTH, BILL_HEIGHT));
-			jScrollPaneBill.setMinimumSize(new Dimension(PANEL_WIDTH, BILL_HEIGHT));
-			jScrollPaneBill.setPreferredSize(new Dimension(PANEL_WIDTH, BILL_HEIGHT));
+			Dimension size = new Dimension(PANEL_WIDTH, BILL_HEIGHT);
+			jScrollPaneBill.setMaximumSize(size);
+			jScrollPaneBill.setMinimumSize(size);
+			jScrollPaneBill.setPreferredSize(size);
 		}
 		return jScrollPaneBill;
 	}
@@ -904,9 +911,9 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			jScrollPaneBigTotal = new JScrollPane();
 			jScrollPaneBigTotal.setViewportView(getJTableBigTotal());
 			jScrollPaneBigTotal.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_NEVER);
-			jScrollPaneBigTotal.setMaximumSize(new Dimension(PANEL_WIDTH, BIG_TOTAL_HEIGHT));
-			jScrollPaneBigTotal.setMinimumSize(new Dimension(PANEL_WIDTH, BIG_TOTAL_HEIGHT));
-			jScrollPaneBigTotal.setPreferredSize(new Dimension(PANEL_WIDTH, BIG_TOTAL_HEIGHT));
+			jScrollPaneBigTotal.setMaximumSize(BIGTOTAL_TABLE_SIZE);
+			jScrollPaneBigTotal.setMinimumSize(BIGTOTAL_TABLE_SIZE);
+			jScrollPaneBigTotal.setPreferredSize(BIGTOTAL_TABLE_SIZE);
 		}
 		return jScrollPaneBigTotal;
 	}
@@ -916,9 +923,9 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			jScrollPaneTotal = new JScrollPane();
 			jScrollPaneTotal.setViewportView(getJTableTotal());
 			jScrollPaneTotal.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_NEVER);
-			jScrollPaneTotal.setMaximumSize(new Dimension(PANEL_WIDTH, TOTAL_HEIGHT));
-			jScrollPaneTotal.setMinimumSize(new Dimension(PANEL_WIDTH, TOTAL_HEIGHT));
-			jScrollPaneTotal.setPreferredSize(new Dimension(PANEL_WIDTH, TOTAL_HEIGHT));
+			jScrollPaneTotal.setMaximumSize(TOTAL_TABLE_SIZE);
+			jScrollPaneTotal.setMinimumSize(TOTAL_TABLE_SIZE);
+			jScrollPaneTotal.setPreferredSize(TOTAL_TABLE_SIZE);
 		}
 		return jScrollPaneTotal;
 	}
@@ -936,9 +943,9 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		jTableBigTotal.getColumnModel().getColumn(1).setMaxWidth(CURRENCY_CODE_WIDTH);
 		jTableBigTotal.getColumnModel().getColumn(2).setMinWidth(PRICE_WIDTH);
 		jTableBigTotal.getColumnModel().getColumn(2).setMaxWidth(PRICE_WIDTH);
-		jTableBigTotal.setMaximumSize(new Dimension(PANEL_WIDTH, BIG_TOTAL_HEIGHT));
-		jTableBigTotal.setMinimumSize(new Dimension(PANEL_WIDTH, BIG_TOTAL_HEIGHT));
-		jTableBigTotal.setPreferredSize(new Dimension(PANEL_WIDTH, BIG_TOTAL_HEIGHT));
+		jTableBigTotal.setMaximumSize(BIGTOTAL_TABLE_SIZE);
+		jTableBigTotal.setMinimumSize(BIGTOTAL_TABLE_SIZE);
+		jTableBigTotal.setPreferredSize(BIGTOTAL_TABLE_SIZE);
 	}
 
 	private void setJTableBigTotal() {
@@ -964,9 +971,9 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		jTableTotal.getColumnModel().getColumn(1).setMaxWidth(CURRENCY_CODE_WIDTH);
 		jTableTotal.getColumnModel().getColumn(2).setMinWidth(PRICE_WIDTH);
 		jTableTotal.getColumnModel().getColumn(2).setMaxWidth(PRICE_WIDTH);
-		jTableTotal.setMaximumSize(new Dimension(PANEL_WIDTH, TOTAL_HEIGHT));
-		jTableTotal.setMinimumSize(new Dimension(PANEL_WIDTH, TOTAL_HEIGHT));
-		jTableTotal.setPreferredSize(new Dimension(PANEL_WIDTH, TOTAL_HEIGHT));
+		jTableTotal.setMaximumSize(TOTAL_TABLE_SIZE);
+		jTableTotal.setMinimumSize(TOTAL_TABLE_SIZE);
+		jTableTotal.setPreferredSize(TOTAL_TABLE_SIZE);
 	}
 
 	private JScrollPane getJScrollPanePayment() {
@@ -974,9 +981,10 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			jScrollPanePayment = new JScrollPane();
 			jScrollPanePayment.setBorder(null);
 			jScrollPanePayment.setViewportView(getJTablePayment());
-			jScrollPanePayment.setMaximumSize(new Dimension(PANEL_WIDTH, PAYMENT_HEIGHT));
-			jScrollPanePayment.setMinimumSize(new Dimension(PANEL_WIDTH, PAYMENT_HEIGHT));
-			jScrollPanePayment.setPreferredSize(new Dimension(PANEL_WIDTH, PAYMENT_HEIGHT));
+			Dimension size = new Dimension(PANEL_WIDTH, PAYMENT_HEIGHT);
+			jScrollPanePayment.setMaximumSize(size);
+			jScrollPanePayment.setMinimumSize(size);
+			jScrollPanePayment.setPreferredSize(size);
 		}
 		return jScrollPanePayment;
 	}
@@ -999,9 +1007,9 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			jScrollPaneBalance = new JScrollPane();
 			jScrollPaneBalance.setViewportView(getJTableBalance());
 			jScrollPaneBalance.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_NEVER);
-			jScrollPaneBalance.setMaximumSize(new Dimension(PANEL_WIDTH, BALANCE_HEIGHT));
-			jScrollPaneBalance.setMinimumSize(new Dimension(PANEL_WIDTH, BALANCE_HEIGHT));
-			jScrollPaneBalance.setPreferredSize(new Dimension(PANEL_WIDTH, BALANCE_HEIGHT));
+			jScrollPaneBalance.setMaximumSize(PatientBillEdit.BALANCE_TABLE_SIZE);
+			jScrollPaneBalance.setMinimumSize(PatientBillEdit.BALANCE_TABLE_SIZE);
+			jScrollPaneBalance.setPreferredSize(BALANCE_TABLE_SIZE);
 		}
 		return jScrollPaneBalance;
 	}
@@ -1024,9 +1032,9 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		jTableBalance.getColumnModel().getColumn(1).setMaxWidth(CURRENCY_CODE_WIDTH);
 		jTableBalance.getColumnModel().getColumn(2).setMinWidth(PRICE_WIDTH);
 		jTableBalance.getColumnModel().getColumn(2).setMaxWidth(PRICE_WIDTH);
-		jTableBalance.setMaximumSize(new Dimension(PANEL_WIDTH, BALANCE_HEIGHT));
-		jTableBalance.setMinimumSize(new Dimension(PANEL_WIDTH, BALANCE_HEIGHT));
-		jTableBalance.setPreferredSize(new Dimension(PANEL_WIDTH, BALANCE_HEIGHT));
+		jTableBalance.setMaximumSize(BALANCE_TABLE_SIZE);
+		jTableBalance.setMinimumSize(BALANCE_TABLE_SIZE);
+		jTableBalance.setPreferredSize(BALANCE_TABLE_SIZE);
 	}
 
 	private JPanel getJPanelButtons() {
@@ -1051,9 +1059,10 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			jPanelButtonsBill.add(getJButtonAddOther());
 			jPanelButtonsBill.add(getJButtonAddCustom());
 			jPanelButtonsBill.add(getJButtonRemoveItem());
-			jPanelButtonsBill.setMinimumSize(new Dimension(BUTTON_WIDTH, BILL_HEIGHT + TOTAL_HEIGHT));
-			jPanelButtonsBill.setMaximumSize(new Dimension(BUTTON_WIDTH, BILL_HEIGHT + TOTAL_HEIGHT));
-			jPanelButtonsBill.setPreferredSize(new Dimension(BUTTON_WIDTH, BILL_HEIGHT + TOTAL_HEIGHT));
+			Dimension size = new Dimension(BUTTON_WIDTH, BILL_HEIGHT + TOTAL_HEIGHT);
+			jPanelButtonsBill.setMinimumSize(size);
+			jPanelButtonsBill.setMaximumSize(size);
+			jPanelButtonsBill.setPreferredSize(size);
 
 		}
 		return jPanelButtonsBill;
@@ -1069,8 +1078,9 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 				jPanelButtonsPayment.add(getJButtonPrintPayment());
 			}
 			jPanelButtonsPayment.add(getJButtonRemovePayment());
-			jPanelButtonsPayment.setMinimumSize(new Dimension(BUTTON_WIDTH, PAYMENT_HEIGHT));
-			jPanelButtonsPayment.setMaximumSize(new Dimension(BUTTON_WIDTH, PAYMENT_HEIGHT));
+			Dimension size = new Dimension(BUTTON_WIDTH, PAYMENT_HEIGHT);
+			jPanelButtonsPayment.setMinimumSize(size);
+			jPanelButtonsPayment.setMaximumSize(size);
 		}
 		return jPanelButtonsPayment;
 	}
@@ -1091,7 +1101,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		if (jButtonBalance == null) {
 			jButtonBalance = new JButton(MessageBundle.getMessage("angal.newbill.givechange.btn"));
 			jButtonBalance.setMnemonic(MessageBundle.getMnemonic("angal.newbill.givechange.btn.key"));
-			jButtonBalance.setMaximumSize(new Dimension(BUTTON_WIDTH, BUTTON_HEIGHT));
+			jButtonBalance.setMaximumSize(BUTTON_ACTION_SIZE);
 			jButtonBalance.setIcon(new ImageIcon("rsc/icons/money_button.png"));
 			jButtonBalance.setHorizontalAlignment(SwingConstants.LEFT);
 			toggleJButtonBalance();
@@ -1131,7 +1141,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		if (jButtonSave == null) {
 			jButtonSave = new JButton(MessageBundle.getMessage("angal.common.save.btn"));
 			jButtonSave.setMnemonic(MessageBundle.getMnemonic("angal.common.save.btn.key"));
-			jButtonSave.setMaximumSize(new Dimension(BUTTON_WIDTH, BUTTON_HEIGHT));
+			jButtonSave.setMaximumSize(BUTTON_ACTION_SIZE);
 			jButtonSave.setIcon(new ImageIcon("rsc/icons/save_button.png"));
 			jButtonSave.setHorizontalAlignment(SwingConstants.LEFT);
 			jButtonSave.addActionListener(actionEvent -> {
@@ -1217,7 +1227,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		if (jButtonPrintPayment == null) {
 			jButtonPrintPayment = new JButton(MessageBundle.getMessage("angal.newbill.paymentreceipt.btn"));
 			jButtonPrintPayment.setMnemonic(MessageBundle.getMnemonic("angal.newbill.paymentreceipt.btn.key"));
-			jButtonPrintPayment.setMaximumSize(new Dimension(BUTTON_WIDTH_PAYMENT, BUTTON_HEIGHT));
+			jButtonPrintPayment.setMaximumSize(BUTTON_PAYMENT_SIZE);
 			jButtonPrintPayment.setHorizontalAlignment(SwingConstants.LEFT);
 			jButtonPrintPayment.setIcon(new ImageIcon("rsc/icons/receipt_button.png"));
 			jButtonPrintPayment.addActionListener(actionEvent -> {
@@ -1238,7 +1248,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		if (jButtonPaid == null) {
 			jButtonPaid = new JButton(MessageBundle.getMessage("angal.newbill.paid.btn"));
 			jButtonPaid.setMnemonic(MessageBundle.getMnemonic("angal.newbill.paid.btn.key"));
-			jButtonPaid.setMaximumSize(new Dimension(BUTTON_WIDTH, BUTTON_HEIGHT));
+			jButtonPaid.setMaximumSize(BUTTON_ACTION_SIZE);
 			jButtonPaid.setIcon(new ImageIcon("rsc/icons/ok_button.png"));
 			jButtonPaid.setHorizontalAlignment(SwingConstants.LEFT);
 			toggleJButtonPaid();
@@ -1297,7 +1307,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		if (jButtonClose == null) {
 			jButtonClose = new JButton(MessageBundle.getMessage("angal.common.close.btn"));
 			jButtonClose.setMnemonic(MessageBundle.getMnemonic("angal.common.close.btn.key"));
-			jButtonClose.setMaximumSize(new Dimension(BUTTON_WIDTH, BUTTON_HEIGHT));
+			jButtonClose.setMaximumSize(BUTTON_ACTION_SIZE);
 			jButtonClose.setIcon(new ImageIcon("rsc/icons/close_button.png"));
 			jButtonClose.setHorizontalAlignment(SwingConstants.LEFT);
 			jButtonClose.addActionListener(actionEvent -> {
@@ -1320,7 +1330,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		if (jButtonAddRefund == null) {
 			jButtonAddRefund = new JButton(MessageBundle.getMessage("angal.newbill.refund.btn"));
 			jButtonAddRefund.setMnemonic(MessageBundle.getMnemonic("angal.newbill.refund.btn.key"));
-			jButtonAddRefund.setMaximumSize(new Dimension(BUTTON_WIDTH_PAYMENT, BUTTON_HEIGHT));
+			jButtonAddRefund.setMaximumSize(BUTTON_PAYMENT_SIZE);
 			jButtonAddRefund.setHorizontalAlignment(SwingConstants.LEFT);
 			jButtonAddRefund.setIcon(new ImageIcon("rsc/icons/plus_button.png"));
 			jButtonAddRefund.addActionListener(actionEvent -> {
@@ -1395,7 +1405,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		if (jButtonAddPayment == null) {
 			jButtonAddPayment = new JButton(MessageBundle.getMessage("angal.newbill.payment.btn"));
 			jButtonAddPayment.setMnemonic(MessageBundle.getMnemonic("angal.newbill.payment.btn.key"));
-			jButtonAddPayment.setMaximumSize(new Dimension(BUTTON_WIDTH_PAYMENT, BUTTON_HEIGHT));
+			jButtonAddPayment.setMaximumSize(BUTTON_PAYMENT_SIZE);
 			jButtonAddPayment.setHorizontalAlignment(SwingConstants.LEFT);
 			jButtonAddPayment.setIcon(new ImageIcon("rsc/icons/plus_button.png"));
 			jButtonAddPayment.addActionListener(actionEvent -> {
@@ -1449,7 +1459,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		if (jButtonRemovePayment == null) {
 			jButtonRemovePayment = new JButton(MessageBundle.getMessage("angal.newbill.removepayment.btn"));
 			jButtonRemovePayment.setMnemonic(MessageBundle.getMnemonic("angal.newbill.removepayment.btn.key"));
-			jButtonRemovePayment.setMaximumSize(new Dimension(BUTTON_WIDTH_PAYMENT, BUTTON_HEIGHT));
+			jButtonRemovePayment.setMaximumSize(BUTTON_PAYMENT_SIZE);
 			jButtonRemovePayment.setHorizontalAlignment(SwingConstants.LEFT);
 			jButtonRemovePayment.setIcon(new ImageIcon("rsc/icons/delete_button.png"));
 			jButtonRemovePayment.addActionListener(actionEvent -> {
@@ -1466,7 +1476,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		if (jButtonAddOther == null) {
 			jButtonAddOther = new JButton(MessageBundle.getMessage("angal.newbill.other.btn"));
 			jButtonAddOther.setMnemonic(MessageBundle.getMnemonic("angal.newbill.other.btn.key"));
-			jButtonAddOther.setMaximumSize(new Dimension(BUTTON_WIDTH_BILL, BUTTON_HEIGHT));
+			jButtonAddOther.setMaximumSize(BUTTON_ITEM_SIZE);
 			jButtonAddOther.setHorizontalAlignment(SwingConstants.LEFT);
 			jButtonAddOther.setIcon(new ImageIcon("rsc/icons/plus_button.png"));
 			jButtonAddOther.addActionListener(actionEvent -> {
@@ -1537,7 +1547,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		if (jButtonAddExam == null) {
 			jButtonAddExam = new JButton(MessageBundle.getMessage("angal.newbill.exam.btn"));
 			jButtonAddExam.setMnemonic(MessageBundle.getMnemonic("angal.newbill.exam.btn.key"));
-			jButtonAddExam.setMaximumSize(new Dimension(BUTTON_WIDTH_BILL, BUTTON_HEIGHT));
+			jButtonAddExam.setMaximumSize(BUTTON_ITEM_SIZE);
 			jButtonAddExam.setHorizontalAlignment(SwingConstants.LEFT);
 			jButtonAddExam.setIcon(new ImageIcon("rsc/icons/plus_button.png"));
 			jButtonAddExam.addActionListener(actionEvent -> {
@@ -1563,7 +1573,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		if (jButtonAddOperation == null) {
 			jButtonAddOperation = new JButton(MessageBundle.getMessage("angal.newbill.operation.btn"));
 			jButtonAddOperation.setMnemonic(MessageBundle.getMnemonic("angal.newbill.operation.btn.key"));
-			jButtonAddOperation.setMaximumSize(new Dimension(BUTTON_WIDTH_BILL, BUTTON_HEIGHT));
+			jButtonAddOperation.setMaximumSize(BUTTON_ITEM_SIZE);
 			jButtonAddOperation.setHorizontalAlignment(SwingConstants.LEFT);
 			jButtonAddOperation.setIcon(new ImageIcon("rsc/icons/plus_button.png"));
 			jButtonAddOperation.addActionListener(actionEvent -> {
@@ -1589,7 +1599,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		if (jButtonAddMedical == null) {
 			jButtonAddMedical = new JButton(MessageBundle.getMessage("angal.newbill.medical.btn"));
 			jButtonAddMedical.setMnemonic(MessageBundle.getMnemonic("angal.newbill.medical.btn"));
-			jButtonAddMedical.setMaximumSize(new Dimension(BUTTON_WIDTH_BILL, BUTTON_HEIGHT));
+			jButtonAddMedical.setMaximumSize(BUTTON_ITEM_SIZE);
 			jButtonAddMedical.setHorizontalAlignment(SwingConstants.LEFT);
 			jButtonAddMedical.setIcon(new ImageIcon("rsc/icons/plus_button.png"));
 			jButtonAddMedical.addActionListener(actionEvent -> {
@@ -1628,7 +1638,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		if (jButtonCustom == null) {
 			jButtonCustom = new JButton(MessageBundle.getMessage("angal.newbill.custom.btn"));
 			jButtonCustom.setMnemonic(MessageBundle.getMnemonic("angal.newbill.custom.btn.key"));
-			jButtonCustom.setMaximumSize(new Dimension(BUTTON_WIDTH_BILL, BUTTON_HEIGHT));
+			jButtonCustom.setMaximumSize(BUTTON_ITEM_SIZE);
 			jButtonCustom.setHorizontalAlignment(SwingConstants.LEFT);
 			jButtonCustom.setIcon(new ImageIcon("rsc/icons/plus_button.png"));
 			jButtonCustom.addActionListener(actionEvent -> {
@@ -1668,7 +1678,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		if (jButtonRemoveItem == null) {
 			jButtonRemoveItem = new JButton(MessageBundle.getMessage("angal.newbill.removeitem.btn"));
 			jButtonRemoveItem.setMnemonic(MessageBundle.getMnemonic("angal.newbill.removeitem.btn.key"));
-			jButtonRemoveItem.setMaximumSize(new Dimension(BUTTON_WIDTH_BILL, BUTTON_HEIGHT));
+			jButtonRemoveItem.setMaximumSize(BUTTON_ITEM_SIZE);
 			jButtonRemoveItem.setHorizontalAlignment(SwingConstants.LEFT);
 			jButtonRemoveItem.setIcon(new ImageIcon("rsc/icons/delete_button.png"));
 			jButtonRemoveItem.addActionListener(actionEvent -> {

--- a/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
+++ b/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
@@ -1926,10 +1926,6 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			super(new Object[][] { { "<html><b>" + MessageBundle.getMessage("angal.common.total.txt").toUpperCase() + "</b></html>", currencyCod, total } },
 							new String[] { "", "", "" });
 		}
-
-		private JTableTotalModel(Object[][] data, Object[] columnNames) {
-			super(data, columnNames);
-		}
 		@Override
 		public Class< ? > getColumnClass(int columnIndex) {
 			return types[columnIndex];
@@ -1954,11 +1950,6 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 					{ "<html><b>" + MessageBundle.getMessage("angal.newbill.balance.txt").toUpperCase() + "</b></html>", currencyCod, balance } },
 							new String[] { "", "", "" });
 		}
-
-		private JTableBalanceModel(Object[][] data, Object[] columnNames) {
-			super(data, columnNames);
-		}
-
 		@Override
 		public Class< ? > getColumnClass(int columnIndex) {
 			return types[columnIndex];
@@ -1978,9 +1969,6 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		private JTableBigTotalModel() {
 			super(new Object[][] { { "<html><b>" + MessageBundle.getMessage("angal.newbill.topay.txt") + "</b></html>", currencyCod, bigTotal } },
 							new String[] { "", "", "" });
-		}
-		private JTableBigTotalModel(Object[][] data, Object[] columnNames) {
-			super(data, columnNames);
 		}
 		@Override
 		public Class< ? > getColumnClass(int columnIndex) {

--- a/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
+++ b/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
@@ -590,9 +590,6 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 	}
 
 	private String createMessage(List<String> notFoundPriceList, List<String> changedPriceList) {
-		StringBuilder message = new StringBuilder("Some prices not found and some other changed:\nNot found : ");
-		message.append(String.join(", ", notFoundPriceList)).append("\nChanged : ").append(String.join(", ", changedPriceList))
-						.append("\n\nDo you want to update the existing items prices?");
 		return MessageBundle.formatMessage("angal.newbill.somepricesnotfoundandsomeotherchangeddoyouwanttoupdatetheitemsprices.fmt.msg",
 						String.join(", ", notFoundPriceList), String.join(", ", changedPriceList));
 	}

--- a/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
+++ b/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
@@ -295,9 +295,9 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 	private BigDecimal bigTotal = new BigDecimal(0);
 	private BigDecimal balance = new BigDecimal(0);
 	private boolean insert;
-	private boolean modified = false;
+	private boolean modified;
 	private boolean keepDate = true;
-	private boolean paid = false;
+	private boolean paid;
 	private LocalDateTime today = TimeTools.getNow();
 
 	/**
@@ -1007,8 +1007,8 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			jScrollPaneBalance = new JScrollPane();
 			jScrollPaneBalance.setViewportView(getJTableBalance());
 			jScrollPaneBalance.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_NEVER);
-			jScrollPaneBalance.setMaximumSize(PatientBillEdit.BALANCE_TABLE_SIZE);
-			jScrollPaneBalance.setMinimumSize(PatientBillEdit.BALANCE_TABLE_SIZE);
+			jScrollPaneBalance.setMaximumSize(BALANCE_TABLE_SIZE);
+			jScrollPaneBalance.setMinimumSize(BALANCE_TABLE_SIZE);
 			jScrollPaneBalance.setPreferredSize(BALANCE_TABLE_SIZE);
 		}
 		return jScrollPaneBalance;
@@ -1526,7 +1526,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 						String quantity = (String) JOptionPane.showInputDialog(PatientBillEdit.this, MessageBundle.getMessage("angal.newbill.howmanydays.txt"),
 										MessageBundle.getMessage("angal.newbill.days.title"), JOptionPane.PLAIN_MESSAGE, icon, null, qty);
 						try {
-							if (quantity == null || quantity.equals("")) {
+							if (quantity == null || quantity.isEmpty()) {
 								return;
 							}
 							qty = Integer.parseInt(quantity);

--- a/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
+++ b/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
@@ -348,7 +348,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 	public PatientBillEdit(JFrame owner, Patient patient) {
 		super(owner, true);
 		thisBill = new Bill();
-		load_dataset();
+		loadDataset();
 		initData(thisBill, true);
 		initComponents();
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
+++ b/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
@@ -301,8 +301,11 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 
 	// Tables
 	private Object[] billClasses = { Price.class, Integer.class, Double.class };
-	private String[] billColumnNames = { MessageBundle.getMessage("angal.newbill.item.col").toUpperCase(),
-			MessageBundle.getMessage("angal.common.qty.txt").toUpperCase(), MessageBundle.getMessage("angal.common.amount.txt").toUpperCase() };
+	private String[] billColumnNames = {
+			MessageBundle.getMessage("angal.newbill.item.col").toUpperCase(),
+			MessageBundle.getMessage("angal.common.qty.txt").toUpperCase(),
+			MessageBundle.getMessage("angal.common.amount.txt").toUpperCase()
+	};
 	private Object[] paymentClasses = { Date.class, Double.class };
 
 	// Hospital info

--- a/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
+++ b/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
@@ -370,7 +370,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 	 */
 	public PatientBillEdit(JFrame owner, Bill bill, boolean inserting) {
 		super(owner, true);
-		load_dataset();
+		loadDataset();
 		initData(bill, inserting);
 		initComponents();
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
@@ -389,7 +389,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		});
 	}
 
-	private void load_dataset() {
+	private void loadDataset() {
 		try {
 			this.prcArray = priceListManager.getPrices();
 			this.lstArray = priceListManager.getLists();

--- a/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
+++ b/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
@@ -115,10 +115,11 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 	private static final ImageIcon ADMISSION_ICON = new ImageIcon("rsc/icons/bed_icon.png");
 	private static final String OPD_TEXT = MessageBundle.getMessage("angal.common.opd.txt");
 
-	//LISTENER INTERFACE --------------------------------------------------------
+	// LISTENER INTERFACE --------------------------------------------------------
 	private EventListenerList patientBillListener = new EventListenerList();
 
 	public interface PatientBillListener extends EventListener {
+
 		void billInserted(AWTEvent aEvent);
 	}
 
@@ -165,8 +166,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		} else {
 			if (patientPendingBills.size() == 1) {
 				if (GeneralData.ALLOWMULTIPLEOPENEDBILL) {
-					int response = MessageDialog.yesNo(PatientBillEdit.this,
-							"angal.newbill.thispatienthasapendingbilldoyouwanttocreateanother.msg");
+					int response = MessageDialog.yesNo(PatientBillEdit.this, "angal.newbill.thispatienthasapendingbilldoyouwanttocreateanother.msg");
 					if (response == JOptionPane.YES_OPTION) {
 						this.insert = true;
 						thisBill.setBillPatient(patientSelected);
@@ -179,7 +179,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 						setBill(patientPendingBills.get(0));
 
 						/* ****** Check if it is same month ************** */
-						//checkIfSameMonth();
+						// checkIfSameMonth();
 						/* *********************************************** */
 					}
 				} else {
@@ -188,16 +188,15 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 					setBill(patientPendingBills.get(0));
 
 					/* ****** Check if it is same month ************** */
-					//checkIfSameMonth();
+					// checkIfSameMonth();
 					/* *********************************************** */
 				}
 			} else {
 				if (GeneralData.ALLOWMULTIPLEOPENEDBILL) {
-					int response = MessageDialog.yesNo(PatientBillEdit.this,
-							"angal.newbill.thispatienthasmorethanonependingbilldoyouwanttocreateanother.msg");
+					int response = MessageDialog.yesNo(PatientBillEdit.this, "angal.newbill.thispatienthasmorethanonependingbilldoyouwanttocreateanother.msg");
 					if (response == JOptionPane.YES_OPTION) {
 						this.insert = true;
-						//thisBill.setPatID(patientSelected.getCode());
+						// thisBill.setPatID(patientSelected.getCode());
 						thisBill.setBillPatient(patientSelected);
 						thisBill.setIsPatient(true);
 						thisBill.setPatName(patientSelected.getName());
@@ -206,12 +205,12 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 					} else if (response == JOptionPane.NO_OPTION) {
 						// something must be proposed
 						int resp = MessageDialog.yesNo(PatientBillEdit.this,
-								"angal.newbill.thispatienthasmorethanonependingbilldoyouwanttoopenthelastpendingbill.msg");
+										"angal.newbill.thispatienthasmorethanonependingbilldoyouwanttoopenthelastpendingbill.msg");
 						if (resp == JOptionPane.YES_OPTION) {
 							this.insert = false;
 							setBill(patientPendingBills.get(0));
 							/* ****** Check if it is same month ************** */
-							//checkIfSameMonth();
+							// checkIfSameMonth();
 							/* *********************************************** */
 						} else {
 							dispose();
@@ -306,56 +305,59 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 	private LocalDateTime today = TimeTools.getNow();
 	private String patientSelectedWard = "";
 
-	private Object[] billClasses = {Price.class, Integer.class, Double.class};
-	private String[] billColumnNames = {
-			MessageBundle.getMessage("angal.newbill.item.col").toUpperCase(),
-			MessageBundle.getMessage("angal.common.qty.txt").toUpperCase(),
-			MessageBundle.getMessage("angal.common.amount.txt").toUpperCase()
-	};
-	private Object[] paymentClasses = {Date.class, Double.class};
+	// Tables
+	private Object[] billClasses = { Price.class, Integer.class, Double.class };
+	private String[] billColumnNames = { MessageBundle.getMessage("angal.newbill.item.col").toUpperCase(),
+			MessageBundle.getMessage("angal.common.qty.txt").toUpperCase(), MessageBundle.getMessage("angal.common.amount.txt").toUpperCase() };
+	private Object[] paymentClasses = { Date.class, Double.class };
 
+	// Hospital info
+	private HospitalBrowsingManager hospitalManager = Context.getApplicationContext().getBean(HospitalBrowsingManager.class);
 	private String currencyCod;
 
-	//Prices and Lists (ALL)
+	// Prices and Lists (ALL)
 	private PriceListManager priceListManager = Context.getApplicationContext().getBean(PriceListManager.class);
 	private List<Price> prcArray;
 	private List<PriceList> lstArray;
 
-	//PricesOthers (ALL)
+	// PricesOthers (ALL)
 	private PricesOthersManager pricesOthersManager = Context.getApplicationContext().getBean(PricesOthersManager.class);
 	private List<PricesOthers> othPrices;
 
-	//Items and Payments (ALL)
+	// Items and Payments (ALL)
 	private BillBrowserManager billBrowserManager = Context.getApplicationContext().getBean(BillBrowserManager.class);
 	private PatientBrowserManager patientBrowserManager = Context.getApplicationContext().getBean(PatientBrowserManager.class);
 	private AdmissionBrowserManager admissionBrowserManager = Context.getApplicationContext().getBean(AdmissionBrowserManager.class);
 
-	//Prices, Items and Payments for the tables
+	// Prices, Items and Payments for the tables
 	private List<BillItems> billItems = new ArrayList<>();
 	private List<BillPayments> payItems = new ArrayList<>();
 	private List<Price> prcListArray = new ArrayList<>();
 	private int billItemsSaved;
 	private int payItemsSaved;
 
-	//User
+	// User
 	private String user = UserBrowsingManager.getCurrentUser();
 
 	public PatientBillEdit() {
-		initCurrencyCod();
 		PatientBillEdit newBill = new PatientBillEdit(null, new Bill(), true);
 		newBill.setVisible(true);
+		reload_from_db();
+	}
+
+	private void reload_from_db() {
 		try {
-			prcArray = priceListManager.getPrices();
-			lstArray = priceListManager.getLists();
-			othPrices = pricesOthersManager.getOthers();
+			this.prcArray = priceListManager.getPrices();
+			this.lstArray = priceListManager.getLists();
+			this.othPrices = pricesOthersManager.getOthers();
+			this.currencyCod = hospitalManager.getHospitalCurrencyCod();
 		} catch (OHServiceException e) {
 			OHServiceExceptionUtil.showMessages(e, PatientBillEdit.this);
 		}
 	}
 
-	//TODO: to harmonize constructors
+	// TODO: to harmonize constructors
 	public PatientBillEdit(JFrame owner, Patient patient) {
-		initCurrencyCod();
 		Bill bill = new Bill();
 		bill.setIsPatient(true);
 		bill.setBillPatient(patient);
@@ -368,30 +370,15 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 
 	public PatientBillEdit(JFrame owner, Bill bill, boolean inserting) {
 		super(owner, true);
-		initCurrencyCod();
 		this.insert = inserting;
-		try {
-			prcArray = priceListManager.getPrices();
-			lstArray = priceListManager.getLists();
-			othPrices = pricesOthersManager.getOthers();
-		} catch (OHServiceException e) {
-			OHServiceExceptionUtil.showMessages(e, PatientBillEdit.this);
-		}
-		setBill(bill);
 		initComponents();
+
+		reload_from_db();
+		setBill(bill);
 		updateTotals();
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 		setLocationRelativeTo(null);
 		setResizable(false);
-	}
-
-	private void initCurrencyCod() {
-		try {
-			this.currencyCod = Context.getApplicationContext().getBean(HospitalBrowsingManager.class).getHospitalCurrencyCod();
-		} catch (OHServiceException e) {
-			this.currencyCod = null;
-			OHServiceExceptionUtil.showMessages(e, PatientBillEdit.this);
-		}
 	}
 
 	private void setBill(Bill bill) {
@@ -431,27 +418,19 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		pack();
 	}
 
-	//check if PriceList and Patient still exist
+	// check if PriceList and Patient still exist
 	private void checkBill() {
 		if (thisBill.isList()) {
-			Optional<PriceList> priceList = lstArray.stream()
-					.filter(pl -> pl.getId() == thisBill.getPriceList().getId())
-					.findFirst();
+			Optional<PriceList> priceList = lstArray.stream().filter(pl -> pl.getId() == thisBill.getPriceList().getId()).findFirst();
 			priceList.ifPresent(pl -> listSelected = pl);
 
-			if (!priceList.isPresent()) { //PriceList not found
+			if (!priceList.isPresent()) { // PriceList not found
 				Icon icon = new ImageIcon("rsc/icons/list_dialog.png"); //$NON-NLS-1$
-				PriceList list = (PriceList)JOptionPane.showInputDialog(
-						PatientBillEdit.this,
-						MessageBundle.getMessage("angal.newbill.thepricelistassociatedwiththisbillnolongerexists.msg"),
-						MessageBundle.getMessage("angal.newbill.selectapricelist.title"),
-						JOptionPane.OK_OPTION,
-						icon,
-						lstArray.toArray(),
-						"");
+				PriceList list = (PriceList) JOptionPane.showInputDialog(PatientBillEdit.this,
+								MessageBundle.getMessage("angal.newbill.thepricelistassociatedwiththisbillnolongerexists.msg"),
+								MessageBundle.getMessage("angal.newbill.selectapricelist.title"), JOptionPane.OK_OPTION, icon, lstArray.toArray(), "");
 				if (list == null) {
-					MessageDialog.warning(PatientBillEdit.this, "angal.newbill.nopricelistselectedwillbeused.fmt.msg",
-							lstArray.get(0).getName());
+					MessageDialog.warning(PatientBillEdit.this, "angal.newbill.nopricelistselectedwillbeused.fmt.msg", lstArray.get(0).getName());
 					list = lstArray.get(0);
 				}
 				thisBill.setPriceList(list);
@@ -471,33 +450,36 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			if (patient != null) {
 				setPatientSelected(patient);
 				Admission currentAdmission = admissionBrowserManager.getCurrentAdmission(patient);
-				
+
 				Icon icon = UIManager.getIcon("OptionPane.warningIcon");
 				if (thisBill.getAdmission() == null && currentAdmission != null) {
-					int ok = MessageDialog.yesNo(PatientBillEdit.this, icon, "angal.newbill.thispatientisadmittednowdoyouwanttolinkthisbilltothecurrentadmission.msg");
+					int ok = MessageDialog.yesNo(PatientBillEdit.this, icon,
+									"angal.newbill.thispatientisadmittednowdoyouwanttolinkthisbilltothecurrentadmission.msg");
 					if (ok == JOptionPane.OK_OPTION) {
 						thisBill.setAdmission(currentAdmission);
 						modified = true;
 					}
 				}
 				if (thisBill.getAdmission() != null && currentAdmission == null) {
-					int ok = MessageDialog.yesNo(PatientBillEdit.this, icon, "angal.newbill.thispatientisnolongeradmitteddoyouwanttounlinkthisbillfromthepreviousadmission.msg");
+					int ok = MessageDialog.yesNo(PatientBillEdit.this, icon,
+									"angal.newbill.thispatientisnolongeradmitteddoyouwanttounlinkthisbillfromthepreviousadmission.msg");
 					if (ok == JOptionPane.OK_OPTION) {
 						thisBill.setAdmission(currentAdmission);
 						modified = true;
 					}
 				}
 				if (thisBill.getAdmission() != null && currentAdmission != null && thisBill.getAdmission().getId() != currentAdmission.getId()) {
-					int ok = MessageDialog.yesNo(PatientBillEdit.this, icon, "angal.newbill.thisbillwaslinkedtoapreviousadmissiondoyouwanttolinkittothecurrentadmissioninstead.msg");
+					int ok = MessageDialog.yesNo(PatientBillEdit.this, icon,
+									"angal.newbill.thisbillwaslinkedtoapreviousadmissiondoyouwanttolinkittothecurrentadmissioninstead.msg");
 					if (ok == JOptionPane.OK_OPTION) {
 						thisBill.setAdmission(currentAdmission);
 						modified = true;
 					}
 				}
-				
+
 				setAdmissionWard(thisBill.getAdmission());
-				
-			} else {  //Patient not found
+
+			} else { // Patient not found
 				MessageDialog.warning(PatientBillEdit.this, "angal.newbill.patientassociatedwiththisbillnolongerexists.msg");
 				thisBill.setIsPatient(false);
 				thisBill.getBillPatient().setCode(0);
@@ -549,18 +531,20 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		return jLabelPatient;
 	}
 
-
 	private JTextField getJTextFieldPatient() {
 		if (jTextFieldPatient == null) {
 			jTextFieldPatient = new JTextField();
 			jTextFieldPatient.setText(""); //$NON-NLS-1$
 			jTextFieldPatient.setPreferredSize(PatientDimension);
-			if (thisBill.isPatient()) {
-				jTextFieldPatient.setText(thisBill.getPatName());
-			}
 			jTextFieldPatient.setEditable(false);
 		}
 		return jTextFieldPatient;
+	}
+
+	private void setJTextFieldPatient() {
+		if (thisBill.isPatient()) {
+			jTextFieldPatient.setText(thisBill.getPatName());
+		}
 	}
 
 	private JLabel getJLabelPriceList() {
@@ -569,64 +553,58 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		}
 		return jLabelPriceList;
 	}
-	
+
 	private JComboBox<PriceList> getJComboBoxPriceList() {
 		if (jComboBoxPriceList == null) {
 			jComboBoxPriceList = new JComboBox<>();
-			PriceList list = null;
-			for (PriceList lst : lstArray) {
-
-				jComboBoxPriceList.addItem(lst);
-				if (!this.insert) {
-					if (lst.getId() == thisBill.getPriceList().getId()) {
-						list = lst;
-					}
-				}
-			}
-			if (list != null) {
-				jComboBoxPriceList.setSelectedItem(list);
-			}
-
 			jComboBoxPriceList.addActionListener(actionEvent -> {
 
-				listSelected = (PriceList)jComboBoxPriceList.getSelectedItem();
-				jTableBill.setModel(new BillTableModel());
+				listSelected = (PriceList) jComboBoxPriceList.getSelectedItem();
+				setJTableBill();
 				updateTotals();
 			});
 		}
 		return jComboBoxPriceList;
 	}
-	
+
+	private void setJComboBoxPriceList() {
+		PriceList list = null;
+		for (PriceList lst : lstArray) {
+
+			jComboBoxPriceList.addItem(lst);
+			if (!this.insert) {
+				if (lst.getId() == thisBill.getPriceList().getId()) {
+					list = lst;
+				}
+			}
+		}
+		if (list != null) {
+			jComboBoxPriceList.setSelectedItem(list);
+		}
+	}
+
 	private JLabel getJLabelWard() {
 		if (jLabelWard == null) {
 			jLabelWard = new JLabel();
-			jLabelWard.setPreferredSize(WardDimension); //TODO: improve Layout
+			jLabelWard.setPreferredSize(WardDimension); // TODO: improve Layout
 			jLabelWard.setHorizontalAlignment(SwingConstants.RIGHT);
-			if (!patientSelectedWard.isEmpty()) {
-				jLabelWard.setText(patientSelectedWard);
-				jLabelWard.setIcon(ADMISSION_ICON);
-			} else {
-				jLabelWard.setText(OPD_TEXT);
-				jLabelWard.setIcon(null);
-			}
 		}
 		return jLabelWard;
 	}
-	
+
+	private void setJLabelWard() {
+		if (!patientSelectedWard.isEmpty()) {
+			jLabelWard.setText(patientSelectedWard);
+			jLabelWard.setIcon(ADMISSION_ICON);
+		} else {
+			jLabelWard.setText(OPD_TEXT);
+			jLabelWard.setIcon(null);
+		}
+	}
+
 	private GoodDateTimeToggleChooser getJCalendarDate() {
 		if (jCalendarDate == null) {
-			if (this.insert) {
-				// To remind last used
-				billDate = RememberDates.getLastBillDate();
-				if (RememberDates.getLastBillDate() == null) {
-					billDate = TimeTools.getNow();
-				}
-			} else {
-				// get BillDate
-				billDate = thisBill.getDate();
-			}
 			jCalendarDate = new GoodDateTimeToggleChooser(billDate, false);
-
 			jCalendarDate.addDateTimeChangeListener(event -> {
 				DateChangeEvent dateChangeEvent = event.getDateChangeEvent();
 				TimeChangeEvent timeChangeEvent = event.getTimeChangeEvent();
@@ -663,6 +641,19 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		return jCalendarDate;
 	}
 
+	private void setBillDate() {
+		if (this.insert) {
+			// To remind last used
+			billDate = RememberDates.getLastBillDate();
+			if (RememberDates.getLastBillDate() == null) {
+				billDate = TimeTools.getNow();
+			}
+		} else {
+			// get BillDate
+			billDate = thisBill.getDate();
+		}
+	}
+
 	private JLabel getJLabelDate() {
 		if (jLabelDate == null) {
 			jLabelDate = new JLabel(MessageBundle.getMessage("angal.common.date.txt"));
@@ -689,7 +680,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 	private JLabel getJLabelUser() {
 		if (jLabelUser == null) {
 			jLabelUser = new JLabel(MainMenu.getUser().getUserName());
-			jLabelUser.setPreferredSize(UserDimension);  //TODO: improve Layout
+			jLabelUser.setPreferredSize(UserDimension); // TODO: improve Layout
 			jLabelUser.setHorizontalAlignment(SwingConstants.RIGHT);
 			jLabelUser.setForeground(Color.BLUE);
 			jLabelUser.setFont(new Font(jLabelUser.getFont().getName(), Font.BOLD, jLabelUser.getFont().getSize() + 2));
@@ -717,11 +708,14 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 				jButtonPickPatient.setToolTipText(MessageBundle.getMessage("angal.newbill.associateapatientwiththisbill.tooltip"));
 				jButtonTrashPatient.setEnabled(false);
 			});
-			if (!thisBill.isPatient()) {
-				jButtonTrashPatient.setEnabled(false);
-			}
 		}
 		return jButtonTrashPatient;
+	}
+
+	private void setTrashPatientButton() {
+		if (!thisBill.isPatient()) {
+			jButtonTrashPatient.setEnabled(false);
+		}
 	}
 
 	private JButton getJButtonPickPatient() {
@@ -739,13 +733,16 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 				sp.setVisible(true);
 
 			});
-			if (thisBill.isPatient()) {
-				jButtonPickPatient.setText(MessageBundle.getMessage("angal.newbill.changepatient.btn"));
-				jButtonPickPatient.setMnemonic(MessageBundle.getMnemonic("angal.newbill.changepatient.btn.key"));
-				jButtonPickPatient.setToolTipText(MessageBundle.getMessage("angal.newbill.changethepatientassociatedwiththisbill.tooltip"));
-			}
 		}
 		return jButtonPickPatient;
+	}
+
+	private void setJButtonPickPatient() {
+		if (thisBill.isPatient()) {
+			jButtonPickPatient.setText(MessageBundle.getMessage("angal.newbill.changepatient.btn"));
+			jButtonPickPatient.setMnemonic(MessageBundle.getMnemonic("angal.newbill.changepatient.btn.key"));
+			jButtonPickPatient.setToolTipText(MessageBundle.getMessage("angal.newbill.changethepatientassociatedwiththisbill.tooltip"));
+		}
 	}
 
 	public void setPatientSelected(Patient patientSelected) {
@@ -770,15 +767,13 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			jScrollPaneBill.setMaximumSize(new Dimension(PANEL_WIDTH, BILL_HEIGHT));
 			jScrollPaneBill.setMinimumSize(new Dimension(PANEL_WIDTH, BILL_HEIGHT));
 			jScrollPaneBill.setPreferredSize(new Dimension(PANEL_WIDTH, BILL_HEIGHT));
-
 		}
 		return jScrollPaneBill;
 	}
 
 	private JTable getJTableBill() {
 		if (jTableBill == null) {
-			jTableBill = new JTable();
-			jTableBill.setModel(new BillTableModel());
+			jTableBill = new JTable(new BillTableModel());
 			jTableBill.getColumnModel().getColumn(1).setMinWidth(QUANTITY_WIDTH);
 			jTableBill.getColumnModel().getColumn(1).setMaxWidth(QUANTITY_WIDTH);
 			jTableBill.getColumnModel().getColumn(2).setMinWidth(PRICE_WIDTH);
@@ -786,6 +781,10 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			jTableBill.setAutoCreateColumnsFromModel(false);
 		}
 		return jTableBill;
+	}
+
+	private void setJTableBill() {
+		jTableBill.setModel(new BillTableModel());
 	}
 
 	private JScrollPane getJScrollPaneBigTotal() {
@@ -814,26 +813,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 
 	private JTable getJTableBigTotal() {
 		if (jTableBigTotal == null) {
-			jTableBigTotal = new JTable();
-			jTableBigTotal.setModel(new DefaultTableModel(new Object[][] {
-					{
-							"<html><b>" + MessageBundle.getMessage("angal.newbill.topay.txt") + "</b></html>",
-							currencyCod,
-							bigTotal}
-			}, new String[] {"","", ""}) {
-				private static final long serialVersionUID = 1L;
-				Class<?>[] types = new Class<?>[] { JLabel.class, JLabel.class, Double.class, };
-
-				@Override
-				public Class<?> getColumnClass(int columnIndex) {
-					return types[columnIndex];
-				}
-
-				@Override
-				public boolean isCellEditable(int row, int column) {
-					return false;
-				}
-			});
+			jTableBigTotal = new JTable(new JTableBigTotalModel());
 			jTableBigTotal.getColumnModel().getColumn(1).setMinWidth(CURRENCY_CODE_WIDTH);
 			jTableBigTotal.getColumnModel().getColumn(1).setMaxWidth(CURRENCY_CODE_WIDTH);
 			jTableBigTotal.getColumnModel().getColumn(2).setMinWidth(PRICE_WIDTH);
@@ -845,29 +825,13 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		return jTableBigTotal;
 	}
 
+	private void setJTableBigTotal() {
+		jTableBigTotal.setModel(new JTableBigTotalModel());
+	}
+
 	private JTable getJTableTotal() {
 		if (jTableTotal == null) {
-			jTableTotal = new JTable();
-			jTableTotal.setModel(new DefaultTableModel(new Object[][] {
-					{
-							"<html><b>"+MessageBundle.getMessage("angal.common.total.txt").toUpperCase()+"</b></html>",
-							currencyCod,
-							total}
-			},
-					new String[] {"","", ""}) {
-				private static final long serialVersionUID = 1L;
-				Class<?>[] types = new Class<?>[] { JLabel.class, JLabel.class, Double.class, };
-
-				@Override
-				public Class<?> getColumnClass(int columnIndex) {
-					return types[columnIndex];
-				}
-
-				@Override
-				public boolean isCellEditable(int row, int column) {
-					return false;
-				}
-			});
+			jTableTotal = new JTable(new JTableTotalModel());
 			jTableTotal.getColumnModel().getColumn(1).setMinWidth(CURRENCY_CODE_WIDTH);
 			jTableTotal.getColumnModel().getColumn(1).setMaxWidth(CURRENCY_CODE_WIDTH);
 			jTableTotal.getColumnModel().getColumn(2).setMinWidth(PRICE_WIDTH);
@@ -877,6 +841,10 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			jTableTotal.setPreferredSize(new Dimension(PANEL_WIDTH, TOTAL_HEIGHT));
 		}
 		return jTableTotal;
+	}
+
+	private void setJTableTotal() {
+		jTableTotal.setModel(new JTableTotalModel());
 	}
 
 	private JScrollPane getJScrollPanePayment() {
@@ -893,12 +861,15 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 
 	private JTable getJTablePayment() {
 		if (jTablePayment == null) {
-			jTablePayment = new JTable();
-			jTablePayment.setModel(new PaymentTableModel());
+			jTablePayment = new JTable(new PaymentTableModel());
 			jTablePayment.getColumnModel().getColumn(1).setMinWidth(PRICE_WIDTH);
 			jTablePayment.getColumnModel().getColumn(1).setMaxWidth(PRICE_WIDTH);
 		}
 		return jTablePayment;
+	}
+
+	private void setJTablePayment() {
+		jTablePayment.setModel(new PaymentTableModel());
 	}
 
 	private JScrollPane getJScrollPaneBalance() {
@@ -915,27 +886,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 
 	private JTable getJTableBalance() {
 		if (jTableBalance == null) {
-			jTableBalance = new JTable();
-			jTableBalance.setModel(new DefaultTableModel(new Object[][] {
-					{
-							"<html><b>"+MessageBundle.getMessage("angal.newbill.balance.txt").toUpperCase()+"</b></html>",
-							currencyCod,
-							balance}
-			},
-					new String[] {"","",""}) {
-				private static final long serialVersionUID = 1L;
-				Class<?>[] types = new Class<?>[] { JLabel.class, JLabel.class, Double.class, };
-
-				@Override
-				public Class<?> getColumnClass(int columnIndex) {
-					return types[columnIndex];
-				}
-
-				@Override
-				public boolean isCellEditable(int row, int column) {
-					return false;
-				}
-			});
+			jTableBalance = new JTable(new JTableBalanceModel());
 			jTableBalance.getColumnModel().getColumn(1).setMinWidth(CURRENCY_CODE_WIDTH);
 			jTableBalance.getColumnModel().getColumn(1).setMaxWidth(CURRENCY_CODE_WIDTH);
 			jTableBalance.getColumnModel().getColumn(2).setMinWidth(PRICE_WIDTH);
@@ -945,6 +896,10 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			jTableBalance.setPreferredSize(new Dimension(PANEL_WIDTH, BALANCE_HEIGHT));
 		}
 		return jTableBalance;
+	}
+
+	private void setJTableBalance() {
+		jTableBalance.setModel(new JTableBalanceModel());
 	}
 
 	private JPanel getJPanelButtons() {
@@ -1012,21 +967,14 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			jButtonBalance.setMaximumSize(new Dimension(BUTTON_WIDTH, BUTTON_HEIGHT));
 			jButtonBalance.setIcon(new ImageIcon("rsc/icons/money_button.png"));
 			jButtonBalance.setHorizontalAlignment(SwingConstants.LEFT);
-			if (this.insert)  {
-				jButtonBalance.setEnabled(false);
-			}
+			toggleJButtonBalance();
 			jButtonBalance.addActionListener(actionEvent -> {
 
 				Icon icon = new ImageIcon("rsc/icons/money_dialog.png");
 				BigDecimal amount = new BigDecimal(0);
 
-				String quantity = (String) JOptionPane.showInputDialog(PatientBillEdit.this,
-						MessageBundle.getMessage("angal.newbill.entercustomercash.txt"),
-						MessageBundle.getMessage("angal.newbill.givechange.title"),
-						JOptionPane.OK_CANCEL_OPTION,
-						icon,
-						null,
-						amount);
+				String quantity = (String) JOptionPane.showInputDialog(PatientBillEdit.this, MessageBundle.getMessage("angal.newbill.entercustomercash.txt"),
+								MessageBundle.getMessage("angal.newbill.givechange.title"), JOptionPane.OK_CANCEL_OPTION, icon, null, amount);
 
 				if (quantity != null) {
 					try {
@@ -1035,10 +983,8 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 							return;
 						}
 						JOptionPane.showMessageDialog(PatientBillEdit.this,
-								MessageBundle.formatMessage("angal.newbill.givechange.fmt.msg", amount.subtract(balance)),
-								MessageBundle.getMessage("angal.newbill.givechange.title"),
-								JOptionPane.OK_OPTION,
-								icon);
+										MessageBundle.formatMessage("angal.newbill.givechange.fmt.msg", amount.subtract(balance)),
+										MessageBundle.getMessage("angal.newbill.givechange.title"), JOptionPane.OK_OPTION, icon);
 					} catch (Exception eee) {
 						MessageDialog.error(PatientBillEdit.this, "angal.newbill.invalidquantitypleasetryagain.msg");
 					}
@@ -1046,6 +992,12 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			});
 		}
 		return jButtonBalance;
+	}
+
+	private void toggleJButtonBalance() {
+		if (this.insert) {
+			jButtonBalance.setEnabled(false);
+		}
 	}
 
 	private JButton getJButtonSave() {
@@ -1062,29 +1014,26 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 				}
 
 				if (this.insert) {
-					RememberDates.setLastBillDate(billDate);             //to remember for next INSERT
-					Bill newBill = new Bill(0,                        //Bill ID
-							billDate,                                    //from calendar
-							billDate,                                    //most recent payment
-							true,                                   //is a List?
-							listSelected,                                //List
-							listSelected.getName(),                      //List name
-							thisBill.isPatient(),                        //is a Patient?
-							thisBill.isPatient() ?
-									patientSelected : null,    //Patient ID
-							thisBill.isPatient() ?
-									patientSelected.getName() :
-									jTextFieldPatient.getText(),         //Patient Name
-							paid ? "C" : "O",                            //CLOSED or OPEN
-							total.doubleValue(),                         //Total
-							balance.doubleValue(),                       //Balance
-							user,                                       //User
-							thisBill.getAdmission());					//Admission
-									
+					RememberDates.setLastBillDate(billDate); // to remember for next INSERT
+					Bill newBill = new Bill(0, // Bill ID
+									billDate, // from calendar
+									billDate, // most recent payment
+									true, // is a List?
+									listSelected, // List
+									listSelected.getName(), // List name
+									thisBill.isPatient(), // is a Patient?
+									thisBill.isPatient() ? patientSelected : null, // Patient ID
+									thisBill.isPatient() ? patientSelected.getName() : jTextFieldPatient.getText(), // Patient Name
+									paid ? "C" : "O", // CLOSED or OPEN
+									total.doubleValue(), // Total
+									balance.doubleValue(), // Balance
+									user, // User
+									thisBill.getAdmission()); // Admission
+
 					try {
 						billBrowserManager.newBill(newBill, billItems, payItems);
 						thisBill.setId(newBill.getId());
-					} catch(OHServiceException ex) {
+					} catch (OHServiceException ex) {
 						OHServiceExceptionUtil.showMessages(ex, PatientBillEdit.this);
 						return;
 					}
@@ -1092,23 +1041,20 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 					dispose();
 
 				} else {
-					Bill updateBill = new Bill(thisBill.getId(),         //Bill ID
-							billDate,                                    //from calendar
-							null,                                 //most recent payment
-							true,                                  //is a List?
-							listSelected,                                //List
-							listSelected.getName(),                      //List name
-							thisBill.isPatient(),                        //is a Patient?
-							thisBill.isPatient() ?
-									patientSelected : null,    //Patient ID
-							thisBill.isPatient() ?
-									thisBill.getPatName() :
-									jTextFieldPatient.getText(),         //Patient Name
-							paid ? "C" : "O",                            //CLOSED or OPEN
-							total.doubleValue(),                         //Total
-							balance.doubleValue(),                       //Balance
-							user,                                       //User
-							thisBill.getAdmission());					//Admission
+					Bill updateBill = new Bill(thisBill.getId(), // Bill ID
+									billDate, // from calendar
+									null, // most recent payment
+									true, // is a List?
+									listSelected, // List
+									listSelected.getName(), // List name
+									thisBill.isPatient(), // is a Patient?
+									thisBill.isPatient() ? patientSelected : null, // Patient ID
+									thisBill.isPatient() ? thisBill.getPatName() : jTextFieldPatient.getText(), // Patient Name
+									paid ? "C" : "O", // CLOSED or OPEN
+									total.doubleValue(), // Total
+									balance.doubleValue(), // Balance
+									user, // User
+									thisBill.getAdmission()); // Admission
 
 					try {
 						billBrowserManager.updateBill(updateBill, billItems, payItems);
@@ -1163,33 +1109,27 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			jButtonPaid.setMaximumSize(new Dimension(BUTTON_WIDTH, BUTTON_HEIGHT));
 			jButtonPaid.setIcon(new ImageIcon("rsc/icons/ok_button.png"));
 			jButtonPaid.setHorizontalAlignment(SwingConstants.LEFT);
-			if (this.insert) {
-				jButtonPaid.setEnabled(false);
-			}
+			toggleJButtonPaid();
 			jButtonPaid.addActionListener(actionEvent -> {
 
 				LocalDateTime datePay;
 
 				Icon icon = new ImageIcon("rsc/icons/money_dialog.png"); //$NON-NLS-1$
-				int ok = MessageDialog.yesNo(PatientBillEdit.this, icon,
-						"angal.newbill.doyouwanttosetthecurrentbillaspaid.msg");
+				int ok = MessageDialog.yesNo(PatientBillEdit.this, icon, "angal.newbill.doyouwanttosetthecurrentbillaspaid.msg");
 				if (ok == JOptionPane.NO_OPTION) {
 					return;
 				}
 
 				if (balance.compareTo(new BigDecimal(0)) > 0) {
-					if (billDate.isBefore(today)) { //if Bill is in the past the user will be asked for PAID date
+					if (billDate.isBefore(today)) { // if Bill is in the past the user will be asked for PAID date
 
 						icon = new ImageIcon("rsc/icons/calendar_dialog.png"); //$NON-NLS-1$
 
 						GoodDateTimeSpinnerChooser datePayChooser = new GoodDateTimeSpinnerChooser(TimeTools.getNow());
 
-						int r = JOptionPane.showConfirmDialog(PatientBillEdit.this,
-								datePayChooser,
-								MessageBundle.getMessage("angal.newbill.dateofpayment.title"),
-								JOptionPane.OK_CANCEL_OPTION,
-								JOptionPane.PLAIN_MESSAGE,
-								icon);
+						int r = JOptionPane.showConfirmDialog(PatientBillEdit.this, datePayChooser,
+										MessageBundle.getMessage("angal.newbill.dateofpayment.title"), JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE,
+										icon);
 
 						if (r == JOptionPane.OK_OPTION) {
 							datePay = datePayChooser.getLocalDateTime();
@@ -1213,6 +1153,12 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			});
 		}
 		return jButtonPaid;
+	}
+
+	private void toggleJButtonPaid() {
+		if (this.insert) {
+			jButtonPaid.setEnabled(false);
+		}
 	}
 
 	private JButton getJButtonClose() {
@@ -1252,14 +1198,8 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 
 				LocalDateTime datePay;
 
-				String quantity = (String) JOptionPane.showInputDialog(
-						PatientBillEdit.this,
-						MessageBundle.getMessage("angal.newbill.insertquantity.txt"),
-						MessageBundle.getMessage("angal.common.quantity.txt"),
-						JOptionPane.PLAIN_MESSAGE,
-						icon,
-						null,
-						amount);
+				String quantity = (String) JOptionPane.showInputDialog(PatientBillEdit.this, MessageBundle.getMessage("angal.newbill.insertquantity.txt"),
+								MessageBundle.getMessage("angal.common.quantity.txt"), JOptionPane.PLAIN_MESSAGE, icon, null, amount);
 				if (quantity != null) {
 					try {
 						amount = new BigDecimal(quantity).negate();
@@ -1274,14 +1214,11 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 					return;
 				}
 
-				if (billDate.isBefore(today)) { //if is a bill in the past the user will be asked for date of payment
+				if (billDate.isBefore(today)) { // if is a bill in the past the user will be asked for date of payment
 
 					GoodDateTimeSpinnerChooser datePayChooser = new GoodDateTimeSpinnerChooser(TimeTools.getNow());
-					int r = JOptionPane.showConfirmDialog(PatientBillEdit.this,
-							datePayChooser,
-							MessageBundle.getMessage("angal.newbill.dateofpayment.title"),
-							JOptionPane.OK_CANCEL_OPTION,
-							JOptionPane.PLAIN_MESSAGE);
+					int r = JOptionPane.showConfirmDialog(PatientBillEdit.this, datePayChooser, MessageBundle.getMessage("angal.newbill.dateofpayment.title"),
+									JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
 
 					if (r == JOptionPane.OK_OPTION) {
 						datePay = datePayChooser.getLocalDateTime();
@@ -1336,14 +1273,8 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 
 				LocalDateTime datePay;
 
-				String quantity = (String) JOptionPane.showInputDialog(
-						PatientBillEdit.this,
-						MessageBundle.getMessage("angal.newbill.insertquantity.txt"),
-						MessageBundle.getMessage("angal.common.quantity.txt"),
-						JOptionPane.PLAIN_MESSAGE,
-						icon,
-						null,
-						amount);
+				String quantity = (String) JOptionPane.showInputDialog(PatientBillEdit.this, MessageBundle.getMessage("angal.newbill.insertquantity.txt"),
+								MessageBundle.getMessage("angal.common.quantity.txt"), JOptionPane.PLAIN_MESSAGE, icon, null, amount);
 				if (quantity != null) {
 					try {
 						amount = new BigDecimal(quantity);
@@ -1358,14 +1289,11 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 					return;
 				}
 
-				if (billDate.isBefore(today)) { //if is a bill in the past the user will be asked for date of payment
+				if (billDate.isBefore(today)) { // if is a bill in the past the user will be asked for date of payment
 
 					GoodDateTimeSpinnerChooser datePayChooser = new GoodDateTimeSpinnerChooser(TimeTools.getNow());
-					int r = JOptionPane.showConfirmDialog(PatientBillEdit.this,
-							datePayChooser,
-							MessageBundle.getMessage("angal.newbill.dateofpayment.title"),
-							JOptionPane.OK_CANCEL_OPTION,
-							JOptionPane.PLAIN_MESSAGE);
+					int r = JOptionPane.showConfirmDialog(PatientBillEdit.this, datePayChooser, MessageBundle.getMessage("angal.newbill.dateofpayment.title"),
+									JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
 
 					if (r == JOptionPane.OK_OPTION) {
 						datePay = datePayChooser.getLocalDateTime();
@@ -1426,26 +1354,14 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 				}
 
 				Icon icon = new ImageIcon("rsc/icons/plus_dialog.png");
-				Price oth = (Price) JOptionPane.showInputDialog(
-						PatientBillEdit.this,
-						MessageBundle.getMessage("angal.newbill.pleaseselectanitem.txt"),
-						MessageBundle.getMessage("angal.newbill.item.title"),
-						JOptionPane.PLAIN_MESSAGE,
-						icon,
-						othArray.toArray(),
-						""); //$NON-NLS-1$
+				Price oth = (Price) JOptionPane.showInputDialog(PatientBillEdit.this, MessageBundle.getMessage("angal.newbill.pleaseselectanitem.txt"),
+								MessageBundle.getMessage("angal.newbill.item.title"), JOptionPane.PLAIN_MESSAGE, icon, othArray.toArray(), ""); //$NON-NLS-2$
 
 				if (oth != null) {
 					if (othersHashMap.get(Integer.valueOf(oth.getItem())).isUndefined()) {
 						icon = new ImageIcon("rsc/icons/money_dialog.png"); //$NON-NLS-1$
-						String price = (String) JOptionPane.showInputDialog(
-								PatientBillEdit.this,
-								MessageBundle.getMessage("angal.newbill.howmuchisit.txt"),
-								MessageBundle.getMessage("angal.common.undefined.txt"),
-								JOptionPane.PLAIN_MESSAGE,
-								icon,
-								null,
-								"0"); //$NON-NLS-1$
+						String price = (String) JOptionPane.showInputDialog(PatientBillEdit.this, MessageBundle.getMessage("angal.newbill.howmuchisit.txt"),
+										MessageBundle.getMessage("angal.common.undefined.txt"), JOptionPane.PLAIN_MESSAGE, icon, null, "0"); //$NON-NLS-2$
 						try {
 							if (price == null) {
 								return;
@@ -1465,14 +1381,8 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 					if (othersHashMap.get(Integer.valueOf(oth.getItem())).isDaily()) {
 						int qty = 1;
 						icon = new ImageIcon("rsc/icons/calendar_dialog.png"); //$NON-NLS-1$
-						String quantity = (String) JOptionPane.showInputDialog(
-								PatientBillEdit.this,
-								MessageBundle.getMessage("angal.newbill.howmanydays.txt"),
-								MessageBundle.getMessage("angal.newbill.days.title"),
-								JOptionPane.PLAIN_MESSAGE,
-								icon,
-								null,
-								qty);
+						String quantity = (String) JOptionPane.showInputDialog(PatientBillEdit.this, MessageBundle.getMessage("angal.newbill.howmanydays.txt"),
+										MessageBundle.getMessage("angal.newbill.days.title"), JOptionPane.PLAIN_MESSAGE, icon, null, qty);
 						try {
 							if (quantity == null || quantity.equals("")) {
 								return;
@@ -1509,14 +1419,8 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 				}
 
 				Icon icon = new ImageIcon("rsc/icons/exam_dialog.png"); //$NON-NLS-1$
-				Price exa = (Price) JOptionPane.showInputDialog(
-						PatientBillEdit.this,
-						MessageBundle.getMessage("angal.newbill.selectanexam.txt"),
-						MessageBundle.getMessage("angal.newbill.exam.title"),
-						JOptionPane.PLAIN_MESSAGE,
-						icon,
-						exaArray.toArray(),
-						""); //$NON-NLS-1$
+				Price exa = (Price) JOptionPane.showInputDialog(PatientBillEdit.this, MessageBundle.getMessage("angal.newbill.selectanexam.txt"),
+								MessageBundle.getMessage("angal.newbill.exam.title"), JOptionPane.PLAIN_MESSAGE, icon, exaArray.toArray(), ""); //$NON-NLS-2$
 				addItem(exa, 1, true);
 			});
 		}
@@ -1541,14 +1445,8 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 				}
 
 				Icon icon = new ImageIcon("rsc/icons/operation_dialog.png"); //$NON-NLS-1$
-				Price ope = (Price) JOptionPane.showInputDialog(
-						PatientBillEdit.this,
-						MessageBundle.getMessage("angal.newbill.selectanoperation.txt"),
-						MessageBundle.getMessage("angal.newbill.operation.title"),
-						JOptionPane.PLAIN_MESSAGE,
-						icon,
-						opeArray.toArray(),
-						""); //$NON-NLS-1$
+				Price ope = (Price) JOptionPane.showInputDialog(PatientBillEdit.this, MessageBundle.getMessage("angal.newbill.selectanoperation.txt"),
+								MessageBundle.getMessage("angal.newbill.operation.title"), JOptionPane.PLAIN_MESSAGE, icon, opeArray.toArray(), ""); //$NON-NLS-2$
 				addItem(ope, 1, true);
 			});
 		}
@@ -1573,24 +1471,12 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 				}
 
 				Icon icon = new ImageIcon("rsc/icons/medical_dialog.png"); //$NON-NLS-1$
-				Price med = (Price) JOptionPane.showInputDialog(
-						PatientBillEdit.this,
-						MessageBundle.getMessage("angal.newbill.selectamedical.txt"),
-						MessageBundle.getMessage("angal.newbill.medical.title"),
-						JOptionPane.PLAIN_MESSAGE,
-						icon,
-						medArray.toArray(),
-						""); //$NON-NLS-1$
+				Price med = (Price) JOptionPane.showInputDialog(PatientBillEdit.this, MessageBundle.getMessage("angal.newbill.selectamedical.txt"),
+								MessageBundle.getMessage("angal.newbill.medical.title"), JOptionPane.PLAIN_MESSAGE, icon, medArray.toArray(), ""); //$NON-NLS-2$
 				if (med != null) {
 					int qty = 1;
-					String quantity = (String) JOptionPane.showInputDialog(
-							PatientBillEdit.this,
-							MessageBundle.getMessage("angal.newbill.insertquantity.txt"),
-							MessageBundle.getMessage("angal.common.quantity.txt"),
-							JOptionPane.PLAIN_MESSAGE,
-							icon,
-							null,
-							qty);
+					String quantity = (String) JOptionPane.showInputDialog(PatientBillEdit.this, MessageBundle.getMessage("angal.newbill.insertquantity.txt"),
+									MessageBundle.getMessage("angal.common.quantity.txt"), JOptionPane.PLAIN_MESSAGE, icon, null, qty);
 					try {
 						if (quantity == null || quantity.equals("")) {
 							return;
@@ -1616,26 +1502,15 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			jButtonCustom.addActionListener(actionEvent -> {
 				double amount;
 				Icon icon = new ImageIcon("rsc/icons/custom_dialog.png"); //$NON-NLS-1$
-				String desc = (String) JOptionPane.showInputDialog(
-						PatientBillEdit.this,
-						MessageBundle.getMessage("angal.newbill.chooseadescription.txt"),
-						MessageBundle.getMessage("angal.newbill.customitem.title"),
-						JOptionPane.PLAIN_MESSAGE,
-						icon,
-						null,
-						MessageBundle.getMessage("angal.newbill.newdescription.txt"));
+				String desc = (String) JOptionPane.showInputDialog(PatientBillEdit.this, MessageBundle.getMessage("angal.newbill.chooseadescription.txt"),
+								MessageBundle.getMessage("angal.newbill.customitem.title"), JOptionPane.PLAIN_MESSAGE, icon, null,
+								MessageBundle.getMessage("angal.newbill.newdescription.txt"));
 				if (desc == null || desc.equals("")) { //$NON-NLS-1$
 					return;
 				} else {
 					icon = new ImageIcon("rsc/icons/money_dialog.png"); //$NON-NLS-1$
-					String price = (String) JOptionPane.showInputDialog(
-							PatientBillEdit.this,
-							MessageBundle.getMessage("angal.newbill.howmuchisit.txt"),
-							MessageBundle.getMessage("angal.newbill.customitem.title"),
-							JOptionPane.PLAIN_MESSAGE,
-							icon,
-							null,
-							"0"); //$NON-NLS-1$
+					String price = (String) JOptionPane.showInputDialog(PatientBillEdit.this, MessageBundle.getMessage("angal.newbill.howmuchisit.txt"),
+									MessageBundle.getMessage("angal.newbill.customitem.title"), JOptionPane.PLAIN_MESSAGE, icon, null, "0"); //$NON-NLS-2$
 					try {
 						amount = Double.parseDouble(price);
 					} catch (Exception eee) {
@@ -1646,13 +1521,8 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 				}
 
 				try {
-					BillItems newItem = new BillItems(0,
-							billBrowserManager.getBill(billID),
-							false,
-							"", //$NON-NLS-1$
-							desc,
-							amount,
-							1);
+					BillItems newItem = new BillItems(0, billBrowserManager.getBill(billID), false, "", //$NON-NLS-1$
+									desc, amount, 1);
 					addItem(newItem);
 				} catch (OHServiceException ohServiceException) {
 					MessageDialog.showExceptions(ohServiceException);
@@ -1679,7 +1549,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		return jButtonRemoveItem;
 	}
 
-	private void updateTotal() { //only positive items make the bill's total
+	private void updateTotal() { // only positive items make the bill's total
 		total = new BigDecimal(0);
 		for (BillItems item : billItems) {
 			double amount = item.getItemAmount();
@@ -1690,7 +1560,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		}
 	}
 
-	private void updateBigTotal() { //the big total (to pay) is made by all items
+	private void updateBigTotal() { // the big total (to pay) is made by all items
 		bigTotal = new BigDecimal(0);
 		for (BillItems item : billItems) {
 			BigDecimal itemAmount = new BigDecimal(Double.toString(item.getItemAmount()));
@@ -1698,7 +1568,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		}
 	}
 
-	private void updateBalance() { //the balance is what remaining after payments
+	private void updateBalance() { // the balance is what remaining after payments
 		balance = new BigDecimal(0);
 		BigDecimal payments = new BigDecimal(0);
 		for (BillPayments pay : payItems) {
@@ -1718,13 +1588,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		if (prc != null) {
 			double amount = prc.getPrice();
 			try {
-				BillItems item = new BillItems(0,
-						billBrowserManager.getBill(billID),
-						isPrice,
-						prc.getGroup() + prc.getItem(),
-						prc.getDesc(),
-						amount,
-						qty);
+				BillItems item = new BillItems(0, billBrowserManager.getBill(billID), isPrice, prc.getGroup() + prc.getItem(), prc.getDesc(), amount, qty);
 				billItems.add(item);
 			} catch (OHServiceException e) {
 				OHServiceExceptionUtil.showMessages(e, PatientBillEdit.this);
@@ -1769,11 +1633,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 	private void addPayment(LocalDateTime datePay, double qty) {
 		if (qty != 0) {
 			try {
-				BillPayments pay = new BillPayments(0,
-						billBrowserManager.getBill(billID),
-						datePay,
-						qty,
-						user);
+				BillPayments pay = new BillPayments(0, billBrowserManager.getBill(billID), datePay, qty, user);
 				payItems.add(pay);
 			} catch (OHServiceException e) {
 				OHServiceExceptionUtil.showMessages(e, PatientBillEdit.this);
@@ -1815,21 +1675,15 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			Map<String, Price> priceHashTable;
 			prcListArray = new ArrayList<>();
 
-			/*
-			 * Select the prices of the selected list.
-			 * If no price list is selected (new bill) the first one is taken.
-			 */
-			if (listSelected == null) {
-				listSelected = lstArray.get(0);
-			}
-			prcListArray = prcArray.stream()
-					.filter(price -> price.getList().getId() == listSelected.getId())
-					.collect(Collectors.toList());
+//			if (listSelected == null) {
+//				listSelected = lstArray.get(0);
+//			}
+//			prcListArray = prcArray.stream().filter(price -> price.getList().getId() == listSelected.getId()).collect(Collectors.toList());
 			/*
 			 * Create a hashTable with the selected prices.
 			 */
 			priceHashTable = prcListArray.stream().collect(
-					Collectors.toMap(price -> price.getList().getId() + price.getGroup() + price.getItem(), price -> price, (a, b) -> b, HashMap::new));
+							Collectors.toMap(price -> price.getList().getId() + price.getGroup() + price.getItem(), price -> price, (a, b) -> b, HashMap::new));
 
 			/*
 			 * Updates the items in the bill.
@@ -1851,10 +1705,9 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		}
 
 		@Override
-		public Class<?> getColumnClass(int i) {
+		public Class< ? > getColumnClass(int i) {
 			return billClasses[i].getClass();
 		}
-
 
 		@Override
 		public int getColumnCount() {
@@ -1925,7 +1778,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		}
 
 		@Override
-		public Class<?> getColumnClass(int columnIndex) {
+		public Class< ? > getColumnClass(int columnIndex) {
 			return paymentClasses[columnIndex].getClass();
 		}
 
@@ -1971,8 +1824,78 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		}
 	}
 
+	private final class JTableTotalModel extends DefaultTableModel {
+
+		private static final long serialVersionUID = 1L;
+		Class< ? >[] types = new Class< ? >[] { JLabel.class, JLabel.class, Double.class, };
+
+		private JTableTotalModel() {
+			super(new Object[][] { { "<html><b>" + MessageBundle.getMessage("angal.common.total.txt").toUpperCase() + "</b></html>", currencyCod, total } },
+							new String[] { "", "", "" });
+		}
+
+		private JTableTotalModel(Object[][] data, Object[] columnNames) {
+			super(data, columnNames);
+		}
+		@Override
+		public Class< ? > getColumnClass(int columnIndex) {
+			return types[columnIndex];
+		}
+		@Override
+		public boolean isCellEditable(int row, int column) {
+			return false;
+		}
+	}
+
 	public String formatDateTime(LocalDateTime time) {
 		return DATE_TIME_FORMATTER.format(time);
 	}
 
+	private final class JTableBalanceModel extends DefaultTableModel {
+
+		private static final long serialVersionUID = 1L;
+		Class< ? >[] types = new Class< ? >[] { JLabel.class, JLabel.class, Double.class, };
+
+		private JTableBalanceModel() {
+			super(new Object[][] {
+					{ "<html><b>" + MessageBundle.getMessage("angal.newbill.balance.txt").toUpperCase() + "</b></html>", currencyCod, balance } },
+							new String[] { "", "", "" });
+		}
+
+		private JTableBalanceModel(Object[][] data, Object[] columnNames) {
+			super(data, columnNames);
+		}
+
+		@Override
+		public Class< ? > getColumnClass(int columnIndex) {
+			return types[columnIndex];
+		}
+
+		@Override
+		public boolean isCellEditable(int row, int column) {
+			return false;
+		}
+	}
+
+	private final class JTableBigTotalModel extends DefaultTableModel {
+
+		private static final long serialVersionUID = 1L;
+		Class< ? >[] types = new Class< ? >[] { JLabel.class, JLabel.class, Double.class, };
+
+		private JTableBigTotalModel() {
+			super(new Object[][] { { "<html><b>" + MessageBundle.getMessage("angal.newbill.topay.txt") + "</b></html>", currencyCod, bigTotal } },
+							new String[] { "", "", "" });
+		}
+		private JTableBigTotalModel(Object[][] data, Object[] columnNames) {
+			super(data, columnNames);
+		}
+		@Override
+		public Class< ? > getColumnClass(int columnIndex) {
+			return types[columnIndex];
+		}
+		@Override
+		public boolean isCellEditable(int row, int column) {
+			return false;
+		}
+	}
 }

--- a/src/main/java/org/isf/admission/gui/AdmittedPatientBrowser.java
+++ b/src/main/java/org/isf/admission/gui/AdmittedPatientBrowser.java
@@ -62,7 +62,6 @@ import javax.swing.table.DefaultTableModel;
 
 import org.isf.accounting.gui.PatientBillEdit;
 import org.isf.accounting.manager.BillBrowserManager;
-import org.isf.accounting.model.Bill;
 import org.isf.admission.manager.AdmissionBrowserManager;
 import org.isf.admission.model.Admission;
 import org.isf.admission.model.AdmittedPatient;
@@ -137,33 +136,23 @@ import com.github.lgooddatepicker.zinternaltools.WrapLayout;
  * 06/12/09 - Alex - Cosmetic changes to GUI
  * -----------------------------------------------------------
  */
-public class AdmittedPatientBrowser extends ModalJFrame implements
-		PatientInsert.PatientListener,
-		PatientInsertExtended.PatientListener, AdmissionBrowser.AdmissionListener,
-		PatientDataBrowser.DeleteAdmissionListener {
+public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert.PatientListener, PatientInsertExtended.PatientListener,
+				AdmissionBrowser.AdmissionListener, PatientDataBrowser.DeleteAdmissionListener {
 
 	private static final long serialVersionUID = 1L;
 
 	private static final int PANEL_WIDTH = 240;
-	
-	
+
 	private PatientHistoryManager patientHistoryManager = Context.getApplicationContext().getBean(PatientHistoryManager.class);
 
-
-	private String[] patientClassItems = {
-			MessageBundle.getMessage("angal.common.all.txt"),
-			MessageBundle.getMessage("angal.admission.admitted.txt"),
-			MessageBundle.getMessage("angal.admission.notadmitted.txt")
-	};
+	private String[] patientClassItems = { MessageBundle.getMessage("angal.common.all.txt"), MessageBundle.getMessage("angal.admission.admitted.txt"),
+			MessageBundle.getMessage("angal.admission.notadmitted.txt") };
 	private JComboBox patientClassBox = new JComboBox(patientClassItems);
 	private GoodDateChooser[] dateChoosers = new GoodDateChooser[4];
 	private VoLimitedTextField patientAgeFromTextField = null;
 	private VoLimitedTextField patientAgeToTextField = null;
-	private String[] patientSexItems = { 
-			MessageBundle.getMessage("angal.common.all.txt"),
-			MessageBundle.getMessage("angal.common.male.txt"),
-			MessageBundle.getMessage("angal.common.female.txt")
-	};
+	private String[] patientSexItems = { MessageBundle.getMessage("angal.common.all.txt"), MessageBundle.getMessage("angal.common.male.txt"),
+			MessageBundle.getMessage("angal.common.female.txt") };
 	private JComboBox patientSexBox = new JComboBox(patientSexItems);
 	private JCheckBox[] wardCheck = null;
 	private JTextField searchString = null;
@@ -173,22 +162,19 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 	private List<Ward> wardList = null;
 	private JLabel rowCounter = null;
 	private List<AdmittedPatient> pPatient = new ArrayList<>();
-	private String[] pColumns = {
-			MessageBundle.getMessage("angal.common.code.txt").toUpperCase(),
-			MessageBundle.getMessage("angal.common.name.txt").toUpperCase(),
-			MessageBundle.getMessage("angal.common.age.txt").toUpperCase(),
+	private String[] pColumns = { MessageBundle.getMessage("angal.common.code.txt").toUpperCase(),
+			MessageBundle.getMessage("angal.common.name.txt").toUpperCase(), MessageBundle.getMessage("angal.common.age.txt").toUpperCase(),
 			MessageBundle.getMessage("angal.common.sex.txt").toUpperCase(),
 			MessageBundle.getMessage("angal.admission.cityaddresstelephonenote.col").toUpperCase(),
-			MessageBundle.getMessage("angal.common.ward.txt").toUpperCase()
-	};
-	private int[] pColumnWidth = {100, 200, 80, 50, 150, 100};
-	private boolean[] pColumnResizable = {false, false, false, false, true, false};
+			MessageBundle.getMessage("angal.common.ward.txt").toUpperCase() };
+	private int[] pColumnWidth = { 100, 200, 80, 50, 150, 100 };
+	private boolean[] pColumnResizable = { false, false, false, false, true, false };
 	private AdmittedPatient patient;
 	private JTable table;
 	private JScrollPane scrollPane;
 	private AdmittedPatientBrowser myFrame;
 
-	private	WardBrowserManager wardBrowserManager = Context.getApplicationContext().getBean(WardBrowserManager.class);
+	private WardBrowserManager wardBrowserManager = Context.getApplicationContext().getBean(WardBrowserManager.class);
 	private PatientBrowserManager patientBrowserManager = Context.getApplicationContext().getBean(PatientBrowserManager.class);
 	private AdmissionBrowserManager admissionBrowserManager = Context.getApplicationContext().getBean(AdmissionBrowserManager.class);
 	private ExaminationBrowserManager examinationBrowserManager = Context.getApplicationContext().getBean(ExaminationBrowserManager.class);
@@ -218,18 +204,18 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 	@Override
 	public void deleteAdmissionUpdated(AWTEvent e) {
 		Admission adm = (Admission) e.getSource();
-		
-		//remember selected row
+
+		// remember selected row
 		int row = table.getSelectedRow();
-		
+
 		for (AdmittedPatient elem : pPatient) {
 			if (elem.getPatient().getCode().equals(adm.getPatient().getCode())) {
-				//found same patient in the list
+				// found same patient in the list
 				Admission elemAdm = elem.getAdmission();
 				if (elemAdm != null) {
-					//the patient is admitted
+					// the patient is admitted
 					if (elemAdm.getId() == adm.getId()) {
-						//same admission --> delete
+						// same admission --> delete
 						elem.setAdmission(null);
 					}
 				}
@@ -252,14 +238,14 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 	@Override
 	public void admissionInserted(AWTEvent e) {
 		Admission adm = (Admission) e.getSource();
-		
-		//remember selected row
+
+		// remember selected row
 		int row = table.getSelectedRow();
 		int patId = adm.getPatient().getCode();
-		
+
 		for (AdmittedPatient elem : pPatient) {
 			if (elem.getPatient().getCode() == patId) {
-				//found same patient in the list
+				// found same patient in the list
 				elem.setAdmission(adm);
 				break;
 			}
@@ -275,33 +261,32 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 	}
 
 	/*
-	 * param contains info about patient admission,
-	 * ward can varying or patient may be discharged
+	 * param contains info about patient admission, ward can varying or patient may be discharged
 	 */
 	@Override
 	public void admissionUpdated(AWTEvent e) {
 		Admission adm = (Admission) e.getSource();
-		
-		//remember selected row
+
+		// remember selected row
 		int row = table.getSelectedRow();
 		int admId = adm.getId();
 		int patId = adm.getPatient().getCode();
-		
+
 		for (AdmittedPatient elem : pPatient) {
 			if (elem.getPatient().getCode() == patId) {
-				//found same patient in the list
+				// found same patient in the list
 				Admission elemAdm = elem.getAdmission();
 				if (adm.getDisDate() != null) {
-					//is a discharge
+					// is a discharge
 					if (elemAdm != null) {
-						//the patient is not discharged
+						// the patient is not discharged
 						if (elemAdm.getId() == admId) {
-							//same admission --> discharge
+							// same admission --> discharge
 							elem.setAdmission(null);
 						}
 					}
 				} else {
-					//is not a discharge --> patient admitted
+					// is not a discharge --> patient admitted
 					elem.setAdmission(adm);
 				}
 				break;
@@ -320,8 +305,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 	/*
 	 * manage PatientEdit messages
 	 * 
-	 * mind PatientEdit return a patient patientInserted create a new
-	 * AdmittedPatient for table
+	 * mind PatientEdit return a patient patientInserted create a new AdmittedPatient for table
 	 */
 	@Override
 	public void patientInserted(AWTEvent e) {
@@ -341,12 +325,12 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 
 	@Override
 	public void patientUpdated(AWTEvent e) {
-		
+
 		Patient u = (Patient) e.getSource();
-		
-		//remember selected row
+
+		// remember selected row
 		int row = table.getSelectedRow();
-		
+
 		for (int i = 0; i < pPatient.size(); i++) {
 			if ((pPatient.get(i).getPatient().getCode()).equals(u.getCode())) {
 				Admission admission = pPatient.get(i).getAdmission();
@@ -378,13 +362,13 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 				OHServiceExceptionUtil.showMessages(e);
 			}
 		}
-		
+
 		initComponents();
 		setMinimumSize(new Dimension(1270, 570));
 		pack();
 		setLocationRelativeTo(null);
 		setVisible(true);
-		
+
 		rowCounter.setText(MessageBundle.formatMessage("angal.admission.count.fmt.txt", pPatient.size()));
 		searchString.requestFocus();
 
@@ -392,7 +376,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 
 			@Override
 			public void windowClosing(WindowEvent e) {
-				//to free memory
+				// to free memory
 				if (pPatient != null) {
 					pPatient.clear();
 				}
@@ -415,7 +399,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 		dataAndControlPanel.add(getScrollPane(), BorderLayout.CENTER);
 		return dataAndControlPanel;
 	}
-	
+
 	/*
 	 * Panel with filtering controls
 	 */
@@ -424,7 +408,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 			lastKey = "";
 			filterPatient(null);
 		});
-		
+
 		patientClassBox = new JComboBox(patientClassItems);
 		if (!GeneralData.ENHANCEDSEARCH) {
 			patientClassBox.addActionListener(listener);
@@ -449,8 +433,8 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 					wardList.add(elem);
 				}
 			}
-		} 
-		
+		}
+
 		JPanel[] checkPanel = new JPanel[wardList.size()];
 		wardCheck = new JCheckBox[wardList.size()];
 
@@ -467,14 +451,15 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 		}
 
 		wardPanel = setMyBorder(wardPanel, MessageBundle.getMessage("angal.admission.ward.border"));
-		
+
 		rowCounter = new JLabel(MessageBundle.formatMessage("angal.admission.count.fmt.txt", 0));
 		rowCounter.setAlignmentX(Component.CENTER_ALIGNMENT);
 		wardPanel.add(rowCounter);
-		
+
 		JPanel calendarPanel = getAdmissionFilterPanel();
 
 		KeyListener ageKeyListener = new KeyAdapter() {
+
 			@Override
 			public void keyPressed(KeyEvent e) {
 				super.keyPressed(e);
@@ -521,16 +506,18 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 		searchString.setColumns(15);
 		if (GeneralData.ENHANCEDSEARCH) {
 			searchString.addKeyListener(new KeyAdapter() {
+
 				@Override
 				public void keyPressed(KeyEvent e) {
 					int key = e.getKeyCode();
-				     if (key == KeyEvent.VK_ENTER) {
-				    	 jSearchButton.doClick();
-				     }
+					if (key == KeyEvent.VK_ENTER) {
+						jSearchButton.doClick();
+					}
 				}
 			});
 		} else {
 			searchString.addKeyListener(new KeyListener() {
+
 				@Override
 				public void keyTyped(KeyEvent e) {
 					if (altKeyReleased) {
@@ -542,7 +529,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 						filterPatient(searchString.getText());
 					}
 				}
-	
+
 				@Override
 				public void keyPressed(KeyEvent e) {
 					int key = e.getKeyCode();
@@ -550,7 +537,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 						altKeyReleased = false;
 					}
 				}
-	
+
 				@Override
 				public void keyReleased(KeyEvent e) {
 					altKeyReleased = true;
@@ -568,27 +555,29 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 		layout.setAutoCreateContainerGaps(true);
 		int width = calendarPanel.getMinimumSize().width;
 		layout.setHorizontalGroup(layout.createSequentialGroup() //
-				.addGroup(layout.createParallelGroup() //
-						.addComponent(classPanel, width, width, width) //
-						.addComponent(wardPanel, width, width, width) //
-						.addComponent(calendarPanel, width, width, width) //
-						.addComponent(agePanel, width, width, width) //
-						.addComponent(sexPanel, width, width, width) //
-						.addComponent(searchPanel, width, width, width)));
+						.addGroup(layout.createParallelGroup() //
+										.addComponent(classPanel, width, width, width) //
+										.addComponent(wardPanel, width, width, width) //
+										.addComponent(calendarPanel, width, width, width) //
+										.addComponent(agePanel, width, width, width) //
+										.addComponent(sexPanel, width, width, width) //
+										.addComponent(searchPanel, width, width, width)));
 
 		layout.setVerticalGroup(layout.createSequentialGroup()
-				.addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
-						.addComponent(classPanel, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)) //
-				.addPreferredGap(ComponentPlacement.RELATED).addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE) //
-						.addComponent(wardPanel, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)) //
-				.addPreferredGap(ComponentPlacement.RELATED).addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE) //
-						.addComponent(calendarPanel, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)) //
-				.addPreferredGap(ComponentPlacement.RELATED).addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE) //
-						.addComponent(agePanel, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)) //
-				.addPreferredGap(ComponentPlacement.RELATED).addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
-						.addComponent(sexPanel, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)) //
-				.addPreferredGap(ComponentPlacement.RELATED, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE).addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE) //
-						.addComponent(searchPanel, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)));
+						.addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE).addComponent(classPanel, GroupLayout.DEFAULT_SIZE,
+										GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)) //
+						.addPreferredGap(ComponentPlacement.RELATED).addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE) //
+										.addComponent(wardPanel, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)) //
+						.addPreferredGap(ComponentPlacement.RELATED).addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE) //
+										.addComponent(calendarPanel, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)) //
+						.addPreferredGap(ComponentPlacement.RELATED).addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE) //
+										.addComponent(agePanel, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)) //
+						.addPreferredGap(ComponentPlacement.RELATED)
+						.addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE).addComponent(sexPanel, GroupLayout.DEFAULT_SIZE,
+										GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)) //
+						.addPreferredGap(ComponentPlacement.RELATED, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+						.addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE) //
+										.addComponent(searchPanel, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)));
 
 		mainPanel.setLayout(layout);
 		return mainPanel;
@@ -717,7 +706,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 		if (MainMenu.checkUserGrants("btnadmexamination")) {
 			buttonPanel.add(getButtonExamination());
 		}
-		
+
 		if (GeneralData.OPDEXTENDED && MainMenu.checkUserGrants("btnadmopd")) {
 			buttonPanel.add(getButtonOpd());
 		}
@@ -745,8 +734,8 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 		buttonPanel.add(getButtonClose());
 		return buttonPanel;
 	}
-	
-	private  JButton getJAnamnesisButton() {
+
+	private JButton getJAnamnesisButton() {
 		JButton jAnamnesisButton = new JButton(MessageBundle.getMessage("angal.anamnesis.open.anamnesis.btn"));
 		jAnamnesisButton.setMnemonic(MessageBundle.getMnemonic("angal.opd.anamnesis.btn.key"));
 		jAnamnesisButton.addActionListener(actionEvent -> {
@@ -768,7 +757,6 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 		});
 		return jAnamnesisButton;
 	}
-
 
 	private JButton getButtonExamination() {
 		if (jButtonExamination == null) {
@@ -928,8 +916,8 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 			}
 			patient = reloadSelectedPatient(table.getSelectedRow());
 
-			if (patient  != null) {
-				Opd opd = new Opd(0,' ', -1, new Disease());
+			if (patient != null) {
+				Opd opd = new Opd(0, ' ', -1, new Disease());
 				OpdEditExtended newrecord = new OpdEditExtended(myFrame, opd, patient.getPatient(), true);
 				newrecord.setLocationRelativeTo(null);
 				newrecord.showAsModal(myFrame);
@@ -937,7 +925,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 		});
 		return buttonOpd;
 	}
-	
+
 	private JButton getButtonLab() {
 		JButton buttonLab = new JButton(MessageBundle.getMessage("angal.admission.lab.btn"));
 		buttonLab.setMnemonic(MessageBundle.getMnemonic("angal.admission.lab.btn.key"));
@@ -947,9 +935,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 				return;
 			}
 			patient = reloadSelectedPatient(table.getSelectedRow());
-			Laboratory laboratory = new Laboratory(0, new Exam("", "",
-					new ExamType("", ""), 0, ""),
-					TimeTools.getNow(), "P", "", new Patient(), "");
+			Laboratory laboratory = new Laboratory(0, new Exam("", "", new ExamType("", ""), 0, ""), TimeTools.getNow(), "P", "", new Patient(), "");
 			if (GeneralData.LABEXTENDED) {
 				if (GeneralData.LABMULTIPLEINSERT) {
 					LabNew editrecord = new LabNew(myFrame, patient.getPatient());
@@ -965,7 +951,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 		});
 		return buttonLab;
 	}
-	
+
 	private JButton getButtonBill() {
 		JButton buttonBill = new JButton(MessageBundle.getMessage("angal.admission.bill.btn"));
 		buttonBill.setMnemonic(MessageBundle.getMnemonic("angal.admission.bill.btn.key"));
@@ -978,31 +964,8 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 
 			if (patient != null) {
 				Patient pat = patient.getPatient();
-				List<Bill> patientPendingBills;
-				try {
-					patientPendingBills = billBrowserManager.getPendingBills(pat.getCode());
-				} catch (OHServiceException e) {
-					patientPendingBills = new ArrayList<>();
-					OHServiceExceptionUtil.showMessages(e);
-				}
-				if (patientPendingBills.isEmpty()) {
-					new PatientBillEdit(AdmittedPatientBrowser.this, pat);
-					//dispose();
-				} else {
-					if (patientPendingBills.size() == 1) {
-						MessageDialog.warning(AdmittedPatientBrowser.this, "angal.admission.thispatienthasapendingbill.msg");
-						PatientBillEdit pbe = new PatientBillEdit(AdmittedPatientBrowser.this, patientPendingBills.get(0), false);
-						pbe.setVisible(true);
-						//dispose();
-					} else {
-						int ok = MessageDialog.okCancel(AdmittedPatientBrowser.this,
-								"angal.admission.thereismorethanonependingbillforthispatientcontinue.msg");
-						if (ok == JOptionPane.OK_OPTION) {
-							new PatientBillEdit(AdmittedPatientBrowser.this, pat);
-							//dispose();
-						}
-					}
-				}
+				PatientBillEdit pbe = new PatientBillEdit(AdmittedPatientBrowser.this, pat);
+				pbe.setVisible(true);
 			}
 		});
 		return buttonBill;
@@ -1024,7 +987,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 		});
 		return buttonData;
 	}
-	
+
 	private JButton getDICOMButton() {
 		JButton dicomButton = new JButton(MessageBundle.getMessage("angal.admission.patientfolder.dicom.btn"));
 		dicomButton.setMnemonic(MessageBundle.getMnemonic("angal.admission.patientfolder.dicom.btn.key"));
@@ -1085,41 +1048,35 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 			int[] indexes = table.getSelectedRows();
 
 			Patient mergedPatient;
-			Patient patient1 = ((AdmittedPatient)table.getValueAt(indexes[0], -1)).getPatient();
-			Patient patient2 = ((AdmittedPatient)table.getValueAt(indexes[1], -1)).getPatient();
+			Patient patient1 = ((AdmittedPatient) table.getValueAt(indexes[0], -1)).getPatient();
+			Patient patient2 = ((AdmittedPatient) table.getValueAt(indexes[1], -1)).getPatient();
 
 			// Select most recent patient
 			if (patient1.getCode() > patient2.getCode()) {
 				mergedPatient = patient1;
-			}
-			else {
+			} else {
 				mergedPatient = patient2;
 				patient2 = patient1;
 			}
 
-			//ASK CONFIRMATION
+			// ASK CONFIRMATION
 			int ok = MessageDialog.yesNo(AdmittedPatientBrowser.this,
-					"angal.admission.withthisoperationthepatientwillbedeletedandhisherhistorytransferedtothepatient.fmt.msg",
-					patient2.getCode(), patient2.getName(), patient2.getAge(), patient2.getAddress(),
-					mergedPatient.getCode(), mergedPatient.getName(), mergedPatient.getAge(), mergedPatient.getAddress());
+							"angal.admission.withthisoperationthepatientwillbedeletedandhisherhistorytransferedtothepatient.fmt.msg", patient2.getCode(),
+							patient2.getName(), patient2.getAge(), patient2.getAddress(), mergedPatient.getCode(), mergedPatient.getName(),
+							mergedPatient.getAge(), mergedPatient.getAddress());
 			if (ok != JOptionPane.YES_OPTION) {
 				return;
 			}
 
 			if (mergedPatient.getName().toUpperCase().compareTo(patient2.getName().toUpperCase()) != 0) {
-				String[] names = {mergedPatient.getName(), patient2.getName()};
-				String whichName = (String) JOptionPane.showInputDialog(null,
-						MessageBundle.getMessage("angal.admission.pleaseselectthefinalname.msg"),
-						MessageDialog.QUESTION,
-						JOptionPane.QUESTION_MESSAGE,
-						null,
-						names,
-						null);
+				String[] names = { mergedPatient.getName(), patient2.getName() };
+				String whichName = (String) JOptionPane.showInputDialog(null, MessageBundle.getMessage("angal.admission.pleaseselectthefinalname.msg"),
+								MessageDialog.QUESTION, JOptionPane.QUESTION_MESSAGE, null, names, null);
 				if (whichName == null) {
 					return;
 				}
 				if (whichName.compareTo(names[1]) == 0) {
-					//patient2 name selected
+					// patient2 name selected
 					mergedPatient.setFirstName(patient2.getFirstName());
 					mergedPatient.setSecondName(patient2.getSecondName());
 				}
@@ -1140,7 +1097,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 		JButton buttonClose = new JButton(MessageBundle.getMessage("angal.common.close.btn"));
 		buttonClose.setMnemonic(MessageBundle.getMnemonic("angal.common.close.btn.key"));
 		buttonClose.addActionListener(actionEvent -> {
-			//to free Memory
+			// to free Memory
 			if (pPatient != null) {
 				pPatient.clear();
 			}
@@ -1151,26 +1108,27 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 		});
 		return buttonClose;
 	}
-	
+
 	private void filterPatient(String key) {
 		table.setModel(new AdmittedPatientBrowserModel(key));
 		rowCounter.setText(MessageBundle.formatMessage("angal.admission.count.fmt.txt", table.getRowCount()));
 		searchString.requestFocus();
 	}
-	
+
 	private void searchPatient() {
 		boolean isFilteredList = patientClassBox.getSelectedIndex() > 0 || //
-				(dateChoosers[0].getDate() != null && //
-				dateChoosers[1].getDate() != null) || //
-				(dateChoosers[2].getDate() != null && //
-				dateChoosers[3].getDate() != null) || //
-				!patientAgeFromTextField.getText().isEmpty() || //
-				!patientAgeToTextField.getText().isEmpty() || //
-				patientSexBox.getSelectedIndex() > 0 || //
-				!searchString.getText().isEmpty();	
+						(dateChoosers[0].getDate() != null && //
+										dateChoosers[1].getDate() != null)
+						|| //
+						(dateChoosers[2].getDate() != null && //
+										dateChoosers[3].getDate() != null)
+						|| //
+						!patientAgeFromTextField.getText().isEmpty() || //
+						!patientAgeToTextField.getText().isEmpty() || //
+						patientSexBox.getSelectedIndex() > 0 || //
+						!searchString.getText().isEmpty();
 		if (!isFilteredList) {
-			int ok = MessageDialog.okCancel(AdmittedPatientBrowser.this,
-					"angal.common.thiscouldretrievealargeamountofdataproceed.msg");
+			int ok = MessageDialog.okCancel(AdmittedPatientBrowser.this, "angal.common.thiscouldretrievealargeamountofdataproceed.msg");
 			if (ok != JOptionPane.OK_OPTION) {
 				return;
 			}
@@ -1178,7 +1136,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 
 		LocalDateTime[] admissionRange = new LocalDateTime[2];
 		LocalDateTime[] dischargeRange = new LocalDateTime[2];
-		for(int i = 0; i <= dateChoosers.length - 1; i++) {
+		for (int i = 0; i <= dateChoosers.length - 1; i++) {
 			switch (i) {
 			case 0:
 				admissionRange[0] = dateChoosers[i].getDateStartOfDay();
@@ -1202,7 +1160,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 		}
 		filterPatient(null);
 	}
-	
+
 	private JButton getButtonSearch() {
 		if (jSearchButton == null) {
 			jSearchButton = new JButton();
@@ -1214,11 +1172,9 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 		}
 		return jSearchButton;
 	}
-	
+
 	private JPanel setMyBorder(JPanel c, String title) {
-		javax.swing.border.Border b2 = BorderFactory.createCompoundBorder(
-				BorderFactory.createTitledBorder(title), BorderFactory
-						.createEmptyBorder(0, 0, 0, 0));
+		javax.swing.border.Border b2 = BorderFactory.createCompoundBorder(BorderFactory.createTitledBorder(title), BorderFactory.createEmptyBorder(0, 0, 0, 0));
 		c.setBorder(b2);
 		return c;
 	}
@@ -1228,7 +1184,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 		private static final long serialVersionUID = 1L;
 
 		List<AdmittedPatient> patientList = new ArrayList<>();
-		
+
 		public AdmittedPatientBrowserModel(String key) {
 			for (AdmittedPatient ap : pPatient) {
 				Admission adm = ap.getAdmission();
@@ -1268,7 +1224,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 						continue;
 					}
 				}
-				
+
 				// upper age limit
 				ageLimit = patientAgeToTextField.getText();
 				if (ageLimit.matches("\\d+")) {
@@ -1276,7 +1232,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 						continue;
 					}
 				}
-					
+
 				// sex patient type
 				Character sex = null;
 				switch (patientSexBox.getSelectedIndex()) {
@@ -1287,7 +1243,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 					sex = 'F';
 					break;
 				}
-				
+
 				if (sex != null && !sex.equals(ap.getPatient().getSex())) {
 					continue;
 				}
@@ -1358,8 +1314,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 					return "";
 				} else {
 					for (Ward ward : wardList) {
-						if (ward.getCode()
-								.equalsIgnoreCase(admission.getWard().getCode())) {
+						if (ward.getCode().equalsIgnoreCase(admission.getWard().getCode())) {
 							return ward.getDescription();
 						}
 					}
@@ -1375,15 +1330,13 @@ public class AdmittedPatientBrowser extends ModalJFrame implements
 			return false;
 		}
 	}
-	
-	
-	class CenterTableCellRenderer extends DefaultTableCellRenderer {  
+
+	class CenterTableCellRenderer extends DefaultTableCellRenderer {
 
 		private static final long serialVersionUID = 1L;
 
 		@Override
-		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
-				boolean hasFocus, int row, int column) {
+		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
 
 			Component cell = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
 			cell.setForeground(Color.BLACK);

--- a/src/main/java/org/isf/patient/gui/SelectPatient.java
+++ b/src/main/java/org/isf/patient/gui/SelectPatient.java
@@ -66,14 +66,15 @@ import org.isf.utils.jobjects.MessageDialog;
 import org.isf.utils.jobjects.VoLimitedTextField;
 
 public class SelectPatient extends JDialog implements PatientListener {
-	
+
 //LISTENER INTERFACE --------------------------------------------------------
 	private EventListenerList selectionListener = new EventListenerList();
-	
+
 	public interface SelectionListener extends EventListener {
+
 		void patientSelected(Patient patient);
 	}
-	
+
 	public void addSelectionListener(SelectionListener l) {
 		selectionListener.add(SelectionListener.class, l);
 	}
@@ -89,6 +90,7 @@ public class SelectPatient extends JDialog implements PatientListener {
 			((SelectionListener) listener).patientSelected(patient);
 		}
 	}
+
 //---------------------------------------------------------------------------	
 	private static final long serialVersionUID = 1L;
 	private JPanel jPanelButtons;
@@ -103,15 +105,15 @@ public class SelectPatient extends JDialog implements PatientListener {
 	private JButton jSearchButton;
 	private JPanel jPanelDataPatient;
 	private Patient patient;
+
 	public Patient getPatient() {
 		return patient;
 	}
+
 	private JButton buttonNew;
 	private PatientSummary ps;
-	private String[] patColumns = {
-			MessageBundle.getMessage("angal.common.code.txt").toUpperCase(),
-			MessageBundle.getMessage("angal.common.name.txt").toUpperCase()
-	}; 
+	private String[] patColumns = { MessageBundle.getMessage("angal.common.code.txt").toUpperCase(),
+			MessageBundle.getMessage("angal.common.name.txt").toUpperCase() };
 	private int[] patColumnsWidth = { 100, 250 };
 	private boolean[] patColumnsResizable = { false, true };
 
@@ -119,13 +121,13 @@ public class SelectPatient extends JDialog implements PatientListener {
 	List<Patient> patArray = new ArrayList<>();
 	List<Patient> patSearch = new ArrayList<>();
 	private String lastKey = "";
-		
+
 	public SelectPatient(JFrame owner, Patient pat) {
 		super(owner, true);
 		if (!GeneralData.ENHANCEDSEARCH) {
 			try {
 				patArray = patientBrowserManager.getPatientsByOneOfFieldsLike(null);
-			} catch(OHServiceException ohServiceException) {
+			} catch (OHServiceException ohServiceException) {
 				MessageDialog.showExceptions(ohServiceException);
 				patArray = new ArrayList<>();
 			}
@@ -142,7 +144,7 @@ public class SelectPatient extends JDialog implements PatientListener {
 
 			@Override
 			public void windowClosing(WindowEvent e) {
-				//to free memory
+				// to free memory
 				patArray.clear();
 				patSearch.clear();
 				dispose();
@@ -150,13 +152,13 @@ public class SelectPatient extends JDialog implements PatientListener {
 		});
 		setLocationRelativeTo(null);
 	}
-	
+
 	public SelectPatient(JDialog owner, Patient pat) {
 		super(owner, true);
 		if (!GeneralData.ENHANCEDSEARCH) {
 			try {
 				patArray = patientBrowserManager.getPatientsByOneOfFieldsLike(null);
-			} catch(OHServiceException ohServiceException) {
+			} catch (OHServiceException ohServiceException) {
 				MessageDialog.showExceptions(ohServiceException);
 				patArray = new ArrayList<>();
 			}
@@ -173,7 +175,7 @@ public class SelectPatient extends JDialog implements PatientListener {
 
 			@Override
 			public void windowClosing(WindowEvent e) {
-				//to free memory
+				// to free memory
 				patArray.clear();
 				patSearch.clear();
 				dispose();
@@ -181,13 +183,13 @@ public class SelectPatient extends JDialog implements PatientListener {
 		});
 		setLocationRelativeTo(null);
 	}
-	
+
 	public SelectPatient(JDialog owner, String search) {
 		super(owner, true);
 		if (!GeneralData.ENHANCEDSEARCH) {
 			try {
 				patArray = patientBrowserManager.getPatientsByOneOfFieldsLike(null);
-			} catch(OHServiceException ohServiceException) {
+			} catch (OHServiceException ohServiceException) {
 				MessageDialog.showExceptions(ohServiceException);
 				patArray = new ArrayList<>();
 			}
@@ -199,7 +201,7 @@ public class SelectPatient extends JDialog implements PatientListener {
 
 			@Override
 			public void windowClosing(WindowEvent e) {
-				//to free memory
+				// to free memory
 				patArray.clear();
 				patSearch.clear();
 				dispose();
@@ -347,15 +349,15 @@ public class SelectPatient extends JDialog implements PatientListener {
 	}
 
 	private void filterPatient() {
-		
+
 		String s = jTextFieldSearchPatient.getText() + lastKey;
 		s = s.trim();
 		String[] s1 = s.split(" ");
 
 		patSearch = new ArrayList<>();
-		
+
 		for (Patient pat : patArray) {
-		
+
 			if (!s.equals("")) {
 				String name = pat.getSearchString();
 				int a = 0;
@@ -371,22 +373,22 @@ public class SelectPatient extends JDialog implements PatientListener {
 				patSearch.add(pat);
 			}
 		}
-		
+
 		if (jTablePatient.getRowCount() == 0) {
-			
+
 			patient = null;
 			updatePatientSummary();
 		}
 		if (jTablePatient.getRowCount() == 1) {
-			
-			final Patient selectedPatient = (Patient)jTablePatient.getValueAt(0, -1);
+
+			final Patient selectedPatient = (Patient) jTablePatient.getValueAt(0, -1);
 			patient = reloadSelectedPatient(selectedPatient.getCode());
 			updatePatientSummary();
 		}
 		jTablePatient.updateUI();
 		jTextFieldSearchPatient.requestFocus();
 	}
-	
+
 	private JLabel getJLabelSearch() {
 		if (jLabelSearch == null) {
 			jLabelSearch = new JLabel(MessageBundle.getMessage("angal.patient.searchpatient"));
@@ -401,11 +403,11 @@ public class SelectPatient extends JDialog implements PatientListener {
 			jButtonSelect.addActionListener(actionEvent -> {
 
 				if (patient != null) {
-					//to free memory
+					// to free memory
 					patArray.clear();
 					patSearch.clear();
-					fireSelectedPatient(patient);
 					dispose();
+					fireSelectedPatient(patient);
 				}
 			});
 		}
@@ -417,7 +419,7 @@ public class SelectPatient extends JDialog implements PatientListener {
 			jButtonCancel = new JButton(MessageBundle.getMessage("angal.common.cancel.btn"));
 			jButtonCancel.setMnemonic(MessageBundle.getMnemonic("angal.common.cancel.btn.key"));
 			jButtonCancel.addActionListener(actionEvent -> {
-				//to free memory
+				// to free memory
 				patArray.clear();
 				patSearch.clear();
 				dispose();
@@ -448,31 +450,35 @@ public class SelectPatient extends JDialog implements PatientListener {
 			}
 			jTablePatient.setAutoCreateColumnsFromModel(false);
 			jTablePatient.getColumnModel().getColumn(0).setCellRenderer(new CenterTableCellRenderer());
-			
+
 			ListSelectionModel listSelectionModel = jTablePatient.getSelectionModel();
 			listSelectionModel.addListSelectionListener(selectionEvent -> {
 				if (!selectionEvent.getValueIsAdjusting()) {
 					int index = jTablePatient.getSelectedRow();
-					final Patient selectedPatient = (Patient)jTablePatient.getValueAt(index, -1);
+					final Patient selectedPatient = (Patient) jTablePatient.getValueAt(index, -1);
 					patient = reloadSelectedPatient(selectedPatient.getCode());
 					updatePatientSummary();
 				}
 			});
-			
+
 			jTablePatient.addMouseListener(new MouseListener() {
-				
+
 				@Override
-				public void mouseReleased(MouseEvent e) {}
-				
+				public void mouseReleased(MouseEvent e) {
+				}
+
 				@Override
-				public void mousePressed(MouseEvent e) {}
-				
+				public void mousePressed(MouseEvent e) {
+				}
+
 				@Override
-				public void mouseExited(MouseEvent e) {}
-				
+				public void mouseExited(MouseEvent e) {
+				}
+
 				@Override
-				public void mouseEntered(MouseEvent e) {}
-				
+				public void mouseEntered(MouseEvent e) {
+				}
+
 				@Override
 				public void mouseClicked(MouseEvent e) {
 					if (e.getClickCount() == 2 && !e.isConsumed()) {
@@ -498,7 +504,7 @@ public class SelectPatient extends JDialog implements PatientListener {
 		ps = new PatientSummary(patient);
 		jPanelDataPatient = ps.getPatientCompleteSummary();
 		jPanelDataPatient.setAlignmentY(Component.TOP_ALIGNMENT);
-		
+
 		jPanelCenter.add(jPanelDataPatient);
 		jPanelCenter.validate();
 		jPanelCenter.repaint();
@@ -517,7 +523,7 @@ public class SelectPatient extends JDialog implements PatientListener {
 						jTablePatient.addRowSelectionInterval(i, i);
 						int j = 0;
 						if (i > 10) {
-							j = i - 10; //to center the selected row
+							j = i - 10; // to center the selected row
 						}
 						jTablePatient.scrollRectToVisible(jTablePatient.getCellRect(j, i, true));
 						break;
@@ -551,7 +557,7 @@ public class SelectPatient extends JDialog implements PatientListener {
 			jSearchButton.addActionListener(actionEvent -> {
 				try {
 					patArray = patientBrowserManager.getPatientsByOneOfFieldsLike(jTextFieldSearchPatient.getText());
-				} catch(OHServiceException ohServiceException) {
+				} catch (OHServiceException ohServiceException) {
 					MessageDialog.showExceptions(ohServiceException);
 					patArray = new ArrayList<>();
 				}
@@ -566,8 +572,7 @@ public class SelectPatient extends JDialog implements PatientListener {
 		buttonNew.addActionListener(actionEvent -> {
 
 			if (GeneralData.PATIENTEXTENDED) {
-				PatientInsertExtended newrecord = new PatientInsertExtended(SelectPatient.this, new Patient(),
-						true);
+				PatientInsertExtended newrecord = new PatientInsertExtended(SelectPatient.this, new Patient(), true);
 				newrecord.addPatientListener((PatientListener) SelectPatient.this);
 				newrecord.setVisible(true);
 			} else {
@@ -616,21 +621,17 @@ public class SelectPatient extends JDialog implements PatientListener {
 
 		@Override
 		public Object getValueAt(int r, int c) {
-			Patient patient = patSearch.get(r); 
+			Patient patient = patSearch.get(r);
 			if (c == -1) {
 				return patient;
 			} else if (c == 0) {
 				return patient.getCode();
-			}  else if (c == 1) {
+			} else if (c == 1) {
 				return patient.getName();
-			} /*else if (c == 2) {
-				return patient.getAge();
-			} else if (c == 3) {
-				return patient.getSex();
-			} else if (c == 4) {
-				return patient.getCity() + " "
-						+ patient.getAddress();
-			} */
+			} /*
+				 * else if (c == 2) { return patient.getAge(); } else if (c == 3) { return patient.getSex(); } else if (c == 4) { return patient.getCity() + " "
+				 * + patient.getAddress(); }
+				 */
 			return null;
 		}
 
@@ -645,8 +646,7 @@ public class SelectPatient extends JDialog implements PatientListener {
 		private static final long serialVersionUID = 1L;
 
 		@Override
-		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
-				boolean hasFocus, int row, int column) {
+		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
 
 			Component cell = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
 			cell.setForeground(Color.BLACK);
@@ -658,15 +658,16 @@ public class SelectPatient extends JDialog implements PatientListener {
 	public void setButtonNew(JButton buttonNew) {
 		this.buttonNew = buttonNew;
 	}
+
 	List<BillBrowser> billBrowserListeners = new ArrayList<>();
+
 	public void addSelectionListener(BillBrowser l) {
 		billBrowserListeners.add(l);
 	}
 
-
 	@Override
-	public void patientUpdated(AWTEvent e) {}
-
+	public void patientUpdated(AWTEvent e) {
+	}
 
 	@Override
 	public void patientInserted(AWTEvent e) {

--- a/src/main/java/org/isf/patient/gui/SelectPatient.java
+++ b/src/main/java/org/isf/patient/gui/SelectPatient.java
@@ -628,10 +628,7 @@ public class SelectPatient extends JDialog implements PatientListener {
 				return patient.getCode();
 			} else if (c == 1) {
 				return patient.getName();
-			} /*
-				 * else if (c == 2) { return patient.getAge(); } else if (c == 3) { return patient.getSex(); } else if (c == 4) { return patient.getCity() + " "
-				 * + patient.getAddress(); }
-				 */
+			}
 			return null;
 		}
 


### PR DESCRIPTION
See OP-1025.

Changes:

- removed unnecessary class fields and mostly using `this.thisBill` as main object
- separated methods for model changes and GUI changes
- first initialize data, then initialize components, then update components anytime needed after data changes
- add check on prices changes
- reusing the code
- overall formatting

Please test it thoroughly 🙂