### PR TITLE
Chore: remove unused code

### DIFF
--- a/src/main/java/org/isf/admission/gui/PatientDataBrowser.java
+++ b/src/main/java/org/isf/admission/gui/PatientDataBrowser.java
@@ -68,8 +68,6 @@ import org.isf.utils.exception.gui.OHServiceExceptionUtil;
 import org.isf.utils.jobjects.MessageDialog;
 import org.isf.utils.jobjects.ModalJFrame;
 import org.isf.utils.table.TableSorter;
-import org.isf.ward.manager.WardBrowserManager;
-import org.isf.ward.model.Ward;
 
 /**
  * This class shows and allows to modify all patient data and all patient admissions.
@@ -199,7 +197,6 @@ public class PatientDataBrowser extends ModalJFrame implements
 	}
 
 	private OpdBrowserManager opdBrowserManager = Context.getApplicationContext().getBean(OpdBrowserManager.class);
-	private WardBrowserManager wardBrowserManager = Context.getApplicationContext().getBean(WardBrowserManager.class);
 	private AdmissionBrowserManager admissionBrowserManager = Context.getApplicationContext().getBean(AdmissionBrowserManager.class);
 	private DiseaseBrowserManager diseaseBrowserManager = Context.getApplicationContext().getBean(DiseaseBrowserManager.class);
 
@@ -399,11 +396,6 @@ class AdmissionBrowserModel extends DefaultTableModel {
 				admList = admissionBrowserManager.getAdmissions(patient);
 			} catch(OHServiceException e) {
 				OHServiceExceptionUtil.showMessages(e);
-			}
-			try {
-				List<Ward> ward = wardBrowserManager.getWards();
-			} catch(OHServiceException e) {
-                OHServiceExceptionUtil.showMessages(e);
 			}
 			try {
 				disease = diseaseBrowserManager.getDiseaseAll();


### PR DESCRIPTION
A previous PR moved the definition of `List<Ward> ward` from a class instance to a local variable.  With it being local it is now obvious that the variable `ward` is not used.   Looking at the git history, this piece of code has been this way since moving to github since 2015.   It is just not needed.