### PR TITLE
Chore: add 's' to "If not, see <http://www.gnu.org/licenses/>" in header

### DIFF
--- a/oh.bat
+++ b/oh.bat
@@ -17,7 +17,7 @@ REM # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 REM # GNU General Public License for more details.
 REM #
 REM # You should have received a copy of the GNU General Public License
-REM # along with this program. If not, see <http://www.gnu.org/licenses/>.
+REM # along with this program. If not, see <https://www.gnu.org/licenses/>.
 REM #
 
 REM ################### Script configuration ###################

--- a/oh.ps1
+++ b/oh.ps1
@@ -19,7 +19,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
 <#

--- a/oh.sh
+++ b/oh.sh
@@ -18,7 +18,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 #
 

--- a/src/main/java/org/isf/accounting/gui/BillBrowser.java
+++ b/src/main/java/org/isf/accounting/gui/BillBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.gui;
 

--- a/src/main/java/org/isf/accounting/gui/BillDataLoader.java
+++ b/src/main/java/org/isf/accounting/gui/BillDataLoader.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.gui;
 

--- a/src/main/java/org/isf/accounting/gui/BillItemPicker.java
+++ b/src/main/java/org/isf/accounting/gui/BillItemPicker.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.gui;
 

--- a/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
+++ b/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.gui;
 

--- a/src/main/java/org/isf/accounting/gui/totals/BalanceTotal.java
+++ b/src/main/java/org/isf/accounting/gui/totals/BalanceTotal.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.gui.totals;
 

--- a/src/main/java/org/isf/accounting/gui/totals/PaymentsTotal.java
+++ b/src/main/java/org/isf/accounting/gui/totals/PaymentsTotal.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.gui.totals;
 

--- a/src/main/java/org/isf/accounting/gui/totals/UserTotal.java
+++ b/src/main/java/org/isf/accounting/gui/totals/UserTotal.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.gui.totals;
 

--- a/src/main/java/org/isf/admission/gui/AdmissionBrowser.java
+++ b/src/main/java/org/isf/admission/gui/AdmissionBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.gui;
 

--- a/src/main/java/org/isf/admission/gui/AdmittedPatientBrowser.java
+++ b/src/main/java/org/isf/admission/gui/AdmittedPatientBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.gui;
 

--- a/src/main/java/org/isf/admission/gui/DiseaseFinder.java
+++ b/src/main/java/org/isf/admission/gui/DiseaseFinder.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.gui;
 

--- a/src/main/java/org/isf/admission/gui/PatientDataBrowser.java
+++ b/src/main/java/org/isf/admission/gui/PatientDataBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.gui;
 

--- a/src/main/java/org/isf/admission/gui/PatientFolderBrowser.java
+++ b/src/main/java/org/isf/admission/gui/PatientFolderBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.gui;
 

--- a/src/main/java/org/isf/admission/gui/PatientFolderReportModal.java
+++ b/src/main/java/org/isf/admission/gui/PatientFolderReportModal.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.gui;
 

--- a/src/main/java/org/isf/admission/gui/validation/OperationRowValidator.java
+++ b/src/main/java/org/isf/admission/gui/validation/OperationRowValidator.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.gui.validation;
 

--- a/src/main/java/org/isf/admission/gui/ward/WardComboBoxInitializer.java
+++ b/src/main/java/org/isf/admission/gui/ward/WardComboBoxInitializer.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.gui.ward;
 

--- a/src/main/java/org/isf/admtype/gui/AdmissionTypeBrowser.java
+++ b/src/main/java/org/isf/admtype/gui/AdmissionTypeBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admtype.gui;
 

--- a/src/main/java/org/isf/admtype/gui/AdmissionTypeBrowserEdit.java
+++ b/src/main/java/org/isf/admtype/gui/AdmissionTypeBrowserEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admtype.gui;
 

--- a/src/main/java/org/isf/agetype/gui/AgeTypeBrowser.java
+++ b/src/main/java/org/isf/agetype/gui/AgeTypeBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.agetype.gui;
 

--- a/src/main/java/org/isf/anamnesis/gui/PatientHistoryEdit.java
+++ b/src/main/java/org/isf/anamnesis/gui/PatientHistoryEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.anamnesis.gui;
 

--- a/src/main/java/org/isf/dicom/gui/DicomGui.java
+++ b/src/main/java/org/isf/dicom/gui/DicomGui.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.gui;
 

--- a/src/main/java/org/isf/dicom/gui/DicomLoader.java
+++ b/src/main/java/org/isf/dicom/gui/DicomLoader.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.gui;
 

--- a/src/main/java/org/isf/dicom/gui/DicomViewGui.java
+++ b/src/main/java/org/isf/dicom/gui/DicomViewGui.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.gui;
 

--- a/src/main/java/org/isf/dicom/gui/FileDicomFilter.java
+++ b/src/main/java/org/isf/dicom/gui/FileDicomFilter.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.gui;
 

--- a/src/main/java/org/isf/dicom/gui/FileJPEGFilter.java
+++ b/src/main/java/org/isf/dicom/gui/FileJPEGFilter.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.gui;
 

