### PR TITLE
Chore: remove unnecessary fully qualified name

### DIFF
--- a/src/main/java/org/isf/admission/gui/AdmissionBrowser.java
+++ b/src/main/java/org/isf/admission/gui/AdmissionBrowser.java
@@ -94,7 +94,6 @@ import org.isf.menu.manager.Context;
 import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.operation.gui.OperationRowAdm;
 import org.isf.patient.gui.PatientSummary;
-import org.isf.patient.manager.PatientBrowserManager;
 import org.isf.patient.model.Patient;
 import org.isf.pregtreattype.manager.PregnantTreatmentTypeBrowserManager;
 import org.isf.pregtreattype.model.PregnantTreatmentType;
@@ -505,8 +504,8 @@ public class AdmissionBrowser extends ModalJFrame {
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getDataPanel(), java.awt.BorderLayout.CENTER);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getDataPanel(), BorderLayout.CENTER);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}
@@ -514,8 +513,8 @@ public class AdmissionBrowser extends ModalJFrame {
 	private JPanel getDataPanel() {
 		JPanel data = new JPanel();
 		data.setLayout(new BorderLayout());
-		data.add(getPatientDataPanel(), java.awt.BorderLayout.WEST);
-		data.add(getJTabbedPaneAdmission(), java.awt.BorderLayout.CENTER);
+		data.add(getPatientDataPanel(), BorderLayout.WEST);
+		data.add(getJTabbedPaneAdmission(), BorderLayout.CENTER);
 		return data;
 	}
 
@@ -923,7 +922,7 @@ public class AdmissionBrowser extends ModalJFrame {
 				if (wardBox.getSelectedIndex() <= 0) {
 					yProgTextField.setText("");
 					// This fixes the problem of losing the top border on the date picker because of the combox
-					javax.swing.SwingUtilities.invokeLater(() -> {
+					SwingUtilities.invokeLater(() -> {
 						validate();
 						repaint();
 					});
@@ -977,7 +976,7 @@ public class AdmissionBrowser extends ModalJFrame {
 					}
 				}
 				// This fixes the problem of losing the top border on the date picker because of the combox
-				javax.swing.SwingUtilities.invokeLater(() -> {
+				SwingUtilities.invokeLater(() -> {
 					validate();
 					repaint();
 				});

--- a/src/main/java/org/isf/admission/gui/AdmittedPatientBrowser.java
+++ b/src/main/java/org/isf/admission/gui/AdmittedPatientBrowser.java
@@ -57,6 +57,7 @@ import javax.swing.LayoutStyle.ComponentPlacement;
 import javax.swing.SwingUtilities;
 import javax.swing.Timer;
 import javax.swing.WindowConstants;
+import javax.swing.border.Border;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
 
@@ -1171,7 +1172,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 	}
 
 	private JPanel setMyBorder(JPanel c, String title) {
-		javax.swing.border.Border b2 = BorderFactory.createCompoundBorder(BorderFactory.createTitledBorder(title), BorderFactory.createEmptyBorder(0, 0, 0, 0));
+		Border b2 = BorderFactory.createCompoundBorder(BorderFactory.createTitledBorder(title), BorderFactory.createEmptyBorder(0, 0, 0, 0));
 		c.setBorder(b2);
 		return c;
 	}

--- a/src/main/java/org/isf/admission/gui/PatientDataBrowser.java
+++ b/src/main/java/org/isf/admission/gui/PatientDataBrowser.java
@@ -173,8 +173,8 @@ public class PatientDataBrowser extends ModalJFrame implements
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getPatientDataPanel(), java.awt.BorderLayout.NORTH);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getPatientDataPanel(), BorderLayout.NORTH);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/admission/gui/PatientFolderBrowser.java
+++ b/src/main/java/org/isf/admission/gui/PatientFolderBrowser.java
@@ -182,8 +182,8 @@ public class PatientFolderBrowser extends ModalJFrame
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getPatientDataPanel(), java.awt.BorderLayout.NORTH);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getPatientDataPanel(), BorderLayout.NORTH);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/admission/gui/PatientFolderReportModal.java
+++ b/src/main/java/org/isf/admission/gui/PatientFolderReportModal.java
@@ -26,10 +26,12 @@ import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JFrame;
@@ -171,7 +173,7 @@ public class PatientFolderReportModal extends ModalJFrame {
 			launchReportButton.setMnemonic(MessageBundle.getMnemonic("angal.common.launchreport.btn.key"));
 			launchReportButton.addActionListener(new ActionListener() {
 				@Override
-				public void actionPerformed(java.awt.event.ActionEvent e) {
+				public void actionPerformed(ActionEvent e) {
 					new GenericReportPatientVersion2(patId, getParameterString(), getDateFromValue(), getDateToValue(), GeneralData.PATIENTSHEET);
 				}
 				
@@ -221,7 +223,7 @@ public class PatientFolderReportModal extends ModalJFrame {
 		if (choosePanel == null) {
 
 			choosePanel = new JPanel();
-			choosePanel.setLayout(new javax.swing.BoxLayout(choosePanel, javax.swing.BoxLayout.Y_AXIS));
+			choosePanel.setLayout(new BoxLayout(choosePanel, BoxLayout.Y_AXIS));
 			
 			choosePanel.add(getPanelLabel());
 			choosePanel.add(getPanelAll());

--- a/src/main/java/org/isf/admtype/gui/AdmissionTypeBrowser.java
+++ b/src/main/java/org/isf/admtype/gui/AdmissionTypeBrowser.java
@@ -91,8 +91,8 @@ public class AdmissionTypeBrowser extends ModalJFrame implements LaboratoryTypeL
 		if (jContainPanel == null) {
 			jContainPanel = new JPanel();
 			jContainPanel.setLayout(new BorderLayout());
-			jContainPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
-			jContainPanel.add(new JScrollPane(getJTable()), java.awt.BorderLayout.CENTER);
+			jContainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
+			jContainPanel.add(new JScrollPane(getJTable()), BorderLayout.CENTER);
 			validate();
 		}
 		return jContainPanel;

--- a/src/main/java/org/isf/admtype/gui/AdmissionTypeBrowserEdit.java
+++ b/src/main/java/org/isf/admtype/gui/AdmissionTypeBrowserEdit.java
@@ -137,8 +137,8 @@ public class AdmissionTypeBrowserEdit extends JDialog {
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getDataPanel(), java.awt.BorderLayout.NORTH);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getDataPanel(), BorderLayout.NORTH);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/agetype/gui/AgeTypeBrowser.java
+++ b/src/main/java/org/isf/agetype/gui/AgeTypeBrowser.java
@@ -87,7 +87,7 @@ public class AgeTypeBrowser extends ModalJFrame {
 		if (jContainPanel == null) {
 			jContainPanel = new JPanel();
 			jContainPanel.setLayout(new BorderLayout());
-			jContainPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
 			jContainPanel.add(getJTable(), BorderLayout.CENTER);
 			validate();
 		}

--- a/src/main/java/org/isf/dicom/gui/FileDicomFilter.java
+++ b/src/main/java/org/isf/dicom/gui/FileDicomFilter.java
@@ -23,6 +23,7 @@ package org.isf.dicom.gui;
 
 import java.io.File;
 
+import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileView;
 
 /**
@@ -31,7 +32,7 @@ import javax.swing.filechooser.FileView;
  * @author Pietro Castellucci
  * @version 1.0.0
  */
-public class FileDicomFilter extends javax.swing.filechooser.FileFilter {
+public class FileDicomFilter extends FileFilter {
 
 	/**
 	 * Whether the given file is accepted by this filter.

--- a/src/main/java/org/isf/dicom/gui/FileJPEGFilter.java
+++ b/src/main/java/org/isf/dicom/gui/FileJPEGFilter.java
@@ -23,6 +23,7 @@ package org.isf.dicom.gui;
 
 import java.io.File;
 
+import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileView;
 
 /**
@@ -31,9 +32,7 @@ import javax.swing.filechooser.FileView;
  * @author Pietro Castellucci
  * @version 1.0.0
  */
-public class FileJPEGFilter
-        extends javax.swing.filechooser.FileFilter
-{
+public class FileJPEGFilter extends FileFilter {
 
 	/**
 	 * Whether the given file is accepted by this filter.

--- a/src/main/java/org/isf/dicomtype/gui/DicomTypeBrowser.java
+++ b/src/main/java/org/isf/dicomtype/gui/DicomTypeBrowser.java
@@ -102,9 +102,8 @@ public class DicomTypeBrowser extends ModalJFrame implements DicomTypeListener {
 		if (jContainPanel == null) {
 			jContainPanel = new JPanel();
 			jContainPanel.setLayout(new BorderLayout());
-			jContainPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
-			jContainPanel.add(new JScrollPane(getJTable()),
-					java.awt.BorderLayout.CENTER);
+			jContainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
+			jContainPanel.add(new JScrollPane(getJTable()), BorderLayout.CENTER);
 			validate();
 		}
 		return jContainPanel;

--- a/src/main/java/org/isf/dicomtype/gui/DicomTypeEdit.java
+++ b/src/main/java/org/isf/dicomtype/gui/DicomTypeEdit.java
@@ -138,8 +138,8 @@ public class DicomTypeEdit extends JDialog {
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getDataPanel(), java.awt.BorderLayout.NORTH);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getDataPanel(), BorderLayout.NORTH);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/disctype/gui/DischargeTypeBrowser.java
+++ b/src/main/java/org/isf/disctype/gui/DischargeTypeBrowser.java
@@ -91,8 +91,8 @@ public class DischargeTypeBrowser extends ModalJFrame implements DischargeTypeLi
 		if (jContainPanel == null) {
 			jContainPanel = new JPanel();
 			jContainPanel.setLayout(new BorderLayout());
-			jContainPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
-			jContainPanel.add(new JScrollPane(getJTable()), java.awt.BorderLayout.CENTER);
+			jContainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
+			jContainPanel.add(new JScrollPane(getJTable()), BorderLayout.CENTER);
 			validate();
 		}
 		return jContainPanel;

--- a/src/main/java/org/isf/disctype/gui/DischargeTypeBrowserEdit.java
+++ b/src/main/java/org/isf/disctype/gui/DischargeTypeBrowserEdit.java
@@ -139,8 +139,8 @@ public class DischargeTypeBrowserEdit extends JDialog {
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getDataPanel(), java.awt.BorderLayout.NORTH);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getDataPanel(), BorderLayout.NORTH);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/disease/gui/DiseaseEdit.java
+++ b/src/main/java/org/isf/disease/gui/DiseaseEdit.java
@@ -159,8 +159,8 @@ public class DiseaseEdit extends JDialog {
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getDataPanel(), java.awt.BorderLayout.CENTER);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getDataPanel(), BorderLayout.CENTER);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/distype/gui/DiseaseTypeBrowser.java
+++ b/src/main/java/org/isf/distype/gui/DiseaseTypeBrowser.java
@@ -90,8 +90,8 @@ public class DiseaseTypeBrowser extends ModalJFrame implements DiseaseTypeListen
 		if (jContainPanel == null) {
 			jContainPanel = new JPanel();
 			jContainPanel.setLayout(new BorderLayout());
-			jContainPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
-			jContainPanel.add(new JScrollPane(getJTable()), java.awt.BorderLayout.CENTER);
+			jContainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
+			jContainPanel.add(new JScrollPane(getJTable()), BorderLayout.CENTER);
 			validate();
 		}
 		return jContainPanel;

--- a/src/main/java/org/isf/distype/gui/DiseaseTypeBrowserEdit.java
+++ b/src/main/java/org/isf/distype/gui/DiseaseTypeBrowserEdit.java
@@ -137,8 +137,8 @@ public class DiseaseTypeBrowserEdit extends JDialog {
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getDataPanel(), java.awt.BorderLayout.NORTH);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getDataPanel(), BorderLayout.NORTH);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/dlvrrestype/gui/DeliveryResultTypeBrowser.java
+++ b/src/main/java/org/isf/dlvrrestype/gui/DeliveryResultTypeBrowser.java
@@ -92,8 +92,8 @@ public class DeliveryResultTypeBrowser extends ModalJFrame implements DeliveryRe
 	private JPanel getJContainPanel() {
 		if (jContainPanel == null) {
 			jContainPanel = new JPanel(new BorderLayout());
-			jContainPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
-			jContainPanel.add(new JScrollPane(getJTable()), java.awt.BorderLayout.CENTER);
+			jContainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
+			jContainPanel.add(new JScrollPane(getJTable()), BorderLayout.CENTER);
 			validate();
 		}
 		return jContainPanel;

--- a/src/main/java/org/isf/dlvrrestype/gui/DeliveryResultTypeBrowserEdit.java
+++ b/src/main/java/org/isf/dlvrrestype/gui/DeliveryResultTypeBrowserEdit.java
@@ -139,8 +139,8 @@ public class DeliveryResultTypeBrowserEdit extends JDialog {
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getDataPanel(), java.awt.BorderLayout.NORTH);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getDataPanel(), BorderLayout.NORTH);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/dlvrtype/gui/DeliveryTypeBrowser.java
+++ b/src/main/java/org/isf/dlvrtype/gui/DeliveryTypeBrowser.java
@@ -91,8 +91,8 @@ public class DeliveryTypeBrowser extends ModalJFrame implements DeliveryTypeList
 		if (jContainPanel == null) {
 			jContainPanel = new JPanel();
 			jContainPanel.setLayout(new BorderLayout());
-			jContainPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
-			jContainPanel.add(new JScrollPane(getJTable()),	java.awt.BorderLayout.CENTER);
+			jContainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
+			jContainPanel.add(new JScrollPane(getJTable()),	BorderLayout.CENTER);
 			validate();
 		}
 		return jContainPanel;

--- a/src/main/java/org/isf/dlvrtype/gui/DeliveryTypeBrowserEdit.java
+++ b/src/main/java/org/isf/dlvrtype/gui/DeliveryTypeBrowserEdit.java
@@ -139,8 +139,8 @@ public class DeliveryTypeBrowserEdit extends JDialog {
         if (jContentPane == null) {
             jContentPane = new JPanel();
             jContentPane.setLayout(new BorderLayout());
-            jContentPane.add(getDataPanel(), java.awt.BorderLayout.NORTH);
-            jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+            jContentPane.add(getDataPanel(), BorderLayout.NORTH);
+            jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
         }
         return jContentPane;
     }

--- a/src/main/java/org/isf/exatype/gui/ExamTypeBrowser.java
+++ b/src/main/java/org/isf/exatype/gui/ExamTypeBrowser.java
@@ -98,8 +98,8 @@ public class ExamTypeBrowser extends ModalJFrame implements ExamTypeListener {
 		if (jContainPanel == null) {
 			jContainPanel = new JPanel();
 			jContainPanel.setLayout(new BorderLayout());
-			jContainPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
-			jContainPanel.add(new JScrollPane(getJTable()), java.awt.BorderLayout.CENTER);
+			jContainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
+			jContainPanel.add(new JScrollPane(getJTable()), BorderLayout.CENTER);
 			validate();
 		}
 		return jContainPanel;

--- a/src/main/java/org/isf/exatype/gui/ExamTypeEdit.java
+++ b/src/main/java/org/isf/exatype/gui/ExamTypeEdit.java
@@ -147,8 +147,8 @@ public class ExamTypeEdit extends JDialog {
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getDataPanel(), java.awt.BorderLayout.NORTH);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getDataPanel(), BorderLayout.NORTH);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/hospital/gui/HospitalBrowser.java
+++ b/src/main/java/org/isf/hospital/gui/HospitalBrowser.java
@@ -97,8 +97,8 @@ public class HospitalBrowser extends ModalJFrame {
 	private JPanel getJContainPanel() {
 		if (jContainPanel == null) {
 			jContainPanel = new JPanel(new BorderLayout());
-			jContainPanel.add(getJDataPanel(), java.awt.BorderLayout.CENTER);
-			jContainPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContainPanel.add(getJDataPanel(), BorderLayout.CENTER);
+			jContainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContainPanel;
 	}

--- a/src/main/java/org/isf/medicals/gui/MedicalEdit.java
+++ b/src/main/java/org/isf/medicals/gui/MedicalEdit.java
@@ -23,6 +23,8 @@ package org.isf.medicals.gui;
 
 import java.awt.AWTEvent;
 import java.awt.BorderLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.util.EventListener;
 import java.util.List;
 
@@ -164,8 +166,8 @@ public class MedicalEdit extends JDialog {
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getDataPanel(), java.awt.BorderLayout.CENTER);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getDataPanel(), BorderLayout.CENTER);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}
@@ -237,9 +239,9 @@ public class MedicalEdit extends JDialog {
 		if (okButton == null) {
 			okButton = new JButton(MessageBundle.getMessage("angal.common.ok.btn"));
 			okButton.setMnemonic(MessageBundle.getMnemonic("angal.common.ok.btn.key"));
-			okButton.addActionListener(new java.awt.event.ActionListener() {
+			okButton.addActionListener(new ActionListener() {
 				@Override
-				public void actionPerformed(java.awt.event.ActionEvent e) {
+				public void actionPerformed(ActionEvent e) {
 					boolean result = false;
 					if (insert) { // inserting
 						Medical newMedical = null;

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacyNew.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacyNew.java
@@ -840,7 +840,7 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 			}
 			wardBox.addItem("");
 			if (wardList != null) {
-				for (org.isf.ward.model.Ward elem : wardList) {
+				for (Ward elem : wardList) {
 					if (!wardSelected.getCode().equals(elem.getCode())) {
 						wardBox.addItem(elem);
 					}

--- a/src/main/java/org/isf/medstockmovtype/gui/MedicalDsrStockMovementTypeBrowser.java
+++ b/src/main/java/org/isf/medstockmovtype/gui/MedicalDsrStockMovementTypeBrowser.java
@@ -93,8 +93,8 @@ public class MedicalDsrStockMovementTypeBrowser extends ModalJFrame implements M
 		if (jContainPanel == null) {
 			jContainPanel = new JPanel();
 			jContainPanel.setLayout(new BorderLayout());
-			jContainPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
-			jContainPanel.add(new JScrollPane(getJTable()), java.awt.BorderLayout.CENTER);
+			jContainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
+			jContainPanel.add(new JScrollPane(getJTable()), BorderLayout.CENTER);
 			validate();
 		}
 		return jContainPanel;

--- a/src/main/java/org/isf/medstockmovtype/gui/MedicalDsrStockMovementTypeBrowserEdit.java
+++ b/src/main/java/org/isf/medstockmovtype/gui/MedicalDsrStockMovementTypeBrowserEdit.java
@@ -140,8 +140,8 @@ public class MedicalDsrStockMovementTypeBrowserEdit extends JDialog {
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getDataPanel(), java.awt.BorderLayout.NORTH);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getDataPanel(), BorderLayout.NORTH);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/medtype/gui/MedicalTypeBrowser.java
+++ b/src/main/java/org/isf/medtype/gui/MedicalTypeBrowser.java
@@ -91,8 +91,8 @@ public class MedicalTypeBrowser extends ModalJFrame implements MedicalTypeListen
 		if (jContainPanel == null) {
 			jContainPanel = new JPanel();
 			jContainPanel.setLayout(new BorderLayout());
-			jContainPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
-			jContainPanel.add(new JScrollPane(getJTable()), java.awt.BorderLayout.CENTER);
+			jContainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
+			jContainPanel.add(new JScrollPane(getJTable()), BorderLayout.CENTER);
 			validate();
 		}
 		return jContainPanel;

--- a/src/main/java/org/isf/menu/gui/Menu.java
+++ b/src/main/java/org/isf/menu/gui/Menu.java
@@ -27,6 +27,7 @@ import java.util.Scanner;
 import java.util.regex.Pattern;
 
 import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
 
 import org.isf.generaldata.Version;
 import org.isf.menu.manager.Context;
@@ -112,6 +113,6 @@ public class Menu {
 			System.exit(1);
 		}
 		Context.setApplicationContext(context);
-		javax.swing.SwingUtilities.invokeLater(() -> createAndShowGUI());
+		SwingUtilities.invokeLater(() -> createAndShowGUI());
 	}
 }

--- a/src/main/java/org/isf/menu/gui/SplashWindow3.java
+++ b/src/main/java/org/isf/menu/gui/SplashWindow3.java
@@ -55,7 +55,7 @@ class SplashWindow3 extends JWindow {
 		getContentPane().add(l, BorderLayout.CENTER);
 		pack();
 
-		Toolkit kit = java.awt.Toolkit.getDefaultToolkit();
+		Toolkit kit = Toolkit.getDefaultToolkit();
 		Dimension screenSize = kit.getScreenSize();
 
 		Dimension labelSize = l.getPreferredSize();

--- a/src/main/java/org/isf/opd/gui/OpdBrowser.java
+++ b/src/main/java/org/isf/opd/gui/OpdBrowser.java
@@ -295,9 +295,9 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 		if (jContainPanel == null) {
 			jContainPanel = new JPanel();
 			jContainPanel.setLayout(new BorderLayout());
-			jContainPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
-			jContainPanel.add(getJSelectionPanel(), java.awt.BorderLayout.WEST);
-			jContainPanel.add(new JScrollPane(getJTable()),	java.awt.BorderLayout.CENTER);
+			jContainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
+			jContainPanel.add(getJSelectionPanel(), BorderLayout.WEST);
+			jContainPanel.add(new JScrollPane(getJTable()),	BorderLayout.CENTER);
 			validate();
 		}
 		return jContainPanel;

--- a/src/main/java/org/isf/opd/gui/OpdEdit.java
+++ b/src/main/java/org/isf/opd/gui/OpdEdit.java
@@ -49,6 +49,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JTextField;
+import javax.swing.border.Border;
 import javax.swing.event.EventListenerList;
 
 import org.isf.disease.manager.DiseaseBrowserManager;
@@ -223,8 +224,8 @@ public class OpdEdit extends JDialog {
 		if (principalPanel == null) {
 			principalPanel = new JPanel();
 			principalPanel.setLayout(new BorderLayout());
-			principalPanel.add(getInsertPanel(), java.awt.BorderLayout.NORTH);
-			principalPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
+			principalPanel.add(getInsertPanel(), BorderLayout.NORTH);
+			principalPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
 		}
 		return principalPanel;
 	}
@@ -930,7 +931,7 @@ public class OpdEdit extends JDialog {
 	 * Set a specific border+title to a panel
 	 */
 	private JPanel setMyBorder(JPanel c, String title) {
-		javax.swing.border.Border b2 = BorderFactory.createCompoundBorder(
+		Border b2 = BorderFactory.createCompoundBorder(
 				BorderFactory.createTitledBorder(title), BorderFactory
 						.createEmptyBorder(0, 0, 0, 0));
 		c.setBorder(b2);

--- a/src/main/java/org/isf/opd/gui/OpdEditExtended.java
+++ b/src/main/java/org/isf/opd/gui/OpdEditExtended.java
@@ -69,6 +69,7 @@ import javax.swing.JTextField;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingConstants;
 import javax.swing.WindowConstants;
+import javax.swing.border.Border;
 import javax.swing.border.MatteBorder;
 import javax.swing.border.TitledBorder;
 import javax.swing.event.EventListenerList;
@@ -1953,7 +1954,7 @@ public class OpdEditExtended extends ModalJFrame implements PatientInsertExtende
 	 * Set a specific border+title to a panel
 	 */
 	private JPanel setMyBorder(JPanel c, String title) {
-		javax.swing.border.Border b2 = BorderFactory.createCompoundBorder(
+		Border b2 = BorderFactory.createCompoundBorder(
 				BorderFactory.createTitledBorder(title), BorderFactory
 						.createEmptyBorder(0, 0, 0, 0));
 		c.setBorder(b2);

--- a/src/main/java/org/isf/operation/gui/OperationEdit.java
+++ b/src/main/java/org/isf/operation/gui/OperationEdit.java
@@ -158,8 +158,8 @@ public class OperationEdit extends JDialog {
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getDataPanel(), java.awt.BorderLayout.NORTH);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getDataPanel(), BorderLayout.NORTH);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/operation/gui/OperationRowBase.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowBase.java
@@ -55,6 +55,7 @@ import org.isf.menu.manager.Context;
 import org.isf.operation.manager.OperationBrowserManager;
 import org.isf.operation.manager.OperationRowBrowserManager;
 import org.isf.operation.model.Operation;
+import org.isf.operation.model.OperationRow;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.gui.OHServiceExceptionUtil;
 import org.isf.utils.jobjects.GoodDateTimeSpinnerChooser;
@@ -87,8 +88,8 @@ abstract class OperationRowBase extends JPanel {
 	protected OperationBrowserManager operationBrowserManager = Context.getApplicationContext().getBean(OperationBrowserManager.class);
 	protected OperationRowBrowserManager operationRowBrowserManager = Context.getApplicationContext().getBean(OperationRowBrowserManager.class);
 
-	protected OhTableOperationModel<org.isf.operation.model.OperationRow> modelOhOpeRow;
-	protected List<org.isf.operation.model.OperationRow> oprowData = new ArrayList<>();
+	protected OhTableOperationModel<OperationRow> modelOhOpeRow;
+	protected List<OperationRow> oprowData = new ArrayList<>();
 
 	protected List<String> operationResults = operationBrowserManager.getResultDescriptionList();
 	protected OhDefaultCellRenderer cellRenderer = new OhDefaultCellRenderer();
@@ -399,7 +400,7 @@ abstract class OperationRowBase extends JPanel {
 	abstract List<Operation> getOperationCollection() throws OHServiceException;
 
 	public void addToForm() {
-		org.isf.operation.model.OperationRow opeRow = oprowData.get(tableData.getSelectedRow());
+		OperationRow opeRow = oprowData.get(tableData.getSelectedRow());
 		/* ** for combo operation **** */
 		List<Operation> opeList = new ArrayList<>();
 		try {
@@ -441,7 +442,7 @@ abstract class OperationRowBase extends JPanel {
 	}
 
 	public void deleteOpeRow(Component parentComponent, int idRow) {
-		org.isf.operation.model.OperationRow operationRow;
+		OperationRow operationRow;
 		if (idRow < 0) {
 			MessageDialog.error(parentComponent, "angal.common.pleaseselectarow.msg");
 		} else {
@@ -489,11 +490,11 @@ abstract class OperationRowBase extends JPanel {
 		comboOperation.setEnabled(true);
 	}
 
-	public List<org.isf.operation.model.OperationRow> getOprowData() {
+	public List<OperationRow> getOprowData() {
 		return oprowData;
 	}
 
-	public void setOprowData(List<org.isf.operation.model.OperationRow> oprowData) {
+	public void setOprowData(List<OperationRow> oprowData) {
 		this.oprowData = oprowData;
 	}
 

--- a/src/main/java/org/isf/opetype/gui/OperationTypeBrowser.java
+++ b/src/main/java/org/isf/opetype/gui/OperationTypeBrowser.java
@@ -93,8 +93,8 @@ public class OperationTypeBrowser extends ModalJFrame implements OperationTypeLi
 		if (jContainPanel == null) {
 			jContainPanel = new JPanel();
 			jContainPanel.setLayout(new BorderLayout());
-			jContainPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
-			jContainPanel.add(new JScrollPane(getJTable()),	java.awt.BorderLayout.CENTER);
+			jContainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
+			jContainPanel.add(new JScrollPane(getJTable()),	BorderLayout.CENTER);
 			validate();
 		}
 		return jContainPanel;

--- a/src/main/java/org/isf/opetype/gui/OperationTypeEdit.java
+++ b/src/main/java/org/isf/opetype/gui/OperationTypeEdit.java
@@ -139,8 +139,8 @@ public class OperationTypeEdit extends JDialog {
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getDataPanel(), java.awt.BorderLayout.NORTH);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getDataPanel(), BorderLayout.NORTH);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/patient/gui/PatientBrowser.java
+++ b/src/main/java/org/isf/patient/gui/PatientBrowser.java
@@ -137,9 +137,8 @@ public class PatientBrowser extends ModalJFrame implements PatientListener {
 		if (jContainPanel == null) {
 			jContainPanel = new JPanel();
 			jContainPanel.setLayout(new BorderLayout());
-			jContainPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
-			jContainPanel.add(new JScrollPane(getJTable()),
-					java.awt.BorderLayout.CENTER);
+			jContainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
+			jContainPanel.add(new JScrollPane(getJTable()), BorderLayout.CENTER);
 			validate();
 		}
 		return jContainPanel;

--- a/src/main/java/org/isf/patient/gui/PatientInsert.java
+++ b/src/main/java/org/isf/patient/gui/PatientInsert.java
@@ -46,6 +46,8 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.ScrollPaneConstants;
+import javax.swing.border.Border;
+import javax.swing.border.TitledBorder;
 import javax.swing.event.EventListenerList;
 
 import org.isf.generaldata.MessageBundle;
@@ -197,8 +199,8 @@ public class PatientInsert extends JDialog implements ActionListener {
 		if (jContainPanel == null) {
 			jContainPanel = new JPanel();
 			jContainPanel.setLayout(new BorderLayout());
-			jContainPanel.add(getJDataPanel(), java.awt.BorderLayout.NORTH);
-			jContainPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContainPanel.add(getJDataPanel(), BorderLayout.NORTH);
+			jContainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContainPanel;
 	}
@@ -753,7 +755,7 @@ public class PatientInsert extends JDialog implements ActionListener {
 			jFirstName = new JPanel();
 			jFirstName.setLayout(new BorderLayout());
 			jFirstName.add(getJFirstNamePanel(), BorderLayout.WEST);
-			jFirstName.add(getJPanel1(), java.awt.BorderLayout.EAST);
+			jFirstName.add(getJPanel1(), BorderLayout.EAST);
 		}
 		return jFirstName;
 	}
@@ -780,8 +782,8 @@ public class PatientInsert extends JDialog implements ActionListener {
 		if (jSecondName == null) {
 			jSecondName = new JPanel();
 			jSecondName.setLayout(new BorderLayout());
-			jSecondName.add(getJSecondNamePanel(), java.awt.BorderLayout.WEST);
-			jSecondName.add(getJSecondNamePanel1(), java.awt.BorderLayout.EAST);
+			jSecondName.add(getJSecondNamePanel(), BorderLayout.WEST);
+			jSecondName.add(getJSecondNamePanel1(), BorderLayout.EAST);
 		}
 		return jSecondName;
 	}
@@ -795,8 +797,8 @@ public class PatientInsert extends JDialog implements ActionListener {
 		if (jAge == null) {
 			jAge = new JPanel();
 			jAge.setLayout(new BorderLayout());
-			jAge.add(getJAgePanel(), java.awt.BorderLayout.WEST);
-			jAge.add(getJAgePanel1(), java.awt.BorderLayout.EAST);
+			jAge.add(getJAgePanel(), BorderLayout.WEST);
+			jAge.add(getJAgePanel1(), BorderLayout.EAST);
 		}
 		return jAge;
 	}
@@ -862,8 +864,8 @@ public class PatientInsert extends JDialog implements ActionListener {
 		if (jAddress == null) {
 			jAddress = new JPanel();
 			jAddress.setLayout(new BorderLayout());
-			jAddress.add(getJAddressPanel(), java.awt.BorderLayout.WEST);
-			jAddress.add(getJPanel(), java.awt.BorderLayout.EAST);
+			jAddress.add(getJAddressPanel(), BorderLayout.WEST);
+			jAddress.add(getJPanel(), BorderLayout.EAST);
 			
 		}
 		return jAddress;
@@ -878,8 +880,8 @@ public class PatientInsert extends JDialog implements ActionListener {
 		if (jCity == null) {
 			jCity = new JPanel();
 			jCity.setLayout(new BorderLayout());
-			jCity.add(getJCityPanel(), java.awt.BorderLayout.WEST);
-			jCity.add(getJPanel2(), java.awt.BorderLayout.EAST);
+			jCity.add(getJCityPanel(), BorderLayout.WEST);
+			jCity.add(getJPanel2(), BorderLayout.EAST);
 		}
 		return jCity;
 	}
@@ -893,8 +895,8 @@ public class PatientInsert extends JDialog implements ActionListener {
 		if (jNextKin == null) {
 			jNextKin = new JPanel();
 			jNextKin.setLayout(new BorderLayout());
-			jNextKin.add(getJNextKinPanel(), java.awt.BorderLayout.WEST);
-			jNextKin.add(getJPanel3(), java.awt.BorderLayout.EAST);
+			jNextKin.add(getJNextKinPanel(), BorderLayout.WEST);
+			jNextKin.add(getJPanel3(), BorderLayout.EAST);
 		}
 		return jNextKin;
 	}
@@ -908,8 +910,8 @@ public class PatientInsert extends JDialog implements ActionListener {
 		if (jTelephone == null) {
 			jTelephone = new JPanel();
 			jTelephone.setLayout(new BorderLayout());
-			jTelephone.add(getJTelPanel(), java.awt.BorderLayout.WEST);
-			jTelephone.add(getJPanel5(), java.awt.BorderLayout.EAST);
+			jTelephone.add(getJTelPanel(), BorderLayout.WEST);
+			jTelephone.add(getJPanel5(), BorderLayout.EAST);
 		}
 		return jTelephone;
 	}
@@ -938,20 +940,20 @@ public class PatientInsert extends JDialog implements ActionListener {
 	 * Set a specific border+title to a panel
 	 */
 	private JPanel setMyBorder(JPanel c, String title) {
-		javax.swing.border.Border b1 = BorderFactory.createLineBorder(Color.lightGray);
+		Border b1 = BorderFactory.createLineBorder(Color.lightGray);
 
-		javax.swing.border.Border b2 = BorderFactory.createTitledBorder(b1, title,
-				javax.swing.border.TitledBorder.LEFT, javax.swing.border.TitledBorder.TOP);
+		Border b2 = BorderFactory.createTitledBorder(b1, title,
+				TitledBorder.LEFT, TitledBorder.TOP);
 
 		c.setBorder(b2);
 		return c;
 	}
 
 	private JPanel setMyBorderCenter(JPanel c, String title) {
-		javax.swing.border.Border b1 = BorderFactory.createLineBorder(Color.lightGray);
+		Border b1 = BorderFactory.createLineBorder(Color.lightGray);
 
-		javax.swing.border.Border b2 = BorderFactory.createTitledBorder(b1, title,
-				javax.swing.border.TitledBorder.CENTER, javax.swing.border.TitledBorder.TOP);
+		Border b2 = BorderFactory.createTitledBorder(b1, title,
+				TitledBorder.CENTER, TitledBorder.TOP);
 
 		c.setBorder(b2);
 		return c;

--- a/src/main/java/org/isf/patient/gui/PatientInsertExtended.java
+++ b/src/main/java/org/isf/patient/gui/PatientInsertExtended.java
@@ -58,6 +58,8 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.WindowConstants;
+import javax.swing.border.Border;
+import javax.swing.border.TitledBorder;
 import javax.swing.event.EventListenerList;
 
 import org.isf.agetype.manager.AgeTypeBrowserManager;
@@ -367,7 +369,7 @@ public class PatientInsertExtended extends JDialog {
 			jMainPanel = new JPanel();
 			jMainPanel.setLayout(new BorderLayout());
 			jMainPanel.add(getJDataPanel(), BorderLayout.CENTER);
-			jMainPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jMainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jMainPanel;
 	}
@@ -1190,7 +1192,7 @@ public class PatientInsertExtended extends JDialog {
 			jFirstName = new JPanel();
 			jFirstName.setLayout(new BorderLayout());
 			jFirstName.add(getJFirstNamePanel(), BorderLayout.WEST);
-			jFirstName.add(getJFirstNameFieldPanel(), java.awt.BorderLayout.EAST);
+			jFirstName.add(getJFirstNameFieldPanel(), BorderLayout.EAST);
 		}
 		return jFirstName;
 	}
@@ -1217,8 +1219,8 @@ public class PatientInsertExtended extends JDialog {
 		if (jSecondName == null) {
 			jSecondName = new JPanel();
 			jSecondName.setLayout(new BorderLayout());
-			jSecondName.add(getJSecondNamePanel(), java.awt.BorderLayout.WEST);
-			jSecondName.add(getJSecondNamePanel1(), java.awt.BorderLayout.EAST);
+			jSecondName.add(getJSecondNamePanel(), BorderLayout.WEST);
+			jSecondName.add(getJSecondNamePanel1(), BorderLayout.EAST);
 		}
 		return jSecondName;
 	}
@@ -1628,8 +1630,8 @@ public class PatientInsertExtended extends JDialog {
 		if (jAddress == null) {
 			jAddress = new JPanel();
 			jAddress.setLayout(new BorderLayout());
-			jAddress.add(getJAddressLabelPanel(), java.awt.BorderLayout.WEST);
-			jAddress.add(getJAddressFieldPanel(), java.awt.BorderLayout.EAST);
+			jAddress.add(getJAddressLabelPanel(), BorderLayout.WEST);
+			jAddress.add(getJAddressFieldPanel(), BorderLayout.EAST);
 
 		}
 		return jAddress;
@@ -1644,8 +1646,8 @@ public class PatientInsertExtended extends JDialog {
 		if (jTaxCodePanel == null) {
 			jTaxCodePanel = new JPanel();
 			jTaxCodePanel.setLayout(new BorderLayout());
-			jTaxCodePanel.add(getJTaxCodeLabelPanel(), java.awt.BorderLayout.WEST);
-			jTaxCodePanel.add(getJTaxCodeFieldPanel(), java.awt.BorderLayout.EAST);
+			jTaxCodePanel.add(getJTaxCodeLabelPanel(), BorderLayout.WEST);
+			jTaxCodePanel.add(getJTaxCodeFieldPanel(), BorderLayout.EAST);
 
 		}
 		return jTaxCodePanel;
@@ -1660,8 +1662,8 @@ public class PatientInsertExtended extends JDialog {
 		if (jCity == null) {
 			jCity = new JPanel();
 			jCity.setLayout(new BorderLayout());
-			jCity.add(getJCityLabelPanel(), java.awt.BorderLayout.WEST);
-			jCity.add(getJCityFieldPanel(), java.awt.BorderLayout.EAST);
+			jCity.add(getJCityLabelPanel(), BorderLayout.WEST);
+			jCity.add(getJCityFieldPanel(), BorderLayout.EAST);
 		}
 		return jCity;
 	}
@@ -1675,8 +1677,8 @@ public class PatientInsertExtended extends JDialog {
 		if (jNextKin == null) {
 			jNextKin = new JPanel();
 			jNextKin.setLayout(new BorderLayout());
-			jNextKin.add(getJNextKinLabelPanel(), java.awt.BorderLayout.WEST);
-			jNextKin.add(getJNextKinFieldPanel(), java.awt.BorderLayout.EAST);
+			jNextKin.add(getJNextKinLabelPanel(), BorderLayout.WEST);
+			jNextKin.add(getJNextKinFieldPanel(), BorderLayout.EAST);
 		}
 		return jNextKin;
 	}
@@ -1690,8 +1692,8 @@ public class PatientInsertExtended extends JDialog {
 		if (jTelephone == null) {
 			jTelephone = new JPanel();
 			jTelephone.setLayout(new BorderLayout());
-			jTelephone.add(getJTelPanel(), java.awt.BorderLayout.WEST);
-			jTelephone.add(getJTelephoneFieldPanel(), java.awt.BorderLayout.EAST);
+			jTelephone.add(getJTelPanel(), BorderLayout.WEST);
+			jTelephone.add(getJTelephoneFieldPanel(), BorderLayout.EAST);
 		}
 		return jTelephone;
 	}
@@ -2067,15 +2069,15 @@ public class PatientInsertExtended extends JDialog {
 	 * Set a specific border+title to a panel
 	 */
 	private JPanel setMyBorder(JPanel c, String title) {
-		javax.swing.border.Border b1 = BorderFactory.createLineBorder(Color.lightGray);
-		javax.swing.border.Border b2 = BorderFactory.createTitledBorder(b1, title, javax.swing.border.TitledBorder.LEFT, javax.swing.border.TitledBorder.TOP);
+		Border b1 = BorderFactory.createLineBorder(Color.lightGray);
+		Border b2 = BorderFactory.createTitledBorder(b1, title, TitledBorder.LEFT, TitledBorder.TOP);
 		c.setBorder(b2);
 		return c;
 	}
 
 	private JPanel setMyBorderCenter(JPanel c, String title) {
-		javax.swing.border.Border b1 = BorderFactory.createLineBorder(Color.lightGray);
-		javax.swing.border.Border b2 = BorderFactory.createTitledBorder(b1, title, javax.swing.border.TitledBorder.CENTER, javax.swing.border.TitledBorder.TOP);
+		Border b1 = BorderFactory.createLineBorder(Color.lightGray);
+		Border b2 = BorderFactory.createTitledBorder(b1, title, TitledBorder.CENTER, TitledBorder.TOP);
 		c.setBorder(b2);
 		return c;
 	}

--- a/src/main/java/org/isf/patient/gui/PatientSummary.java
+++ b/src/main/java/org/isf/patient/gui/PatientSummary.java
@@ -25,6 +25,7 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
+import java.awt.GridLayout;
 import java.awt.Image;
 import java.io.File;
 import java.io.IOException;
@@ -39,6 +40,8 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.ScrollPaneConstants;
+import javax.swing.border.Border;
+import javax.swing.border.TitledBorder;
 
 import org.isf.generaldata.GeneralData;
 import org.isf.generaldata.MessageBundle;
@@ -103,28 +106,28 @@ public class PatientSummary {
 	}
 
 	private JPanel getPatientAddressAndCityPanel() {
-		JPanel dataPanel = new JPanel(new java.awt.GridLayout(1, 2));
+		JPanel dataPanel = new JPanel(new GridLayout(1, 2));
 		dataPanel.add(setMyBorder(getPatientAddressPanel(), MessageBundle.getMessage("angal.admission.address.label")));
 		dataPanel.add(setMyBorder(getPatientCityPanel(), MessageBundle.getMessage("angal.admission.city.label")));
 		return dataPanel;
 	}
 
 	private JPanel getPatientBloodAndEcoPanel() {
-		JPanel dataPanel = new JPanel(new java.awt.GridLayout(1, 2));
+		JPanel dataPanel = new JPanel(new GridLayout(1, 2));
 		dataPanel.add(setMyBorder(getPatientBloodTypePanel(), MessageBundle.getMessage("angal.admission.bloodtype.label")));
 		dataPanel.add(setMyBorder(getPatientEcoStatusPanel(), MessageBundle.getMessage("angal.admission.insurance.label")));
 		return dataPanel;
 	}
 
 	private JPanel getPatientMaritalAndProfession() {
-		JPanel dataPanel = new JPanel(new java.awt.GridLayout(1, 2));
+		JPanel dataPanel = new JPanel(new GridLayout(1, 2));
 		dataPanel.add(setMyBorder(getPatientMaritalStatusPanel(), MessageBundle.getMessage("angal.admission.maritalstatus.label")));
 		dataPanel.add(setMyBorder(getPatientProfessionPanel(), MessageBundle.getMessage("angal.admission.profession.label")));
 		return dataPanel;
 	}
 
 	private JPanel getPatientKinAndTelephonePanel() {
-		JPanel dataPanel = new JPanel(new java.awt.GridLayout(1, 2));
+		JPanel dataPanel = new JPanel(new GridLayout(1, 2));
 		dataPanel.add(setMyBorder(getPatientKinPanel(), MessageBundle.getMessage("angal.admission.nextofkin.label")));
 		dataPanel.add(setMyBorder(getPatientTelephonePanel(), MessageBundle.getMessage("angal.admission.telephone.label")));
 		return dataPanel;
@@ -350,8 +353,8 @@ public class PatientSummary {
 	}
 
 	private JPanel setMyBorder(JPanel c, String title) {
-		javax.swing.border.Border b1 = BorderFactory.createLineBorder(Color.lightGray);
-		javax.swing.border.Border b2 = BorderFactory.createTitledBorder(b1, title, javax.swing.border.TitledBorder.LEFT, javax.swing.border.TitledBorder.TOP);
+		Border b1 = BorderFactory.createLineBorder(Color.lightGray);
+		Border b2 = BorderFactory.createTitledBorder(b1, title, TitledBorder.LEFT, TitledBorder.TOP);
 		c.setBorder(b2);
 		return c;
 	}

--- a/src/main/java/org/isf/patvac/gui/PatVacBrowser.java
+++ b/src/main/java/org/isf/patvac/gui/PatVacBrowser.java
@@ -161,9 +161,9 @@ public class PatVacBrowser extends ModalJFrame {
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
-			jContentPane.add(getJSelectionPanel(), java.awt.BorderLayout.WEST);
-			jContentPane.add(new JScrollPane(getJTable()), java.awt.BorderLayout.CENTER);
+			jContentPane.add(getJButtonPanel(), BorderLayout.SOUTH);
+			jContentPane.add(getJSelectionPanel(), BorderLayout.WEST);
+			jContentPane.add(new JScrollPane(getJTable()), BorderLayout.CENTER);
 			validate();
 		}
 		return jContentPane;

--- a/src/main/java/org/isf/pregtreattype/gui/PregnantTreatmentTypeBrowser.java
+++ b/src/main/java/org/isf/pregtreattype/gui/PregnantTreatmentTypeBrowser.java
@@ -93,8 +93,8 @@ public class PregnantTreatmentTypeBrowser extends ModalJFrame implements Pregnan
 		if (jContainPanel == null) {
 			jContainPanel = new JPanel();
 			jContainPanel.setLayout(new BorderLayout());
-			jContainPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
-			jContainPanel.add(new JScrollPane(getJTable()), java.awt.BorderLayout.CENTER);
+			jContainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
+			jContainPanel.add(new JScrollPane(getJTable()), BorderLayout.CENTER);
 			validate();
 		}
 		return jContainPanel;

--- a/src/main/java/org/isf/pregtreattype/gui/PregnantTreatmentTypeEdit.java
+++ b/src/main/java/org/isf/pregtreattype/gui/PregnantTreatmentTypeEdit.java
@@ -140,8 +140,8 @@ public class PregnantTreatmentTypeEdit extends JDialog {
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getDataPanel(), java.awt.BorderLayout.NORTH);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getDataPanel(), BorderLayout.NORTH);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/stat/reportlauncher/gui/ReportLauncher.java
+++ b/src/main/java/org/isf/stat/reportlauncher/gui/ReportLauncher.java
@@ -387,7 +387,7 @@ public class ReportLauncher extends ModalJFrame {
 	}
 
 	public static Date convertToDateUsingInstant(LocalDate date) {
-		return java.util.Date.from(date.atStartOfDay()
+		return Date.from(date.atStartOfDay()
 						.atZone(ZoneId.systemDefault())
 						.toInstant());
 	}

--- a/src/main/java/org/isf/supplier/gui/SupplierBrowser.java
+++ b/src/main/java/org/isf/supplier/gui/SupplierBrowser.java
@@ -136,8 +136,8 @@ public class SupplierBrowser extends ModalJFrame implements SupplierEdit.Supplie
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
-			jContentPane.add(getJScrollPane(), java.awt.BorderLayout.CENTER);
+			jContentPane.add(getJButtonPanel(), BorderLayout.SOUTH);
+			jContentPane.add(getJScrollPane(), BorderLayout.CENTER);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/supplier/gui/SupplierEdit.java
+++ b/src/main/java/org/isf/supplier/gui/SupplierEdit.java
@@ -155,8 +155,8 @@ public class SupplierEdit extends JDialog {
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getDataPanel(), java.awt.BorderLayout.NORTH);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getDataPanel(), BorderLayout.NORTH);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/utils/jobjects/OhDefaultCellRenderer.java
+++ b/src/main/java/org/isf/utils/jobjects/OhDefaultCellRenderer.java
@@ -53,7 +53,7 @@ public class OhDefaultCellRenderer extends DefaultTableCellRenderer {
 	}
 
 	@Override
-	public Component getTableCellRendererComponent(JTable table, java.lang.Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+	public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
 		Component cmp = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
 
 		JLabel lbl = (JLabel) cmp;

--- a/src/main/java/org/isf/vaccine/gui/VaccineBrowser.java
+++ b/src/main/java/org/isf/vaccine/gui/VaccineBrowser.java
@@ -138,8 +138,8 @@ public class VaccineBrowser extends ModalJFrame implements VaccineEdit.VaccineLi
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
-			jContentPane.add(getJScrollPane(), java.awt.BorderLayout.CENTER);
+			jContentPane.add(getJButtonPanel(), BorderLayout.SOUTH);
+			jContentPane.add(getJScrollPane(), BorderLayout.CENTER);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/vaccine/gui/VaccineEdit.java
+++ b/src/main/java/org/isf/vaccine/gui/VaccineEdit.java
@@ -148,8 +148,8 @@ public class VaccineEdit extends JDialog {
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getDataPanel(), java.awt.BorderLayout.NORTH);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getDataPanel(), BorderLayout.NORTH);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/vactype/gui/VaccineTypeBrowser.java
+++ b/src/main/java/org/isf/vactype/gui/VaccineTypeBrowser.java
@@ -99,8 +99,8 @@ public class VaccineTypeBrowser extends ModalJFrame implements VaccineTypeListen
 		if (jContainPanel == null) {
 			jContainPanel = new JPanel();
 			jContainPanel.setLayout(new BorderLayout());
-			jContainPanel.add(getJButtonPanel(), java.awt.BorderLayout.SOUTH);
-			jContainPanel.add(new JScrollPane(getJTable()), java.awt.BorderLayout.CENTER);
+			jContainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
+			jContainPanel.add(new JScrollPane(getJTable()), BorderLayout.CENTER);
 			validate();
 		}
 		return jContainPanel;

--- a/src/main/java/org/isf/vactype/gui/VaccineTypeEdit.java
+++ b/src/main/java/org/isf/vactype/gui/VaccineTypeEdit.java
@@ -149,8 +149,8 @@ public class VaccineTypeEdit extends JDialog {
 		if (jContentPane == null) {
 			jContentPane = new JPanel();
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getDataPanel(), java.awt.BorderLayout.NORTH);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getDataPanel(), BorderLayout.NORTH);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/video/gui/PatientPhotoPanel.java
+++ b/src/main/java/org/isf/video/gui/PatientPhotoPanel.java
@@ -39,6 +39,8 @@ import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.WindowConstants;
+import javax.swing.border.Border;
+import javax.swing.border.TitledBorder;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
@@ -179,7 +181,7 @@ public class PatientPhotoPanel extends JPanel {
 			buttonBox1.add(jAttachPhotoButton);
 
 			jPhotoPanel.add(externalPanel, BorderLayout.NORTH);
-			jPhotoPanel.add(buttonBox1, java.awt.BorderLayout.CENTER);
+			jPhotoPanel.add(buttonBox1, BorderLayout.CENTER);
 
 			jPhotoPanel.setMinimumSize(new Dimension((int) getPreferredSize().getWidth(), 100));
 		}
@@ -189,8 +191,8 @@ public class PatientPhotoPanel extends JPanel {
 
 	
 	private JPanel setMyBorder(JPanel c, String title) {
-		javax.swing.border.Border b1 = BorderFactory.createLineBorder(Color.lightGray);
-		javax.swing.border.Border b2 = BorderFactory.createTitledBorder(b1, title, javax.swing.border.TitledBorder.LEFT, javax.swing.border.TitledBorder.TOP);
+		Border b1 = BorderFactory.createLineBorder(Color.lightGray);
+		Border b2 = BorderFactory.createTitledBorder(b1, title, TitledBorder.LEFT, TitledBorder.TOP);
 
 		c.setBorder(b2);
 		return c;

--- a/src/main/java/org/isf/ward/gui/WardEdit.java
+++ b/src/main/java/org/isf/ward/gui/WardEdit.java
@@ -159,8 +159,8 @@ public class WardEdit extends JDialog {
 			jContentPane = new JPanel();
 			jContentPane.setBorder(new EmptyBorder(5, 5, 5, 5));
 			jContentPane.setLayout(new BorderLayout());
-			jContentPane.add(getDataPanel(), java.awt.BorderLayout.CENTER);
-			jContentPane.add(getButtonPanel(), java.awt.BorderLayout.SOUTH);
+			jContentPane.add(getDataPanel(), BorderLayout.CENTER);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
 		}
 		return jContentPane;
 	}

--- a/src/main/java/org/isf/xmpp/gui/CommunicationFrame.java
+++ b/src/main/java/org/isf/xmpp/gui/CommunicationFrame.java
@@ -24,6 +24,7 @@ package org.isf.xmpp.gui;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.Frame;
 import java.awt.Insets;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
@@ -233,7 +234,7 @@ public class CommunicationFrame extends JFrame implements MessageListener, FileT
 					printMessage(getArea(user, true), interaction.userFromAddress(message.getFrom()), message.getBody(), false);
 					if (!isVisible()) {
 						setVisible(true);
-						setState(java.awt.Frame.NORMAL);
+						setState(Frame.NORMAL);
 						toFront();
 					} else {
 						toFront();
@@ -484,7 +485,7 @@ public class CommunicationFrame extends JFrame implements MessageListener, FileT
 			printMessage((getArea(user, false)), user, arg1.getBody(), false);
 			if (!this.isVisible()) {
 				this.setVisible(true);
-				this.setState(java.awt.Frame.ICONIFIED);
+				this.setState(Frame.ICONIFIED);
 				this.toFront();
 			} else {
 				this.toFront();
@@ -572,7 +573,7 @@ public class CommunicationFrame extends JFrame implements MessageListener, FileT
 					printMessage((getArea(user, false)), interaction.userFromAddress(message.getFrom()), message.getBody(), false);
 					if (!isVisible()) {
 						setVisible(true);
-						setState(java.awt.Frame.NORMAL);
+						setState(Frame.NORMAL);
 						toFront();
 					} else {
 						toFront();


### PR DESCRIPTION
Remove unnecessary fully qualified name (java.awt, javax.swing, etc.)