### PR TITLE
Chore: remove toUpperCase() when everything is lower cased later

### DIFF
--- a/src/main/java/org/isf/patvac/gui/PatVacEdit.java
+++ b/src/main/java/org/isf/patvac/gui/PatVacEdit.java
@@ -486,8 +486,8 @@ public class PatVacEdit extends JDialog {
 			if (key != null) {
 				// Search key extended to name and code
 				StringBuilder sbName = new StringBuilder();
-				sbName.append(elem.getSecondName().toUpperCase());
-				sbName.append(elem.getFirstName().toUpperCase());
+				sbName.append(elem.getSecondName());
+				sbName.append(elem.getFirstName());
 				sbName.append(elem.getCode());
 				String name = sbName.toString();
 


### PR DESCRIPTION
After the `name` is built it is made lower cased in the next non-blank line:
<pre>
if (name.toLowerCase().contains(key.toLowerCase())) {
</pre>