--- a/src/main/java/org/isf/dicom/gui/ShowPreLoadDialog.java
+++ b/src/main/java/org/isf/dicom/gui/ShowPreLoadDialog.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.gui;
 

--- a/src/main/java/org/isf/dicom/gui/ThumbnailViewGui.java
+++ b/src/main/java/org/isf/dicom/gui/ThumbnailViewGui.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.gui;
 

--- a/src/main/java/org/isf/dicomtype/gui/DicomTypeBrowser.java
+++ b/src/main/java/org/isf/dicomtype/gui/DicomTypeBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicomtype.gui;
 

--- a/src/main/java/org/isf/dicomtype/gui/DicomTypeEdit.java
+++ b/src/main/java/org/isf/dicomtype/gui/DicomTypeEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicomtype.gui;
 

--- a/src/main/java/org/isf/disctype/gui/DischargeTypeBrowser.java
+++ b/src/main/java/org/isf/disctype/gui/DischargeTypeBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disctype.gui;
 

--- a/src/main/java/org/isf/disctype/gui/DischargeTypeBrowserEdit.java
+++ b/src/main/java/org/isf/disctype/gui/DischargeTypeBrowserEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disctype.gui;
 

--- a/src/main/java/org/isf/disease/gui/DiseaseBrowser.java
+++ b/src/main/java/org/isf/disease/gui/DiseaseBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disease.gui;
 

--- a/src/main/java/org/isf/disease/gui/DiseaseEdit.java
+++ b/src/main/java/org/isf/disease/gui/DiseaseEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disease.gui;
 

--- a/src/main/java/org/isf/distype/gui/DiseaseTypeBrowser.java
+++ b/src/main/java/org/isf/distype/gui/DiseaseTypeBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.distype.gui;
 

--- a/src/main/java/org/isf/distype/gui/DiseaseTypeBrowserEdit.java
+++ b/src/main/java/org/isf/distype/gui/DiseaseTypeBrowserEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.distype.gui;
 

--- a/src/main/java/org/isf/dlvrrestype/gui/DeliveryResultTypeBrowser.java
+++ b/src/main/java/org/isf/dlvrrestype/gui/DeliveryResultTypeBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrrestype.gui;
 

--- a/src/main/java/org/isf/dlvrrestype/gui/DeliveryResultTypeBrowserEdit.java
+++ b/src/main/java/org/isf/dlvrrestype/gui/DeliveryResultTypeBrowserEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrrestype.gui;
 

--- a/src/main/java/org/isf/dlvrtype/gui/DeliveryTypeBrowser.java
+++ b/src/main/java/org/isf/dlvrtype/gui/DeliveryTypeBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrtype.gui;
 

--- a/src/main/java/org/isf/dlvrtype/gui/DeliveryTypeBrowserEdit.java
+++ b/src/main/java/org/isf/dlvrtype/gui/DeliveryTypeBrowserEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrtype.gui;
 

--- a/src/main/java/org/isf/exa/gui/ExamBrowser.java
+++ b/src/main/java/org/isf/exa/gui/ExamBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exa.gui;
 

--- a/src/main/java/org/isf/exa/gui/ExamEdit.java
+++ b/src/main/java/org/isf/exa/gui/ExamEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exa.gui;
 

--- a/src/main/java/org/isf/exa/gui/ExamFilterFactory.java
+++ b/src/main/java/org/isf/exa/gui/ExamFilterFactory.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exa.gui;
 

--- a/src/main/java/org/isf/exa/gui/ExamRowEdit.java
+++ b/src/main/java/org/isf/exa/gui/ExamRowEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exa.gui;
 

--- a/src/main/java/org/isf/exa/gui/ExamShow.java
+++ b/src/main/java/org/isf/exa/gui/ExamShow.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exa.gui;
 

--- a/src/main/java/org/isf/examination/gui/PatientExaminationEdit.java
+++ b/src/main/java/org/isf/examination/gui/PatientExaminationEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.examination.gui;
 

--- a/src/main/java/org/isf/exatype/gui/ExamTypeBrowser.java
+++ b/src/main/java/org/isf/exatype/gui/ExamTypeBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exatype.gui;
 

--- a/src/main/java/org/isf/exatype/gui/ExamTypeEdit.java
+++ b/src/main/java/org/isf/exatype/gui/ExamTypeEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exatype.gui;
 

--- a/src/main/java/org/isf/gui/BaseComponent.java
+++ b/src/main/java/org/isf/gui/BaseComponent.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.gui;
 

--- a/src/main/java/org/isf/help/HelpViewer.java
+++ b/src/main/java/org/isf/help/HelpViewer.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.help;
 

--- a/src/main/java/org/isf/hospital/gui/HospitalBrowser.java
+++ b/src/main/java/org/isf/hospital/gui/HospitalBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.hospital.gui;
 

--- a/src/main/java/org/isf/lab/gui/ExamPicker.java
+++ b/src/main/java/org/isf/lab/gui/ExamPicker.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui;
 

