### PR TITLE
Chore: remove import statement for class in same package

### DIFF
--- a/src/main/java/org/isf/xmpp/gui/CommunicationFrame.java
+++ b/src/main/java/org/isf/xmpp/gui/CommunicationFrame.java
@@ -59,7 +59,6 @@ import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.gui.OHServiceExceptionUtil;
 import org.isf.xmpp.gui.ChatTab.TabButton;
-import org.isf.xmpp.gui.ComplexCellRender;
 import org.isf.xmpp.manager.Interaction;
 import org.jivesoftware.smack.Chat;
 import org.jivesoftware.smack.ChatManager;


### PR DESCRIPTION
There is no need to specify an import for a class in the same package.