### PR TITLE
Chore: code cleanup and remove unused methods

### DIFF
--- a/src/main/java/org/isf/lab/gui/ExamPicker.java
+++ b/src/main/java/org/isf/lab/gui/ExamPicker.java
@@ -22,6 +22,7 @@
 package org.isf.lab.gui;
 
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -36,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.DefaultListSelectionModel;
+import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
@@ -84,9 +86,9 @@ public class ExamPicker extends JPanel {
 		JPanel jPanel3 = new JPanel();
 		JPanel jPanel1 = new JPanel();
 
-		jPanel3.setBackground(new java.awt.Color(240, 240, 240));
+		jPanel3.setBackground(new Color(240, 240, 240));
 
-		jPanel1.setBackground(new java.awt.Color(240, 240, 240));
+		jPanel1.setBackground(new Color(240, 240, 240));
 
 		setLayout(new BorderLayout(10, 10));
 		add(jPanel1, BorderLayout.CENTER);
@@ -97,7 +99,7 @@ public class ExamPicker extends JPanel {
 		gblPanel1.rowWeights = new double[] { 1.0, Double.MIN_VALUE };
 		jPanel1.setLayout(gblPanel1);
 		JScrollPane jScrollPane1 = new JScrollPane();
-		jTableData = new javax.swing.JTable();
+		jTableData = new JTable();
 
 		jTableData.setSelectionModel(new DefaultListSelectionModel() {
 
@@ -144,7 +146,7 @@ public class ExamPicker extends JPanel {
 		jTableData.setModel(model);
 		jTableData.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
 		jTableData.setShowVerticalLines(false);
-		jTableData.addMouseListener(new java.awt.event.MouseAdapter() {
+		jTableData.addMouseListener(new MouseAdapter() {
 
 			@Override
 			public void mouseClicked(MouseEvent mouseEvent) {
@@ -186,14 +188,14 @@ public class ExamPicker extends JPanel {
 		jPanel3.setLayout(gblPanel3);
 
 		JLabel jLabelImage = new JLabel(MessageBundle.getMessage("angal.exams.find"));
-		jLabelImage.setIcon(new javax.swing.ImageIcon("rsc/icons/operation_dialog.png"));
+		jLabelImage.setIcon(new ImageIcon("rsc/icons/operation_dialog.png"));
 		GridBagConstraints gbcLabelImage = new GridBagConstraints();
 		gbcLabelImage.anchor = GridBagConstraints.WEST;
 		gbcLabelImage.insets = new Insets(0, 15, 0, 5);
 		gbcLabelImage.gridx = 0;
 		gbcLabelImage.gridy = 0;
 		jPanel3.add(jLabelImage, gbcLabelImage);
-		jTextFieldFind = new javax.swing.JTextField();
+		jTextFieldFind = new JTextField();
 
 		jTextFieldFind.getDocument().addDocumentListener(new DocumentListener() {
 
@@ -267,11 +269,11 @@ public class ExamPicker extends JPanel {
 		});
 
 		JPanel jPanel2 = new JPanel();
-		jPanel2.setBackground(new java.awt.Color(240, 240, 240));
+		jPanel2.setBackground(new Color(240, 240, 240));
 
 		JButton jButtonSelect = new JButton(MessageBundle.getMessage("angal.common.select.btn"));
 		jButtonSelect.setMnemonic(MessageBundle.getMnemonic("angal.common.select.btn.key"));
-		jButtonSelect.addMouseListener(new java.awt.event.MouseAdapter() {
+		jButtonSelect.addMouseListener(new MouseAdapter() {
 
 			@Override
 			public void mouseClicked(MouseEvent mouseEvent) {
@@ -282,7 +284,7 @@ public class ExamPicker extends JPanel {
 
 		JButton jButtonCancel = new JButton(MessageBundle.getMessage("angal.common.cancel.btn"));
 		jButtonCancel.setMnemonic(MessageBundle.getMnemonic("angal.common.cancel.btn.key"));
-		jButtonCancel.addMouseListener(new java.awt.event.MouseAdapter() {
+		jButtonCancel.addMouseListener(new MouseAdapter() {
 
 			@Override
 			public void mouseClicked(MouseEvent mouseEvent) {
@@ -301,19 +303,16 @@ public class ExamPicker extends JPanel {
 	}
 
 	private void validateSelection() {
-		this.setSelectedRow(this.jTableData.getSelectedRow());
 		this.setVisible(false);
 		this.getParentFrame().dispose();
 	}
 
 	private void jButtonSelectActionPerformed(ActionEvent actionEvent) {
-		this.setSelectedRow(this.jTableData.getSelectedRow());
 		this.setVisible(false);
 		this.getParentFrame().dispose();
 	}
 
 	private void jButtonSelectMouseClicked(MouseEvent mouseEvent) {
-		this.setSelectedRow(this.jTableData.getSelectedRow());
 		this.setVisible(false);
 		this.getParentFrame().dispose();
 	}
@@ -321,17 +320,6 @@ public class ExamPicker extends JPanel {
 	private void jButtonQuitMouseClicked(MouseEvent mouseEvent) {
 		this.setVisible(false);
 		this.getParentFrame().dispose();
-	}
-
-	private int selectedRow = -1;
-
-	private int getSelectedRow() {
-		return selectedRow;
-	}
-
-	public Object getSelectedObject() {
-		OhTableModelExam<?> model = (OhTableModelExam<?>) jTableData.getModel();
-		return model.getObjectAt(this.getSelectedRow());
 	}
 
 	public List<Exam> getAllSelectedObject() {
@@ -343,10 +331,6 @@ public class ExamPicker extends JPanel {
 			exams.add(model.getObjectAt(row));
 		}
 		return exams;
-	}
-
-	private void setSelectedRow(int selectedRow) {
-		this.selectedRow = selectedRow;
 	}
 
 	private JDialog parentFrame;


### PR DESCRIPTION
First the method, `getSelectedObject()` is never called from any code.   Removing that method means the private method, `getSelectedRow()` is never referenced.  Removing that method means the method, `setSelectedRow()` is not needed as there isn't a way to reference the private variable,  `selectedRow` except by name which isn't done.   

Also removed fully qualified package names in the body of the code.