--- a/src/main/java/org/isf/lab/gui/LabBrowser.java
+++ b/src/main/java/org/isf/lab/gui/LabBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui;
 

--- a/src/main/java/org/isf/lab/gui/LabEdit.java
+++ b/src/main/java/org/isf/lab/gui/LabEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui;
 

--- a/src/main/java/org/isf/lab/gui/LabEditExtended.java
+++ b/src/main/java/org/isf/lab/gui/LabEditExtended.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui;
 

--- a/src/main/java/org/isf/lab/gui/LabNew.java
+++ b/src/main/java/org/isf/lab/gui/LabNew.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui;
 

--- a/src/main/java/org/isf/lab/gui/elements/ExamComboBox.java
+++ b/src/main/java/org/isf/lab/gui/elements/ExamComboBox.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui.elements;
 

--- a/src/main/java/org/isf/lab/gui/elements/ExamRowComboBox.java
+++ b/src/main/java/org/isf/lab/gui/elements/ExamRowComboBox.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui.elements;
 

--- a/src/main/java/org/isf/lab/gui/elements/ExamRowSubPanel.java
+++ b/src/main/java/org/isf/lab/gui/elements/ExamRowSubPanel.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui.elements;
 

--- a/src/main/java/org/isf/lab/gui/elements/MatComboBox.java
+++ b/src/main/java/org/isf/lab/gui/elements/MatComboBox.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui.elements;
 

--- a/src/main/java/org/isf/lab/gui/elements/PatientComboBox.java
+++ b/src/main/java/org/isf/lab/gui/elements/PatientComboBox.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui.elements;
 

--- a/src/main/java/org/isf/malnutrition/gui/InsertMalnutrition.java
+++ b/src/main/java/org/isf/malnutrition/gui/InsertMalnutrition.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.malnutrition.gui;
 

--- a/src/main/java/org/isf/malnutrition/gui/MalnutritionBrowser.java
+++ b/src/main/java/org/isf/malnutrition/gui/MalnutritionBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.malnutrition.gui;
 

--- a/src/main/java/org/isf/medicals/gui/MedicalBrowser.java
+++ b/src/main/java/org/isf/medicals/gui/MedicalBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicals.gui;
 

--- a/src/main/java/org/isf/medicals/gui/MedicalEdit.java
+++ b/src/main/java/org/isf/medicals/gui/MedicalEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicals.gui;
 

--- a/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.gui;
 

--- a/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.gui;
 

--- a/src/main/java/org/isf/medicalstock/gui/MovStockMultipleDischarging.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockMultipleDischarging.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.gui;
 

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.gui;
 

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacyEdit.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacyEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.gui;
 

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacyNew.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacyNew.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.gui;
 

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacyRectify.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacyRectify.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.gui;
 

--- a/src/main/java/org/isf/medstockmovtype/gui/MedicaldsrstockmovTypeBrowser.java
+++ b/src/main/java/org/isf/medstockmovtype/gui/MedicaldsrstockmovTypeBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medstockmovtype.gui;
 

--- a/src/main/java/org/isf/medstockmovtype/gui/MedicaldsrstockmovTypeBrowserEdit.java
+++ b/src/main/java/org/isf/medstockmovtype/gui/MedicaldsrstockmovTypeBrowserEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medstockmovtype.gui;
 

--- a/src/main/java/org/isf/medstockmovtype/gui/MedicalsrMovPatList.java
+++ b/src/main/java/org/isf/medstockmovtype/gui/MedicalsrMovPatList.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medstockmovtype.gui;
 

--- a/src/main/java/org/isf/medtype/gui/MedicalTypeBrowser.java
+++ b/src/main/java/org/isf/medtype/gui/MedicalTypeBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medtype.gui;
 

--- a/src/main/java/org/isf/medtype/gui/MedicalTypeBrowserEdit.java
+++ b/src/main/java/org/isf/medtype/gui/MedicalTypeBrowserEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medtype.gui;
 

--- a/src/main/java/org/isf/menu/gui/GBC.java
+++ b/src/main/java/org/isf/menu/gui/GBC.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.gui;
 

--- a/src/main/java/org/isf/menu/gui/GroupEdit.java
+++ b/src/main/java/org/isf/menu/gui/GroupEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.gui;
 

--- a/src/main/java/org/isf/menu/gui/Login.java
+++ b/src/main/java/org/isf/menu/gui/Login.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.gui;
 

--- a/src/main/java/org/isf/menu/gui/MainMenu.java
+++ b/src/main/java/org/isf/menu/gui/MainMenu.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.gui;
 

--- a/src/main/java/org/isf/menu/gui/Menu.java
+++ b/src/main/java/org/isf/menu/gui/Menu.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.gui;
 

--- a/src/main/java/org/isf/menu/gui/PrivilegeTree.java
+++ b/src/main/java/org/isf/menu/gui/PrivilegeTree.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.gui;
 

