### PR TITLE
Chore: use formatMessage() instead of concat()

### DIFF
--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -1414,7 +1414,7 @@ angal.priceslist.adescription                                                   
 angal.priceslist.changelist                                                                            = Change List
 angal.priceslist.copy.btn                                                                              = Copy
 angal.priceslist.copy.btn.key                                                                          = P
-angal.priceslist.copyof                                                                                = Copy of
+angal.priceslist.copyof.fmt                                                                            = Copy of {0}
 angal.priceslist.currency.col                                                                          = Currency
 angal.priceslist.currencystar                                                                          = Currency*
 angal.priceslist.deletethislistandallitsprices.fmt.msg                                                 = Delete this list and all its prices: {0}?

--- a/src/main/java/org/isf/priceslist/gui/ListBrowser.java
+++ b/src/main/java/org/isf/priceslist/gui/ListBrowser.java
@@ -221,7 +221,7 @@ public class ListBrowser extends ModalJFrame implements ListListener {
 
 						// Save new list
 						if (newName.isEmpty()) {
-							newName = MessageBundle.getMessage("angal.priceslist.copyof").concat(" ").concat(list.getName());
+							newName = MessageBundle.formatMessage("angal.priceslist.copyof.fmt", list.getName());
 						}
 						PriceList copiedList = new PriceList(list.getId(), MessageBundle.getMessage("angal.priceslist.acode"), newName,
 								MessageBundle.getMessage("angal.priceslist.adescription"), list.getCurrency());


### PR DESCRIPTION
Code inspection recommended using `+` instead of `concat()` when constants are involved.  The `better` fix is just to use the capabilities of the `formatMessage()` method.