### PR TITLE
OP-1126: add helpers in Worksheet

### DIFF
--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -1684,7 +1684,6 @@ angal.visit.addvisit1.btn                                                       
 angal.visit.addvisit1.btn.key                                                                          = A
 angal.visit.addvisit2.btn                                                                              = Add Visit
 angal.visit.addvisit2.btn.key                                                                          = V
-angal.visit.allwards.txt                                                                               = <all wards>
 angal.visit.arrowprevious.btn                                                                          = <-Prev.
 angal.visit.avisitcannotbescheduledforadatethatispast.msg                                              = A visit cannot be scheduled for a date that is past.
 angal.visit.changepatient                                                                              = Change Patient

--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -1684,6 +1684,7 @@ angal.visit.addvisit1.btn                                                       
 angal.visit.addvisit1.btn.key                                                                          = A
 angal.visit.addvisit2.btn                                                                              = Add Visit
 angal.visit.addvisit2.btn.key                                                                          = V
+angal.visit.allwards.txt                                                                               = <all wards>
 angal.visit.arrowprevious.btn                                                                          = <-Prev.
 angal.visit.avisitcannotbescheduledforadatethatispast.msg                                              = A visit cannot be scheduled for a date that is past.
 angal.visit.changepatient                                                                              = Change Patient
@@ -1710,12 +1711,13 @@ angal.visit.printthisdaysvisits2.btn                                            
 angal.visit.printthisdaysvisits2.btn.key                                                               = 2
 angal.visit.removevisit.btn                                                                            = Remove Visit
 angal.visit.removevisit.msg                                                                            = Remove the visit?
-angal.visit.selectaward                                                                                = Select a Ward
+angal.visit.selectaward.txt                                                                            = <select a ward>
 angal.visit.service                                                                                    = Service
 angal.visit.thepatientssexandwarddonotagree.msg                                                        = The patient's sex and ward do not agree.
 angal.visit.today.btn                                                                                  = Today
 angal.visit.today.btn.key                                                                              = T
 angal.visit.visits                                                                                     = Visits
+angal.visit.ward.border                                                                                = Ward
 angal.visit.worksheet.title                                                                            = Worksheet
 angal.ward.beds.col                                                                                    = Beds
 angal.ward.bedsedit                                                                                    = Number of beds *

