### PR TITLE
Chore: JUnit improvements

### DIFF
--- a/src/test/java/org/isf/accounting/gui/BillDataLoaderTest.java
+++ b/src/test/java/org/isf/accounting/gui/BillDataLoaderTest.java
@@ -35,11 +35,12 @@ import org.isf.patient.model.Patient;
 import org.isf.utils.exception.OHServiceException;
 import org.junit.jupiter.api.Test;
 
-public class BillDataLoaderTest {
+class BillDataLoaderTest {
 	
 	private static final String NO_USERNAME = null;
+
     @Test
-    public void shouldLoadPendingBillsFromManagerForParentPatient() throws OHServiceException {
+    void shouldLoadPendingBillsFromManagerForParentPatient() throws OHServiceException {
         // given:
         Patient patientParent = new Patient();
         patientParent.setCode(1);
@@ -63,11 +64,11 @@ public class BillDataLoaderTest {
         List<Bill> result = billDataLoader.loadBills("O", NO_USERNAME);
 
         // then:
-        assertThat(result.size()).isEqualTo(3);
+        assertThat(result).hasSize(3);
     }
 
     @Test
-    public void shouldLoadPendingBillsFromPeriodOnly() throws OHServiceException {
+    void shouldLoadPendingBillsFromPeriodOnly() throws OHServiceException {
         // given:
         BillDataLoader billDataLoader = new BillDataLoader(
                 Arrays.asList(
@@ -86,11 +87,11 @@ public class BillDataLoaderTest {
         List<Bill> result = billDataLoader.loadBills("O", NO_USERNAME);
 
         // then:
-        assertThat(result.size()).isEqualTo(1);
+        assertThat(result).hasSize(1);
     }
 
     @Test
-    public void shouldLoadAllBillsMergedWithBillsFromPaymentWithoutDuplicates() throws OHServiceException {
+    void shouldLoadAllBillsMergedWithBillsFromPaymentWithoutDuplicates() throws OHServiceException {
         // given:
         BillDataLoader billDataLoader = new BillDataLoader(
                 Arrays.asList(
@@ -109,11 +110,11 @@ public class BillDataLoaderTest {
         List<Bill> result = billDataLoader.loadBills("ALL", NO_USERNAME);
 
         // then:
-        assertThat(result.size()).isEqualTo(3);
+        assertThat(result).hasSize(3);
     }
 
     @Test
-    public void shouldLoadClosedBillFromGivenPeriod() throws OHServiceException {
+    void shouldLoadClosedBillFromGivenPeriod() throws OHServiceException {
         // given:
         BillDataLoader billDataLoader = new BillDataLoader(
                 Arrays.asList(
@@ -132,7 +133,7 @@ public class BillDataLoaderTest {
         List<Bill> result = billDataLoader.loadBills("C", NO_USERNAME);
 
         // then:
-        assertThat(result.size()).isEqualTo(1);
+        assertThat(result).hasSize(1);
     }
 
 

--- a/src/test/java/org/isf/accounting/gui/totals/BalanceTotalTest.java
+++ b/src/test/java/org/isf/accounting/gui/totals/BalanceTotalTest.java
@@ -29,10 +29,10 @@ import java.util.Arrays;
 import org.isf.accounting.TestBill;
 import org.junit.jupiter.api.Test;
 
-public class BalanceTotalTest {
+class BalanceTotalTest {
 
 	@Test
-	public void shouldCalculateBalanceForWholePeriod() {
+	void shouldCalculateBalanceForWholePeriod() {
 		// given:
 		BalanceTotal balanceTotal = new BalanceTotal(Arrays.asList(
 				TestBill.notDeletedBillWithBalance(1, 123),
@@ -47,7 +47,7 @@ public class BalanceTotalTest {
 	}
 
 	@Test
-	public void shouldSkipDeletedBills() {
+	void shouldSkipDeletedBills() {
 		// given:
 		BalanceTotal balanceTotal = new BalanceTotal(Arrays.asList(
 				TestBill.notDeletedBillWithBalance(1, 123),

--- a/src/test/java/org/isf/accounting/gui/totals/PaymentsTotalTest.java
+++ b/src/test/java/org/isf/accounting/gui/totals/PaymentsTotalTest.java
@@ -30,10 +30,10 @@ import org.isf.accounting.TestBill;
 import org.isf.accounting.TestPayment;
 import org.junit.jupiter.api.Test;
 
-public class PaymentsTotalTest {
+class PaymentsTotalTest {
 
 	@Test
-	public void shouldCalculateFromPayments() {
+	void shouldCalculateFromPayments() {
 		// given:
 		PaymentsTotal paymentsTotal = new PaymentsTotal(
 				Arrays.asList(1, 2),
@@ -51,7 +51,7 @@ public class PaymentsTotalTest {
 	}
 
 	@Test
-	public void shouldSkipPaymentsForDeletedBills() {
+	void shouldSkipPaymentsForDeletedBills() {
 		// given:
 		PaymentsTotal paymentsTotal = new PaymentsTotal(
 				Arrays.asList(1),

--- a/src/test/java/org/isf/accounting/gui/totals/UserTotalTest.java
+++ b/src/test/java/org/isf/accounting/gui/totals/UserTotalTest.java
@@ -30,13 +30,13 @@ import org.isf.accounting.TestBill;
 import org.isf.accounting.TestPayment;
 import org.junit.jupiter.api.Test;
 
-public class UserTotalTest {
+class UserTotalTest {
 
     public static final String TEST_USER = "testUser";
     public static final String OTHER_USER = "dupaUser";
 
     @Test
-    public void shouldCalculateFromPayments() {
+    void shouldCalculateFromPayments() {
         // given:
         UserTotal userTotal = new UserTotal(
                 Arrays.asList(1, 2),
@@ -55,7 +55,7 @@ public class UserTotalTest {
     }
 
     @Test
-    public void shouldSkipPaymentsForDeletedBills() {
+    void shouldSkipPaymentsForDeletedBills() {
         // given:
         UserTotal userTotal = new UserTotal(
                 Arrays.asList(1),
@@ -74,7 +74,7 @@ public class UserTotalTest {
     }
 
     @Test
-    public void shouldSkipPaymentForOtherUser() {
+    void shouldSkipPaymentForOtherUser() {
         // given:
         UserTotal userTotal = new UserTotal(
                 Arrays.asList(1, 2),

--- a/src/test/java/org/isf/admission/gui/DiseaseFinderTest.java
+++ b/src/test/java/org/isf/admission/gui/DiseaseFinderTest.java
@@ -33,12 +33,12 @@ import javax.swing.JComboBox;
 import org.isf.disease.model.Disease;
 import org.junit.jupiter.api.Test;
 
-public class DiseaseFinderTest {
+class DiseaseFinderTest {
 
 	private DiseaseFinder diseaseFinder = new DiseaseFinder();
 
 	@Test
-	public void shouldFindDiseaseByDescriptionContaining() {
+	void shouldFindDiseaseByDescriptionContaining() {
 		// given:
 		List<Disease> diseases = new ArrayList<>(Arrays.asList(TestDisease.diseaseWithDescription("AIDS")));
 
@@ -46,11 +46,11 @@ public class DiseaseFinderTest {
 		List<Disease> result = diseaseFinder.getSearchDiagnosisResults("id", diseases);
 
 		// then:
-		assertThat(result.size()).isEqualTo(1);
+		assertThat(result).hasSize(1);
 	}
 
 	@Test
-	public void shouldFindAllByEmptyQuery() {
+	void shouldFindAllByEmptyQuery() {
 		// given:
 		List<Disease> diseases = new ArrayList<>(Arrays.asList(TestDisease.diseaseWithDescription("AIDS")));
 
@@ -58,11 +58,11 @@ public class DiseaseFinderTest {
 		List<Disease> result = diseaseFinder.getSearchDiagnosisResults("", diseases);
 
 		// then:
-		assertThat(result.size()).isEqualTo(1);
+		assertThat(result).hasSize(1);
 	}
 
 	@Test
-	public void shouldNotFindByWrongDescription() {
+	void shouldNotFindByWrongDescription() {
 		// given:
 		List<Disease> diseases = new ArrayList<>(Arrays.asList(TestDisease.diseaseWithDescription("AIDS")));
 
@@ -70,11 +70,11 @@ public class DiseaseFinderTest {
 		List<Disease> result = diseaseFinder.getSearchDiagnosisResults("hiv", diseases);
 
 		// then:
-		assertThat(result.isEmpty()).isTrue();
+		assertThat(result).isEmpty();
 	}
 
 	@Test
-	public void shouldFindAndSelectAndAddAllFromDiseaseList() {
+	void shouldFindAndSelectAndAddAllFromDiseaseList() {
 		// given:
 		List<Disease> diseases = new ArrayList<>(
 				Arrays.asList(
@@ -89,13 +89,13 @@ public class DiseaseFinderTest {
 		Optional<Disease> result = diseaseFinder.findAndSelectDisease(diseaseToFind, diseases, diseaseBox);
 
 		// then:
-		assertThat(result.isPresent()).isTrue();
+		assertThat(result).isPresent();
 		assertThat(diseaseBox.getItemCount()).isEqualTo(2);
 		assertThat(diseaseBox.getSelectedItem()).isEqualTo(diseaseToFind);
 	}
 
 	@Test
-	public void shouldReturnEmptyForNullDiseaseToFind() {
+	void shouldReturnEmptyForNullDiseaseToFind() {
 		// given:
 		List<Disease> diseases = new ArrayList<>(
 				Arrays.asList(
@@ -110,12 +110,12 @@ public class DiseaseFinderTest {
 		Optional<Disease> result = diseaseFinder.findAndSelectDisease(diseaseToFind, diseases, diseaseBox);
 
 		// then:
-		assertThat(result.isPresent()).isFalse();
+		assertThat(result).isNotPresent();
 		assertThat(diseaseBox.getItemCount()).isEqualTo(2);
 	}
 
 	@Test
-	public void shouldReturnEmptyForNotFoundDisease() {
+	void shouldReturnEmptyForNotFoundDisease() {
 		// given:
 		List<Disease> diseases = new ArrayList<>(
 				Arrays.asList(
@@ -130,12 +130,12 @@ public class DiseaseFinderTest {
 		Optional<Disease> result = diseaseFinder.findAndSelectDisease(diseaseToFind, diseases, diseaseBox);
 
 		// then:
-		assertThat(result.isPresent()).isFalse();
+		assertThat(result).isNotPresent();
 		assertThat(diseaseBox.getItemCount()).isEqualTo(2);
 	}
 
 	@Test
-	public void shouldFindAndSelectAndAddSelectedFromAllDiseaseList() {
+	void shouldFindAndSelectAndAddSelectedFromAllDiseaseList() {
 		// given:
 		List<Disease> diseases = new ArrayList<>(
 				Arrays.asList(
@@ -150,13 +150,13 @@ public class DiseaseFinderTest {
 		Optional<Disease> result = diseaseFinder.findAndSelectFromAllDiseases(diseaseToFind, diseases, diseaseBox);
 
 		// then:
-		assertThat(result.isPresent()).isTrue();
+		assertThat(result).isPresent();
 		assertThat(diseaseBox.getItemCount()).isOne();
 		assertThat(diseaseBox.getSelectedItem()).isEqualTo(diseaseToFind);
 	}
 
 	@Test
-	public void shouldReturnEmptyForNotFoundFromAllDiseaseList() {
+	void shouldReturnEmptyForNotFoundFromAllDiseaseList() {
 		// given:
 		List<Disease> diseases = new ArrayList<>(
 				Arrays.asList(
@@ -171,7 +171,7 @@ public class DiseaseFinderTest {
 		Optional<Disease> result = diseaseFinder.findAndSelectFromAllDiseases(diseaseToFind, diseases, diseaseBox);
 
 		// then:
-		assertThat(result.isPresent()).isFalse();
+		assertThat(result).isNotPresent();
 		assertThat(diseaseBox.getItemCount()).isZero();
 	}
 

--- a/src/test/java/org/isf/admission/gui/validation/OperationRowValidatorTest.java
+++ b/src/test/java/org/isf/admission/gui/validation/OperationRowValidatorTest.java
@@ -34,18 +34,18 @@ import org.isf.utils.exception.model.OHExceptionMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class OperationRowValidatorTest {
+class OperationRowValidatorTest {
 
 	OperationRowValidator operationRowValidator;
 
 	@BeforeEach
-	public void setUp() {
+	void setUp() {
 		GeneralData.LANGUAGE = "en-EN";
 		operationRowValidator = new OperationRowValidator();
 	}
 
 	@Test
-	public void shouldNotAddErrorsWhenDateRangeIsCorrect() {
+	void shouldNotAddErrorsWhenDateRangeIsCorrect() {
 		// given:
 		LocalDateTime operationDate = LocalDateTime.of(2020, 2, 2, 11, 0);
 		LocalDateTime admissionDate = LocalDateTime.of(2020, 2, 1, 11, 0);
@@ -58,11 +58,11 @@ public class OperationRowValidatorTest {
 		);
 
 		// then:
-		assertThat(result.isEmpty()).isTrue();
+		assertThat(result).isEmpty();
 	}
 
 	@Test
-	public void shouldNotAddErrorsWhenAdmissionAndDischargeDatesAreNull() {
+	void shouldNotAddErrorsWhenAdmissionAndDischargeDatesAreNull() {
 		// given:
 		LocalDateTime operationDate = LocalDateTime.of(2020, 2, 2, 11, 0);
 		LocalDateTime admissionDate = null;
@@ -75,11 +75,11 @@ public class OperationRowValidatorTest {
 		);
 
 		// then:
-		assertThat(result.isEmpty()).isTrue();
+		assertThat(result).isEmpty();
 	}
 
 	@Test
-	public void shouldAddErrorsForOperationsBeforeAdmissionDate() {
+	void shouldAddErrorsForOperationsBeforeAdmissionDate() {
 		// given:
 		LocalDateTime firstOperationDate = LocalDateTime.of(2019, 2, 2, 11, 0);
 		LocalDateTime secondOperationDate = LocalDateTime.of(2018, 2, 2, 11, 0);
@@ -96,11 +96,11 @@ public class OperationRowValidatorTest {
 		);
 
 		// then:
-		assertThat(result.size()).isEqualTo(2);
+		assertThat(result).hasSize(2);
 	}
 
 	@Test
-	public void shouldAddErrorsForOperationsBeforeAdmissionDateWhenDischargeDateNotProvided() {
+	void shouldAddErrorsForOperationsBeforeAdmissionDateWhenDischargeDateNotProvided() {
 		// given:
 		LocalDateTime firstOperationDate = LocalDateTime.of(2019, 2, 2, 11, 0);
 		LocalDateTime secondOperationDate = LocalDateTime.of(2018, 2, 2, 11, 0);
@@ -117,11 +117,11 @@ public class OperationRowValidatorTest {
 		);
 
 		// then:
-		assertThat(result.size()).isEqualTo(2);
+		assertThat(result).hasSize(2);
 	}
 
 	@Test
-	public void shouldAddErrorsForOperationsAfterDischargeDate() {
+	void shouldAddErrorsForOperationsAfterDischargeDate() {
 		// given:
 		LocalDateTime firstOperationDate = LocalDateTime.of(2020, 2, 4, 11, 0);
 		LocalDateTime secondOperationDate = LocalDateTime.of(2020, 2, 4, 11, 0);
@@ -138,7 +138,7 @@ public class OperationRowValidatorTest {
 		);
 
 		// then:
-		assertThat(result.size()).isEqualTo(2);
+		assertThat(result).hasSize(2);
 	}
 
 }

--- a/src/test/java/org/isf/admission/gui/ward/WardComboBoxInitializerTest.java
+++ b/src/test/java/org/isf/admission/gui/ward/WardComboBoxInitializerTest.java
@@ -5,7 +5,7 @@
  * Open Hospital is a free and open source software for healthcare data management.
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * it under the terms of the GNU General License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
@@ -14,9 +14,9 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU General License for more details.
  *
- * You should have received a copy of the GNU General Public License
+ * You should have received a copy of the GNU General License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.gui.ward;
@@ -36,19 +36,19 @@ import org.isf.ward.model.Ward;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class WardComboBoxInitializerTest {
+class WardComboBoxInitializerTest {
 
 	private WardBrowserManager wardBrowserManager;
 	private JComboBox wardComboBox;
 
 	@BeforeEach
-	public void setUp() {
+	void setUp() {
 		wardBrowserManager = new WardBrowserManagerStub();
 		wardComboBox = new JComboBox();
 	}
 
 	@Test
-	public void shouldSkipFemaleWardForMalePatient() throws OHServiceException {
+	void shouldSkipFemaleWardForMalePatient() throws OHServiceException {
 		// given:
 		Patient patient = new Patient();
 		patient.setSex('M');
@@ -72,7 +72,7 @@ public class WardComboBoxInitializerTest {
 	}
 
 	@Test
-	public void shouldSkipWardWithoutBeds() throws OHServiceException {
+	void shouldSkipWardWithoutBeds() throws OHServiceException {
 		// given:
 		Patient patient = new Patient();
 		patient.setSex('M');
@@ -97,7 +97,7 @@ public class WardComboBoxInitializerTest {
 	}
 
 	@Test
-	public void shouldSkipMaleWardForFemalePatient() throws OHServiceException {
+	void shouldSkipMaleWardForFemalePatient() throws OHServiceException {
 		// given:
 		Patient patient = new Patient();
 		patient.setSex('F');
@@ -121,7 +121,7 @@ public class WardComboBoxInitializerTest {
 	}
 
 	@Test
-	public void shouldSelectRecentlySavedWard() throws OHServiceException {
+	void shouldSelectRecentlySavedWard() throws OHServiceException {
 		// given:
 		Patient patient = new Patient();
 		patient.setSex('F');
@@ -144,7 +144,7 @@ public class WardComboBoxInitializerTest {
 	}
 
 	@Test
-	public void shouldSelectWardFromAdmissionWhenEditing() throws OHServiceException {
+	void shouldSelectWardFromAdmissionWhenEditing() throws OHServiceException {
 		// given:
 		Patient patient = new Patient();
 		patient.setSex('M');

--- a/src/test/java/org/isf/admission/gui/ward/WardComboBoxInitializerTest.java
+++ b/src/test/java/org/isf/admission/gui/ward/WardComboBoxInitializerTest.java
@@ -5,7 +5,7 @@
  * Open Hospital is a free and open source software for healthcare data management.
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General License as published by
+ * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
@@ -14,9 +14,9 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General License
+ * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.gui.ward;

--- a/src/test/java/org/isf/exa/gui/ExamFilterFactoryTest.java
+++ b/src/test/java/org/isf/exa/gui/ExamFilterFactoryTest.java
@@ -29,12 +29,12 @@ import javax.swing.RowFilter;
 
 import org.junit.jupiter.api.Test;
 
-public class ExamFilterFactoryTest {
+class ExamFilterFactoryTest {
 
 	private ExamFilterFactory examFilterFactory = new ExamFilterFactory();
 
 	@Test
-	public void shouldBuildFiltersForAllWordsProvided() {
+	void shouldBuildFiltersForAllWordsProvided() {
 		// given:
 		String text = "mkbewe mokebe testo";
 
@@ -42,11 +42,11 @@ public class ExamFilterFactoryTest {
 		List<RowFilter<Object, Object>> rowFilters = examFilterFactory.buildFilters(text);
 
 		// then
-		assertThat(rowFilters.size()).isEqualTo(3);
+		assertThat(rowFilters).hasSize(3);
 	}
 
 	@Test
-	public void shouldReturnEmptyForEmptyText() {
+	void shouldReturnEmptyForEmptyText() {
 		// given:
 		String text = "";
 
@@ -54,11 +54,11 @@ public class ExamFilterFactoryTest {
 		List<RowFilter<Object, Object>> rowFilters = examFilterFactory.buildFilters(text);
 
 		// then
-		assertThat(rowFilters.size()).isEqualTo(0);
+		assertThat(rowFilters).isEmpty();
 	}
 
 	@Test
-	public void shouldReturnEmptyForBadPattern() {
+	void shouldReturnEmptyForBadPattern() {
 		// given:
 		String text = "*hgf*";
 
@@ -66,7 +66,7 @@ public class ExamFilterFactoryTest {
 		List<RowFilter<Object, Object>> rowFilters = examFilterFactory.buildFilters(text);
 
 		// then
-		assertThat(rowFilters.size()).isEqualTo(0);
+		assertThat(rowFilters).isEmpty();
 	}
 
 }

--- a/src/test/java/org/isf/lab/gui/elements/ExamComboBoxTest.java
+++ b/src/test/java/org/isf/lab/gui/elements/ExamComboBoxTest.java
@@ -31,10 +31,10 @@ import org.isf.exa.model.Exam;
 import org.isf.lab.model.Laboratory;
 import org.junit.jupiter.api.Test;
 
-public class ExamComboBoxTest {
+class ExamComboBoxTest {
 
 	@Test
-	public void shouldCreateComboBoxWithPersistedExamsAndExamFromLaboratorySelected() {
+	void shouldCreateComboBoxWithPersistedExamsAndExamFromLaboratorySelected() {
 		// given:
 		Exam exam = TestExam.examWithCode("test");
 		Exam exam2 = TestExam.examWithCode("test2");
@@ -48,12 +48,11 @@ public class ExamComboBoxTest {
 
 		// then:
 		assertThat(examComboBox.getItemCount()).isEqualTo(3);
-		assertThat(selectedExam.isPresent()).isTrue();
-		assertThat(selectedExam.get()).isEqualTo(exam2);
+		assertThat(selectedExam).isPresent().contains(exam2);
 	}
 
 	@Test
-	public void shouldCreateComboBoxWithPersistedExamsAndNotSelectWhenInsertMode() {
+	void shouldCreateComboBoxWithPersistedExamsAndNotSelectWhenInsertMode() {
 		// given:
 		Exam exam = TestExam.examWithCode("test");
 		Exam exam2 = TestExam.examWithCode("test2");
@@ -67,7 +66,7 @@ public class ExamComboBoxTest {
 
 		// then:
 		assertThat(examComboBox.getItemCount()).isEqualTo(3);
-		assertThat(selectedExam.isPresent()).isFalse();
+		assertThat(selectedExam).isNotPresent();
 	}
 
 }

--- a/src/test/java/org/isf/lab/gui/elements/ExamRowComboBoxTest.java
+++ b/src/test/java/org/isf/lab/gui/elements/ExamRowComboBoxTest.java
@@ -29,10 +29,10 @@ import java.util.List;
 import org.isf.exa.model.ExamRow;
 import org.junit.jupiter.api.Test;
 
-public class ExamRowComboBoxTest {
+class ExamRowComboBoxTest {
 
 	@Test
-	public void shouldAddExamRowsWithDescriptionDifferentThanGivenString() {
+	void shouldAddExamRowsWithDescriptionDifferentThanGivenString() {
 		// given:
 		List<ExamRow> examRows = Arrays.asList(
 				TestExamRow.examRowWithDesc("test"),

--- a/src/test/java/org/isf/lab/gui/elements/ExamRowSubPanelTest.java
+++ b/src/test/java/org/isf/lab/gui/elements/ExamRowSubPanelTest.java
@@ -33,16 +33,16 @@ import org.isf.lab.model.LaboratoryRow;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ExamRowSubPanelTest {
+class ExamRowSubPanelTest {
 
 	@BeforeEach
-	public void setUp() {
+	void setUp() {
 		GeneralData.LANGUAGE = "en";
 		MessageBundle.initialize();
 	}
 
 	@Test
-	public void shouldCreateWithSelectedNResultWhenOnlyExamRowProvided() {
+	void shouldCreateWithSelectedNResultWhenOnlyExamRowProvided() {
 		// given:
 		ExamRow examRow = new ExamRow();
 
@@ -54,7 +54,7 @@ public class ExamRowSubPanelTest {
 	}
 
 	@Test
-	public void shouldCreateWithSelectedPResultWhenMatchesLaboratoryRow() {
+	void shouldCreateWithSelectedPResultWhenMatchesLaboratoryRow() {
 		// given:
 		ExamRow examRow = new ExamRow();
 		examRow.setDescription("test2");
@@ -71,7 +71,7 @@ public class ExamRowSubPanelTest {
 	}
 
 	@Test
-	public void shouldCreateWithSelectedNResultWhenNotMatchesLaboratoryRow() {
+	void shouldCreateWithSelectedNResultWhenNotMatchesLaboratoryRow() {
 		// given:
 		ExamRow examRow = new ExamRow();
 		examRow.setDescription("test2");

--- a/src/test/java/org/isf/lab/gui/elements/MatComboBoxTest.java
+++ b/src/test/java/org/isf/lab/gui/elements/MatComboBoxTest.java
@@ -30,10 +30,10 @@ import java.util.function.Function;
 import org.isf.lab.model.Laboratory;
 import org.junit.jupiter.api.Test;
 
-public class MatComboBoxTest {
+class MatComboBoxTest {
 
 	@Test
-	public void shouldCreateComboBoxWithMaterialsAndMaterialFromLaboratorySelected() {
+	void shouldCreateComboBoxWithMaterialsAndMaterialFromLaboratorySelected() {
 		// given:
 		List<String> materials = Arrays.asList("mat1translated", "mat2translated");
 		Laboratory laboratory = new Laboratory();
@@ -49,7 +49,7 @@ public class MatComboBoxTest {
 	}
 
 	@Test
-	public void shouldCreateComboBoxWithMaterialsAndNotSelectWhenInsertMode() {
+	void shouldCreateComboBoxWithMaterialsAndNotSelectWhenInsertMode() {
 		// given:
 		List<String> materials = Arrays.asList("mat1translated", "mat2translated");
 		Laboratory laboratory = new Laboratory();

--- a/src/test/java/org/isf/lab/gui/elements/PatientComboBoxTest.java
+++ b/src/test/java/org/isf/lab/gui/elements/PatientComboBoxTest.java
@@ -32,10 +32,10 @@ import org.isf.lab.model.Laboratory;
 import org.isf.patient.model.Patient;
 import org.junit.jupiter.api.Test;
 
-public class PatientComboBoxTest {
+class PatientComboBoxTest {
 
 	@Test
-	public void shouldCreateComboBoxWithPatientsAndPatientFromLaboratorySelected() {
+	void shouldCreateComboBoxWithPatientsAndPatientFromLaboratorySelected() {
 		// given:
 		Patient patient = TestPatient.patientWithCode(1);
 		Patient patient2 = TestPatient.patientWithCode(2);
@@ -49,12 +49,11 @@ public class PatientComboBoxTest {
 
 		// then:
 		assertThat(patientComboBox.getItemCount()).isEqualTo(3);
-		assertThat(selectedPatient.isPresent()).isTrue();
-		assertThat(selectedPatient.get()).isEqualTo(patient2);
+		assertThat(selectedPatient).isPresent().contains(patient2);
 	}
 
 	@Test
-	public void shouldCreateComboBoxWithPatientsAndNotSelectWhenInsertMode() {
+	void shouldCreateComboBoxWithPatientsAndNotSelectWhenInsertMode() {
 		// given:
 		Patient patient = TestPatient.patientWithCode(1);
 		Patient patient2 = TestPatient.patientWithCode(2);
@@ -68,7 +67,7 @@ public class PatientComboBoxTest {
 
 		// then:
 		assertThat(patientComboBox.getItemCount()).isEqualTo(3);
-		assertThat(selectedPatient.isPresent()).isFalse();
+		assertThat(selectedPatient).isNotPresent();
 		assertThat(patientComboBox.getSelectedItem()).isEqualTo(MessageBundle.getMessage("angal.lab.selectapatient"));
 	}
 

--- a/src/test/java/org/isf/utils/image/ImageUtilTest.java
+++ b/src/test/java/org/isf/utils/image/ImageUtilTest.java
@@ -33,10 +33,10 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @Disabled("Disabled until native libraries are available in CI build")
-public class ImageUtilTest {
+class ImageUtilTest {
 
 	@Test
-	public void testScaling() throws Exception {
+	void testScaling() throws Exception {
 		File file = new File(getClass().getResource("patient.jpg").getFile());
 		BufferedImage image = ImageIO.read(file);
 		int originalWidth = image.getWidth();


### PR DESCRIPTION
JUnit5 is more tolerant regarding the visibilities of Test classes than JUnit4, which required everything to be public.
In this context, JUnit5 test classes can have any visibility but private, however, it is recommended to use the default package visibility, which improves readability of code.

Also used more typical method (or more `geeky`) calls in many cases; for example, used `.hasSize()`