### PR TITLE
Chore: remove unused code and methods

### DIFF
--- a/src/main/java/org/isf/accounting/gui/BillBrowser.java
+++ b/src/main/java/org/isf/accounting/gui/BillBrowser.java
@@ -165,7 +165,6 @@ public class BillBrowser extends ModalJFrame implements PatientBillListener {
 	private JTextField jAffiliatePersonJTextField;
 	private JButton jButtonReport;
 	private JComboBox<String> jComboUsers;
-	private JTextField medicalJTextField;
 	private JMonthChooser jComboBoxMonths;
 	private JYearChooser jComboBoxYears;
 	private JPanel panelSupRange;
@@ -842,21 +841,10 @@ public class BillBrowser extends ModalJFrame implements PatientBillListener {
 		jAffiliatePersonJTextField.setText(patientParent != null ? patientParent.getName() : "");
 
 		if (patientParent != null) {
-			if (medicalJTextField != null) {
-				medicalJTextField.setText("");
-			}
 			updateDataSet(dateFrom, dateTo, patientParent);
 			updateTables();
 			updateTotals();
 		}
-	}
-
-	public Patient getPatientParent() {
-		return patientParent;
-	}
-
-	public void setPatientParent(Patient patientParent) {
-		this.patientParent = patientParent;
 	}
 
 	private JComboBox<String> getJComboUsers() {


### PR DESCRIPTION
The variable, `medicalJTextField` was previously used in a panel but the panel was removed leaving this variable defined, set, and never used.

The methods, `getPatientParent` and `setPatientParent` were never accessed.
