### PR TITLE
Chore: remove unused nested class

### DIFF
--- a/src/main/java/org/isf/utils/jobjects/Cropping.java
+++ b/src/main/java/org/isf/utils/jobjects/Cropping.java
@@ -178,43 +178,6 @@ public class Cropping extends JPanel {
 
 }
 
-class ClipMover extends MouseInputAdapter {
-
-	Cropping cropping;
-	Point offset;
-	boolean dragging;
-
-	public ClipMover(Cropping c) {
-		cropping = c;
-		offset = new Point();
-		dragging = false;
-	}
-
-	@Override
-	public void mousePressed(MouseEvent e) {
-		Point p = e.getPoint();
-		if (cropping.clip.contains(p)) {
-			offset.x = p.x - cropping.clip.x;
-			offset.y = p.y - cropping.clip.y;
-			dragging = true;
-		}
-	}
-
-	@Override
-	public void mouseReleased(MouseEvent e) {
-		dragging = false;
-	}
-
-	@Override
-	public void mouseDragged(MouseEvent e) {
-		if (dragging) {
-			int x = e.getX() - offset.x;
-			int y = e.getY() - offset.y;
-			cropping.setClip(x, y);
-		}
-	}
-}
-
 class ClipMoverAndResizer extends MouseInputAdapter {
 
 	Cropping cropping;


### PR DESCRIPTION
The nested class `ClipMover` is never referenced; remove from the code base.