--- a/src/main/java/org/isf/menu/gui/SplashWindow3.java
+++ b/src/main/java/org/isf/menu/gui/SplashWindow3.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.gui;
 

--- a/src/main/java/org/isf/menu/gui/SubMenu.java
+++ b/src/main/java/org/isf/menu/gui/SubMenu.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.gui;
 

--- a/src/main/java/org/isf/menu/gui/UserBrowsing.java
+++ b/src/main/java/org/isf/menu/gui/UserBrowsing.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.gui;
 

--- a/src/main/java/org/isf/menu/gui/UserEdit.java
+++ b/src/main/java/org/isf/menu/gui/UserEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.gui;
 

--- a/src/main/java/org/isf/menu/gui/UserGroupBrowsing.java
+++ b/src/main/java/org/isf/menu/gui/UserGroupBrowsing.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.gui;
 

--- a/src/main/java/org/isf/opd/gui/OpdBrowser.java
+++ b/src/main/java/org/isf/opd/gui/OpdBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opd.gui;
 

--- a/src/main/java/org/isf/opd/gui/OpdEdit.java
+++ b/src/main/java/org/isf/opd/gui/OpdEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opd.gui;
 

--- a/src/main/java/org/isf/opd/gui/OpdEditExtended.java
+++ b/src/main/java/org/isf/opd/gui/OpdEditExtended.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opd.gui;
 

--- a/src/main/java/org/isf/operation/gui/OperationBrowser.java
+++ b/src/main/java/org/isf/operation/gui/OperationBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.gui;
 

--- a/src/main/java/org/isf/operation/gui/OperationEdit.java
+++ b/src/main/java/org/isf/operation/gui/OperationEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.gui;
 

--- a/src/main/java/org/isf/operation/gui/OperationList.java
+++ b/src/main/java/org/isf/operation/gui/OperationList.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.gui;
 

--- a/src/main/java/org/isf/operation/gui/OperationRowAdm.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowAdm.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.gui;
 

--- a/src/main/java/org/isf/operation/gui/OperationRowBase.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowBase.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.gui;
 

--- a/src/main/java/org/isf/operation/gui/OperationRowOpd.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowOpd.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.gui;
 

--- a/src/main/java/org/isf/opetype/gui/OperationTypeBrowser.java
+++ b/src/main/java/org/isf/opetype/gui/OperationTypeBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opetype.gui;
 

--- a/src/main/java/org/isf/opetype/gui/OperationTypeEdit.java
+++ b/src/main/java/org/isf/opetype/gui/OperationTypeEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opetype.gui;
 

--- a/src/main/java/org/isf/patient/gui/PatientBrowser.java
+++ b/src/main/java/org/isf/patient/gui/PatientBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.gui;
 

--- a/src/main/java/org/isf/patient/gui/PatientInsert.java
+++ b/src/main/java/org/isf/patient/gui/PatientInsert.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.gui;
 

--- a/src/main/java/org/isf/patient/gui/PatientInsertExtended.java
+++ b/src/main/java/org/isf/patient/gui/PatientInsertExtended.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.gui;
 

--- a/src/main/java/org/isf/patient/gui/PatientSummary.java
+++ b/src/main/java/org/isf/patient/gui/PatientSummary.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.gui;
 

--- a/src/main/java/org/isf/patient/gui/SelectPatient.java
+++ b/src/main/java/org/isf/patient/gui/SelectPatient.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.gui;
 

--- a/src/main/java/org/isf/patvac/gui/PatVacBrowser.java
+++ b/src/main/java/org/isf/patvac/gui/PatVacBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patvac.gui;
 

--- a/src/main/java/org/isf/patvac/gui/PatVacEdit.java
+++ b/src/main/java/org/isf/patvac/gui/PatVacEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patvac.gui;
 

--- a/src/main/java/org/isf/pregtreattype/gui/PregnantTreatmentTypeBrowser.java
+++ b/src/main/java/org/isf/pregtreattype/gui/PregnantTreatmentTypeBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pregtreattype.gui;
 

--- a/src/main/java/org/isf/pregtreattype/gui/PregnantTreatmentTypeEdit.java
+++ b/src/main/java/org/isf/pregtreattype/gui/PregnantTreatmentTypeEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pregtreattype.gui;
 

--- a/src/main/java/org/isf/priceslist/gui/ListBrowser.java
+++ b/src/main/java/org/isf/priceslist/gui/ListBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.priceslist.gui;
 

--- a/src/main/java/org/isf/priceslist/gui/ListEdit.java
+++ b/src/main/java/org/isf/priceslist/gui/ListEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.priceslist.gui;
 

--- a/src/main/java/org/isf/priceslist/gui/PriceModel.java
+++ b/src/main/java/org/isf/priceslist/gui/PriceModel.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.priceslist.gui;
 

--- a/src/main/java/org/isf/priceslist/gui/PricesBrowser.java
+++ b/src/main/java/org/isf/priceslist/gui/PricesBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.priceslist.gui;
 

--- a/src/main/java/org/isf/pricesothers/gui/PricesOthersBrowser.java
+++ b/src/main/java/org/isf/pricesothers/gui/PricesOthersBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pricesothers.gui;
 

