### PR TITLE
Chore: combine all recent dependabot jar updates to match changes in Core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<oh.version>1.12.0-SNAPSHOT</oh.version>
 		<java.version>11</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring.framework.version>5.3.25</spring.framework.version>
+		<spring.framework.version>5.3.26</spring.framework.version>
 		<spring.boot.version>2.7.9</spring.boot.version>
 		<license.maven.plugin.version>4.1</license.maven.plugin.version>
 	</properties>
@@ -302,12 +302,12 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.6</version>
+			<version>2.0.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-reload4j</artifactId>
-			<version>2.0.6</version>
+			<version>2.0.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.igniterealtime.smack</groupId>


### PR DESCRIPTION
This also fixes the two CVEs noted in https://github.com/informatici/openhospital-core/pull/917