### PR TITLE
Chore: remove unused variable/code

### DIFF
--- a/src/main/java/org/isf/admission/gui/PatientFolderBrowser.java
+++ b/src/main/java/org/isf/admission/gui/PatientFolderBrowser.java
@@ -88,7 +88,6 @@ import org.isf.utils.table.TableSorter;
 import org.isf.utils.time.Converters;
 import org.isf.utils.time.TimeTools;
 import org.isf.ward.manager.WardBrowserManager;
-import org.isf.ward.model.Ward;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -700,11 +699,6 @@ public class PatientFolderBrowser extends ModalJFrame
 			}
 			try {
 				disease = diseaseBrowserManager.getDiseaseAll();
-			} catch (OHServiceException e) {
-				OHServiceExceptionUtil.showMessages(e);
-			}
-			try {
-				List<Ward> ward = wardBrowserManager.getWards();
 			} catch (OHServiceException e) {
 				OHServiceExceptionUtil.showMessages(e);
 			}


### PR DESCRIPTION
Defining a local variable in a `try` block and then not using it has no value.

Looking at the class history, the variable `ward` was originally a class variable that was used to fill a column in the table.  With time the column was modified to include `OPD` and the class variable was no longer used.  In another PR class variables that were used only locally were made into local variables and that is how this particular local was born.

Removing this code has no effect.