--- a/src/main/java/org/isf/pricesothers/gui/PricesOthersEdit.java
+++ b/src/main/java/org/isf/pricesothers/gui/PricesOthersEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pricesothers.gui;
 

--- a/src/main/java/org/isf/session/LoginEventListener.java
+++ b/src/main/java/org/isf/session/LoginEventListener.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.session;
 

--- a/src/main/java/org/isf/session/LogoutEventListener.java
+++ b/src/main/java/org/isf/session/LogoutEventListener.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.session;
 

--- a/src/main/java/org/isf/session/SessionRefresheTimerRunnable.java
+++ b/src/main/java/org/isf/session/SessionRefresheTimerRunnable.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.session;
 

--- a/src/main/java/org/isf/session/UserSession.java
+++ b/src/main/java/org/isf/session/UserSession.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.session;
 

--- a/src/main/java/org/isf/sms/gui/SmsBrowser.java
+++ b/src/main/java/org/isf/sms/gui/SmsBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.gui;
 

--- a/src/main/java/org/isf/sms/gui/SmsEdit.java
+++ b/src/main/java/org/isf/sms/gui/SmsEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.gui;
 

--- a/src/main/java/org/isf/stat/gui/DiseasesListLauncher.java
+++ b/src/main/java/org/isf/stat/gui/DiseasesListLauncher.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui;
 

--- a/src/main/java/org/isf/stat/gui/ExamsList1Launcher.java
+++ b/src/main/java/org/isf/stat/gui/ExamsList1Launcher.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui;
 

--- a/src/main/java/org/isf/stat/gui/OperationsListLauncher.java
+++ b/src/main/java/org/isf/stat/gui/OperationsListLauncher.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui;
 

--- a/src/main/java/org/isf/stat/gui/report/DiseasesList.java
+++ b/src/main/java/org/isf/stat/gui/report/DiseasesList.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/gui/report/DisplayReport.java
+++ b/src/main/java/org/isf/stat/gui/report/DisplayReport.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/gui/report/ExamsList1.java
+++ b/src/main/java/org/isf/stat/gui/report/ExamsList1.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/gui/report/GenericReportAdmission.java
+++ b/src/main/java/org/isf/stat/gui/report/GenericReportAdmission.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/gui/report/GenericReportBill.java
+++ b/src/main/java/org/isf/stat/gui/report/GenericReportBill.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/gui/report/GenericReportDischarge.java
+++ b/src/main/java/org/isf/stat/gui/report/GenericReportDischarge.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/gui/report/GenericReportExamination.java
+++ b/src/main/java/org/isf/stat/gui/report/GenericReportExamination.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/gui/report/GenericReportFromDateToDate.java
+++ b/src/main/java/org/isf/stat/gui/report/GenericReportFromDateToDate.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/gui/report/GenericReportMY.java
+++ b/src/main/java/org/isf/stat/gui/report/GenericReportMY.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/gui/report/GenericReportOpd.java
+++ b/src/main/java/org/isf/stat/gui/report/GenericReportOpd.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/gui/report/GenericReportPatient.java
+++ b/src/main/java/org/isf/stat/gui/report/GenericReportPatient.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/gui/report/GenericReportPatientVersion2.java
+++ b/src/main/java/org/isf/stat/gui/report/GenericReportPatientVersion2.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/gui/report/GenericReportPharmaceuticalOrder.java
+++ b/src/main/java/org/isf/stat/gui/report/GenericReportPharmaceuticalOrder.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/gui/report/GenericReportPharmaceuticalStock.java
+++ b/src/main/java/org/isf/stat/gui/report/GenericReportPharmaceuticalStock.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/gui/report/GenericReportPharmaceuticalStockCard.java
+++ b/src/main/java/org/isf/stat/gui/report/GenericReportPharmaceuticalStockCard.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/gui/report/GenericReportPharmaceuticalStockWard.java
+++ b/src/main/java/org/isf/stat/gui/report/GenericReportPharmaceuticalStockWard.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/gui/report/GenericReportUserInDate.java
+++ b/src/main/java/org/isf/stat/gui/report/GenericReportUserInDate.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/gui/report/OperationsList.java
+++ b/src/main/java/org/isf/stat/gui/report/OperationsList.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/gui/report/WardVisitsReport.java
+++ b/src/main/java/org/isf/stat/gui/report/WardVisitsReport.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.gui.report;
 

--- a/src/main/java/org/isf/stat/reportlauncher/gui/ReportLauncher.java
+++ b/src/main/java/org/isf/stat/reportlauncher/gui/ReportLauncher.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.reportlauncher.gui;
 

--- a/src/main/java/org/isf/supplier/gui/SupplierBrowser.java
+++ b/src/main/java/org/isf/supplier/gui/SupplierBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.supplier.gui;
 

--- a/src/main/java/org/isf/supplier/gui/SupplierEdit.java
+++ b/src/main/java/org/isf/supplier/gui/SupplierEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.supplier.gui;
 

