### PR TITLE
Chore: remove useless if test; the list is always not empty

### DIFF
--- a/src/main/java/org/isf/lab/gui/LabEdit.java
+++ b/src/main/java/org/isf/lab/gui/LabEdit.java
@@ -473,9 +473,7 @@ public class LabEdit extends ModalJFrame {
 									lab.getExam(),
 									lab.getDate(),
 									lab.getResult()));
-					if (!labs.isEmpty()) {
-						printManager.print(MessageBundle.getMessage("angal.common.laboratory.txt"), labs, 0);
-					}
+					printManager.print(MessageBundle.getMessage("angal.common.laboratory.txt"), labs, 0);
 				} catch (OHServiceException e) {
 					OHServiceExceptionUtil.showMessages(e);
 				}

--- a/src/main/java/org/isf/lab/gui/LabEditExtended.java
+++ b/src/main/java/org/isf/lab/gui/LabEditExtended.java
@@ -570,9 +570,7 @@ public class LabEditExtended extends ModalJFrame {
 									lab.getExam(),
 									lab.getDate(),
 									lab.getResult()));
-					if (!labs.isEmpty()) {
-						printManager.print(MessageBundle.getMessage("angal.common.laboratory.txt"), labs, 0);
-					}
+					printManager.print(MessageBundle.getMessage("angal.common.laboratory.txt"), labs, 0);
 				} catch (OHServiceException e) {
 					OHServiceExceptionUtil.showMessages(e);
 				}


### PR DESCRIPTION
A new `LaboratoryForPrint` object was just added to `labs` thus the test is always true; that is `labs` is not empty.