### PR TITLE
Chore: use Integer.parseInt() for String to int conversion

### DIFF
--- a/src/main/java/org/isf/opd/gui/OpdBrowser.java
+++ b/src/main/java/org/isf/opd/gui/OpdBrowser.java
@@ -1162,7 +1162,7 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 				String codeHint = ((JTextField) e.getSource()).getText();
 				int code = 0;
 				try {
-					code = Integer.valueOf(codeHint).intValue();
+					code = Integer.parseInt(codeHint);
 				} catch (NumberFormatException e1) {
 					MessageDialog.error(OpdBrowser.this, MessageBundle.getMessage("angal.common.pleaseinsertavalidnumber.msg"));
 					return;
@@ -1196,7 +1196,7 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 				String codeHint = ((JTextField) e.getSource()).getText();
 				int code = 0;
 				try {
-					code = Integer.valueOf(codeHint).intValue();
+					code = Integer.parseInt(codeHint);
 				} catch (NumberFormatException e1) {
 					MessageDialog.error(OpdBrowser.this, MessageBundle.getMessage("angal.common.pleaseinsertavalidnumber.msg"));
 					return;
@@ -1226,7 +1226,7 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 				String codeHint = ((JTextField) e.getSource()).getText();
 				int code = 0;
 				try {
-					code = Integer.valueOf(codeHint).intValue();
+					code = Integer.parseInt(codeHint);
 				} catch (NumberFormatException e1) {
 					MessageDialog.error(OpdBrowser.this, MessageBundle.getMessage("angal.common.pleaseinsertavalidnumber.msg"));
 					return;


### PR DESCRIPTION
It has the advantage of not needing boxing/unboxing of value.   `Integer.parseInt()` has used in the same file in other locations.