--- a/src/main/java/org/isf/therapy/gui/TherapyEdit.java
+++ b/src/main/java/org/isf/therapy/gui/TherapyEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.therapy.gui;
 

--- a/src/main/java/org/isf/therapy/gui/TherapyEntryForm.java
+++ b/src/main/java/org/isf/therapy/gui/TherapyEntryForm.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.therapy.gui;
 

--- a/src/main/java/org/isf/utils/Constants.java
+++ b/src/main/java/org/isf/utils/Constants.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils;
 

--- a/src/main/java/org/isf/utils/exception/gui/OHServiceExceptionUtil.java
+++ b/src/main/java/org/isf/utils/exception/gui/OHServiceExceptionUtil.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.exception.gui;
 

--- a/src/main/java/org/isf/utils/image/ImageUtil.java
+++ b/src/main/java/org/isf/utils/image/ImageUtil.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.image;
 

--- a/src/main/java/org/isf/utils/jobjects/Cropping.java
+++ b/src/main/java/org/isf/utils/jobjects/Cropping.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/CursorManager.java
+++ b/src/main/java/org/isf/utils/jobjects/CursorManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/DelayTimer.java
+++ b/src/main/java/org/isf/utils/jobjects/DelayTimer.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/DelayTimerCallback.java
+++ b/src/main/java/org/isf/utils/jobjects/DelayTimerCallback.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/DispatchedEvent.java
+++ b/src/main/java/org/isf/utils/jobjects/DispatchedEvent.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/GoodDateChooser.java
+++ b/src/main/java/org/isf/utils/jobjects/GoodDateChooser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/GoodDateTimeChooserBase.java
+++ b/src/main/java/org/isf/utils/jobjects/GoodDateTimeChooserBase.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/GoodDateTimeSpinnerChooser.java
+++ b/src/main/java/org/isf/utils/jobjects/GoodDateTimeSpinnerChooser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/GoodDateTimeToggleChooser.java
+++ b/src/main/java/org/isf/utils/jobjects/GoodDateTimeToggleChooser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/GoodDateTimeVisitChooser.java
+++ b/src/main/java/org/isf/utils/jobjects/GoodDateTimeVisitChooser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/GoodFromDateToDateChooser.java
+++ b/src/main/java/org/isf/utils/jobjects/GoodFromDateToDateChooser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/GoodTimeChooser.java
+++ b/src/main/java/org/isf/utils/jobjects/GoodTimeChooser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/IconButton.java
+++ b/src/main/java/org/isf/utils/jobjects/IconButton.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/JAgenda.java
+++ b/src/main/java/org/isf/utils/jobjects/JAgenda.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 /*
  *  JDayChooser.java  - A bean for choosing a day

--- a/src/main/java/org/isf/utils/jobjects/JLabelRequired.java
+++ b/src/main/java/org/isf/utils/jobjects/JLabelRequired.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/JMonthChooser.java
+++ b/src/main/java/org/isf/utils/jobjects/JMonthChooser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/JMonthYearChooser.java
+++ b/src/main/java/org/isf/utils/jobjects/JMonthYearChooser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/JTextFieldSearchModel.java
+++ b/src/main/java/org/isf/utils/jobjects/JTextFieldSearchModel.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/JYearChooser.java
+++ b/src/main/java/org/isf/utils/jobjects/JYearChooser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/MessageDialog.java
+++ b/src/main/java/org/isf/utils/jobjects/MessageDialog.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/ModalJFrame.java
+++ b/src/main/java/org/isf/utils/jobjects/ModalJFrame.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/OhDefaultCellRenderer.java
+++ b/src/main/java/org/isf/utils/jobjects/OhDefaultCellRenderer.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/OhTableDrugsModel.java
+++ b/src/main/java/org/isf/utils/jobjects/OhTableDrugsModel.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/OhTableModel.java
+++ b/src/main/java/org/isf/utils/jobjects/OhTableModel.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/OhTableModelExam.java
+++ b/src/main/java/org/isf/utils/jobjects/OhTableModelExam.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/OhTableOperationModel.java
+++ b/src/main/java/org/isf/utils/jobjects/OhTableOperationModel.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/RequestFocusListener.java
+++ b/src/main/java/org/isf/utils/jobjects/RequestFocusListener.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/ScaledJSlider.java
+++ b/src/main/java/org/isf/utils/jobjects/ScaledJSlider.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/ShadowBorder.java
+++ b/src/main/java/org/isf/utils/jobjects/ShadowBorder.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/StockCardDialog.java
+++ b/src/main/java/org/isf/utils/jobjects/StockCardDialog.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/StockLedgerDialog.java
+++ b/src/main/java/org/isf/utils/jobjects/StockLedgerDialog.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/TextPrompt.java
+++ b/src/main/java/org/isf/utils/jobjects/TextPrompt.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/VoDoubleTextField.java
+++ b/src/main/java/org/isf/utils/jobjects/VoDoubleTextField.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/VoFloatTextField.java
+++ b/src/main/java/org/isf/utils/jobjects/VoFloatTextField.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/VoIntegerTextField.java
+++ b/src/main/java/org/isf/utils/jobjects/VoIntegerTextField.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/VoLimitedTextArea.java
+++ b/src/main/java/org/isf/utils/jobjects/VoLimitedTextArea.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/VoLimitedTextField.java
+++ b/src/main/java/org/isf/utils/jobjects/VoLimitedTextField.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/jobjects/WaitCursorEventQueue.java
+++ b/src/main/java/org/isf/utils/jobjects/WaitCursorEventQueue.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.jobjects;
 

--- a/src/main/java/org/isf/utils/layout/SpringUtilities.java
+++ b/src/main/java/org/isf/utils/layout/SpringUtilities.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.layout;
 

--- a/src/main/java/org/isf/utils/time/Converters.java
+++ b/src/main/java/org/isf/utils/time/Converters.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.time;
 

--- a/src/main/java/org/isf/vaccine/gui/VaccineBrowser.java
+++ b/src/main/java/org/isf/vaccine/gui/VaccineBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vaccine.gui;
 

--- a/src/main/java/org/isf/vaccine/gui/VaccineEdit.java
+++ b/src/main/java/org/isf/vaccine/gui/VaccineEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vaccine.gui;
 

--- a/src/main/java/org/isf/vactype/gui/VaccineTypeBrowser.java
+++ b/src/main/java/org/isf/vactype/gui/VaccineTypeBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vactype.gui;
 

--- a/src/main/java/org/isf/vactype/gui/VaccineTypeEdit.java
+++ b/src/main/java/org/isf/vactype/gui/VaccineTypeEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vactype.gui;
 

--- a/src/main/java/org/isf/video/PhotoboothTester.java
+++ b/src/main/java/org/isf/video/PhotoboothTester.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.video;
 

--- a/src/main/java/org/isf/video/gui/PatientPhotoPanel.java
+++ b/src/main/java/org/isf/video/gui/PatientPhotoPanel.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.video.gui;
 

--- a/src/main/java/org/isf/video/gui/PhotoFrame.java
+++ b/src/main/java/org/isf/video/gui/PhotoFrame.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.video.gui;
 

--- a/src/main/java/org/isf/video/gui/PhotoPanel.java
+++ b/src/main/java/org/isf/video/gui/PhotoPanel.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.video.gui;
 

--- a/src/main/java/org/isf/video/gui/PhotoPreviewBox.java
+++ b/src/main/java/org/isf/video/gui/PhotoPreviewBox.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.video.gui;
 

--- a/src/main/java/org/isf/video/gui/PhotoPreviewPanel.java
+++ b/src/main/java/org/isf/video/gui/PhotoPreviewPanel.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.video.gui;
 

--- a/src/main/java/org/isf/video/gui/PhotoboothComponent.java
+++ b/src/main/java/org/isf/video/gui/PhotoboothComponent.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.video.gui;
 

--- a/src/main/java/org/isf/video/gui/PhotoboothComponentImpl.java
+++ b/src/main/java/org/isf/video/gui/PhotoboothComponentImpl.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.video.gui;
 

--- a/src/main/java/org/isf/video/gui/PhotoboothDialog.java
+++ b/src/main/java/org/isf/video/gui/PhotoboothDialog.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.video.gui;
 

--- a/src/main/java/org/isf/video/gui/PhotoboothPanelModel.java
+++ b/src/main/java/org/isf/video/gui/PhotoboothPanelModel.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.video.gui;
 

--- a/src/main/java/org/isf/video/gui/PhotoboothPanelPresentationModel.java
+++ b/src/main/java/org/isf/video/gui/PhotoboothPanelPresentationModel.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.video.gui;
 

--- a/src/main/java/org/isf/visits/gui/InsertVisit.java
+++ b/src/main/java/org/isf/visits/gui/InsertVisit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.visits.gui;
 

--- a/src/main/java/org/isf/visits/gui/VisitView.java
+++ b/src/main/java/org/isf/visits/gui/VisitView.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.visits.gui;
 

--- a/src/main/java/org/isf/ward/gui/WardBrowser.java
+++ b/src/main/java/org/isf/ward/gui/WardBrowser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.ward.gui;
 

--- a/src/main/java/org/isf/ward/gui/WardEdit.java
+++ b/src/main/java/org/isf/ward/gui/WardEdit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.ward.gui;
 

--- a/src/main/java/org/isf/xmpp/gui/ChatMessages.java
+++ b/src/main/java/org/isf/xmpp/gui/ChatMessages.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.xmpp.gui;
 

--- a/src/main/java/org/isf/xmpp/gui/ChatPanel.java
+++ b/src/main/java/org/isf/xmpp/gui/ChatPanel.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.xmpp.gui;
 

--- a/src/main/java/org/isf/xmpp/gui/ChatTab.java
+++ b/src/main/java/org/isf/xmpp/gui/ChatTab.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.xmpp.gui;
 

--- a/src/main/java/org/isf/xmpp/gui/CommunicationFrame.java
+++ b/src/main/java/org/isf/xmpp/gui/CommunicationFrame.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.xmpp.gui;
 

--- a/src/test/java/org/isf/accounting/TestBill.java
+++ b/src/test/java/org/isf/accounting/TestBill.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting;
 

--- a/src/test/java/org/isf/accounting/TestPayment.java
+++ b/src/test/java/org/isf/accounting/TestPayment.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting;
 

--- a/src/test/java/org/isf/accounting/gui/BillDataLoaderTest.java
+++ b/src/test/java/org/isf/accounting/gui/BillDataLoaderTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.gui;
 

--- a/src/test/java/org/isf/accounting/gui/totals/BalanceTotalTest.java
+++ b/src/test/java/org/isf/accounting/gui/totals/BalanceTotalTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.gui.totals;
 

--- a/src/test/java/org/isf/accounting/gui/totals/PaymentsTotalTest.java
+++ b/src/test/java/org/isf/accounting/gui/totals/PaymentsTotalTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.gui.totals;
 

--- a/src/test/java/org/isf/accounting/gui/totals/UserTotalTest.java
+++ b/src/test/java/org/isf/accounting/gui/totals/UserTotalTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.gui.totals;
 

--- a/src/test/java/org/isf/admission/gui/DiseaseFinderTest.java
+++ b/src/test/java/org/isf/admission/gui/DiseaseFinderTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.gui;
 

--- a/src/test/java/org/isf/admission/gui/TestAdmission.java
+++ b/src/test/java/org/isf/admission/gui/TestAdmission.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.gui;
 

--- a/src/test/java/org/isf/admission/gui/TestDisease.java
+++ b/src/test/java/org/isf/admission/gui/TestDisease.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.gui;
 

--- a/src/test/java/org/isf/admission/gui/TestOperationRow.java
+++ b/src/test/java/org/isf/admission/gui/TestOperationRow.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.gui;
 

--- a/src/test/java/org/isf/admission/gui/TestWard.java
+++ b/src/test/java/org/isf/admission/gui/TestWard.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.gui;
 

--- a/src/test/java/org/isf/admission/gui/validation/OperationRowValidatorTest.java
+++ b/src/test/java/org/isf/admission/gui/validation/OperationRowValidatorTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.gui.validation;
 

--- a/src/test/java/org/isf/admission/gui/ward/WardBrowserManagerStub.java
+++ b/src/test/java/org/isf/admission/gui/ward/WardBrowserManagerStub.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.gui.ward;
 

--- a/src/test/java/org/isf/admission/gui/ward/WardComboBoxInitializerTest.java
+++ b/src/test/java/org/isf/admission/gui/ward/WardComboBoxInitializerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.gui.ward;
 

--- a/src/test/java/org/isf/exa/gui/ExamFilterFactoryTest.java
+++ b/src/test/java/org/isf/exa/gui/ExamFilterFactoryTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exa.gui;
 

--- a/src/test/java/org/isf/lab/gui/elements/ExamComboBoxTest.java
+++ b/src/test/java/org/isf/lab/gui/elements/ExamComboBoxTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui.elements;
 

--- a/src/test/java/org/isf/lab/gui/elements/ExamRowComboBoxTest.java
+++ b/src/test/java/org/isf/lab/gui/elements/ExamRowComboBoxTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui.elements;
 

--- a/src/test/java/org/isf/lab/gui/elements/ExamRowSubPanelTest.java
+++ b/src/test/java/org/isf/lab/gui/elements/ExamRowSubPanelTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui.elements;
 

--- a/src/test/java/org/isf/lab/gui/elements/MatComboBoxTest.java
+++ b/src/test/java/org/isf/lab/gui/elements/MatComboBoxTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui.elements;
 

--- a/src/test/java/org/isf/lab/gui/elements/PatientComboBoxTest.java
+++ b/src/test/java/org/isf/lab/gui/elements/PatientComboBoxTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui.elements;
 

--- a/src/test/java/org/isf/lab/gui/elements/TestExam.java
+++ b/src/test/java/org/isf/lab/gui/elements/TestExam.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui.elements;
 

--- a/src/test/java/org/isf/lab/gui/elements/TestExamRow.java
+++ b/src/test/java/org/isf/lab/gui/elements/TestExamRow.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui.elements;
 

--- a/src/test/java/org/isf/lab/gui/elements/TestLaboratoryRow.java
+++ b/src/test/java/org/isf/lab/gui/elements/TestLaboratoryRow.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui.elements;
 

--- a/src/test/java/org/isf/lab/gui/elements/TestPatient.java
+++ b/src/test/java/org/isf/lab/gui/elements/TestPatient.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.gui.elements;
 

--- a/src/test/java/org/isf/utils/image/ImageUtilTest.java
+++ b/src/test/java/org/isf/utils/image/ImageUtilTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.image;
 


### PR DESCRIPTION
Change: `If not, see <http://www.gnu.org/licenses/>`
To:   `If not, see <https://www.gnu.org/licenses/>`