--- a/src/main/java/org/isf/visits/gui/VisitView.java
+++ b/src/main/java/org/isf/visits/gui/VisitView.java
@@ -113,7 +113,6 @@ public class VisitView extends ModalJFrame {
 	private static final int ALL_BUTTON_HEIGHT = 30;
 
 	private static final String SELECT_A_WARD = MessageBundle.getMessage("angal.visit.selectaward.txt");
-	private static final String ALL_WARDS = MessageBundle.getMessage("angal.visit.allwards.txt");
 
 	/*
 	 * Attributes
@@ -167,16 +166,9 @@ public class VisitView extends ModalJFrame {
 
 	private void loadDataForWard(Ward ward) {
 		try {
-			String description = ward.getDescription();
-			if (description.equals(ALL_WARDS)) {
-				visits = visitManager.getVisitsWard(null);
-				return;
+			if (!ward.getDescription().equals(SELECT_A_WARD)) {
+				visits = visitManager.getVisitsWard(ward.getCode());
 			}
-			if (description.equals(SELECT_A_WARD)) {
-				visits.clear();
-				return;
-			}
-			visits = visitManager.getVisitsWard(ward.getCode());
 		} catch (OHServiceException e1) {
 			OHServiceExceptionUtil.showMessages(e1);
 		}
@@ -813,8 +805,6 @@ public class VisitView extends ModalJFrame {
 					}
 				}
 			}
-			Ward allWards = new Ward("", ALL_WARDS, "", "", "", -1, -1, -1, false, false);
-			wardBox.addItem(allWards);
 
 			wardBox.addActionListener(actionEvent -> {
 				
@@ -824,6 +814,10 @@ public class VisitView extends ModalJFrame {
 					ward = (Ward) selectedWard;
 					loadDataForWard(ward);
 					showGui(true);
+				}
+				Ward wardAtZero = wardBox.getItemAt(0);
+				if (wardAtZero.getDescription().equals(SELECT_A_WARD)) {
+					wardBox.removeItem(wardAtZero);
 				}
 				updatePanels();
 			});

--- a/src/main/java/org/isf/visits/gui/VisitView.java
+++ b/src/main/java/org/isf/visits/gui/VisitView.java
@@ -111,7 +111,10 @@ public class VisitView extends ModalJFrame {
 	private static final int VISIT_BUTTON_WIDTH = 200;
 	private static final int ACTIONS_BUTTON_WIDTH = 240;
 	private static final int ALL_BUTTON_HEIGHT = 30;
-	
+
+	private static final String SELECT_A_WARD = MessageBundle.getMessage("angal.visit.selectaward.txt");
+	private static final String ALL_WARDS = MessageBundle.getMessage("angal.visit.allwards.txt");
+
 	/*
 	 * Attributes
 	 */
@@ -142,7 +145,7 @@ public class VisitView extends ModalJFrame {
 	private JComboBox<Ward> wardBox;
 	private SpringLayout slVisitParamsPanel;
 	
-	public String[] visColumns = { MessageBundle.getMessage("angal.visit.visits") };
+	private String[] visColumns = { MessageBundle.getMessage("angal.visit.visits") };
 
 	/*
 	 * Managers
@@ -164,11 +167,16 @@ public class VisitView extends ModalJFrame {
 
 	private void loadDataForWard(Ward ward) {
 		try {
-			if (ward != null) {
-				visits = visitManager.getVisitsWard(ward.getCode());
-			} else {
+			String description = ward.getDescription();
+			if (description.equals(ALL_WARDS)) {
 				visits = visitManager.getVisitsWard(null);
+				return;
 			}
+			if (description.equals(SELECT_A_WARD)) {
+				visits.clear();
+				return;
+			}
+			visits = visitManager.getVisitsWard(ward.getCode());
 		} catch (OHServiceException e1) {
 			OHServiceExceptionUtil.showMessages(e1);
 		}
@@ -788,7 +796,6 @@ public class VisitView extends ModalJFrame {
 		if (wardPanel == null) {
 			wardPanel = new JPanel();
 			wardBox = new JComboBox<>();
-			wardBox.addItem(null);
 			List<Ward> wardList;
 			try {
 				wardList = wardBrowserManager.getWards();
@@ -796,14 +803,18 @@ public class VisitView extends ModalJFrame {
 				wardList = new ArrayList<>();
 				OHServiceExceptionUtil.showMessages(e);
 			}
-			for (Ward ward : wardList) {
-				wardBox.addItem(ward);
-				if (this.ward != null) {
-					if (this.ward.getCode().equalsIgnoreCase(ward.getCode())) {
-						wardBox.setSelectedItem(ward);
+			Ward selectAWard = new Ward("", SELECT_A_WARD, "", "", "", -1, -1, -1, false, false);
+			wardBox.addItem(selectAWard);
+			for (Ward aWard : wardList) {
+				wardBox.addItem(aWard);
+				if (ward != null) {
+					if (ward.getCode().equalsIgnoreCase(aWard.getCode())) {
+						wardBox.setSelectedItem(aWard);
 					}
 				}
 			}
+			Ward allWards = new Ward("", ALL_WARDS, "", "", "", -1, -1, -1, false, false);
+			wardBox.addItem(allWards);
 
 			wardBox.addActionListener(actionEvent -> {
 				
@@ -819,7 +830,7 @@ public class VisitView extends ModalJFrame {
 		}
 
 		wardPanel.add(wardBox);
-		wardPanel.setBorder(BorderFactory.createTitledBorder(MessageBundle.getMessage("angal.visit.selectaward"))); //$NON-NLS-1$
+		wardPanel.setBorder(BorderFactory.createTitledBorder(MessageBundle.getMessage("angal.visit.ward.border")));
 
 		return wardPanel;
 	}


### PR DESCRIPTION
See OP-1126

Added "\<select a ward\>" message to initial ward combo box instead of blank.  Changed the behavior slightly as the old behavior when the "blank" entry was selected again after selecting a specific ward, all visits for all wards would be displayed; now, there is another entry "\<all wards\>" that can do  the same thing and selecting "\<select a ward\>" returns the dialog back to its original empty state.    This seems more consistent and understood behavior instead of "\<select a ward\>" meaning something different the first time and when used later.

I will update the documentation after this is committed.