### PR TITLE
OP-1141 Add info with default credentials

### DIFF
--- a/rsc/default_credentials.properties.dist
+++ b/rsc/default_credentials.properties.dist
@@ -1,0 +1,3 @@
+# Default credentials
+admin:admin
+guest:guest

--- a/rsc/default_demo.credentials.properties.dist
+++ b/rsc/default_demo.credentials.properties.dist
@@ -1,0 +1,5 @@
+# Default credentials
+admin:admin
+guest:guest
+laboratorist:laboratorist
+doctor:doctor

--- a/src/main/java/org/isf/menu/gui/Login.java
+++ b/src/main/java/org/isf/menu/gui/Login.java
@@ -30,6 +30,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
+import java.io.File;
 import java.time.Duration;
 import java.util.EventListener;
 import java.util.List;
@@ -62,9 +63,6 @@ import org.isf.utils.layout.SpringUtilities;
 import org.isf.utils.time.TimeTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.io.DefaultResourceLoader;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
 
 public class Login extends JDialog implements ActionListener, KeyListener {
 
@@ -312,8 +310,9 @@ public class Login extends JDialog implements ActionListener, KeyListener {
 			add(body, BorderLayout.NORTH);
 			add(buttons, BorderLayout.SOUTH);
 
-			if (verifyIfResourceExists(DEFAULT_CREDENTIALS_PROPERTIES)) {
-				String tooltip = FileTools.readFileToStringLineByLine(DEFAULT_CREDENTIALS_PROPERTIES, true);
+			File credentialProperties = FileTools.getFile(DEFAULT_CREDENTIALS_PROPERTIES);
+			if (credentialProperties != null) {
+				String tooltip = FileTools.readFileToStringLineByLine(credentialProperties.getAbsolutePath(), true);
 				JLabel infoButton = new JLabelInfo(new ImageIcon("rsc/icons/info_button.png"), tooltip, Color.white);
 
 				JPanel infoPanel = new JPanel();
@@ -328,14 +327,6 @@ public class Login extends JDialog implements ActionListener, KeyListener {
 			cancel.addActionListener(myFrame);
 			cancel.setName("cancel");
 			cancel.addKeyListener(myFrame);
-
 		}
 	}
-
-	private boolean verifyIfResourceExists(String path) {
-		ResourceLoader resourceLoader = new DefaultResourceLoader();
-		Resource resource = resourceLoader.getResource(path);
-		return resource.exists();
-	}
-
 }

--- a/src/main/java/org/isf/utils/jobjects/JLabelInfo.java
+++ b/src/main/java/org/isf/utils/jobjects/JLabelInfo.java
@@ -34,14 +34,12 @@ import javax.swing.ToolTipManager;
 import javax.swing.UIManager;
 
 /**
- * JLabelInfo.java
- *
  * @author Mwithi
  */
 public class JLabelInfo extends JLabel {
 
-	private final int defaultInitDelay = ToolTipManager.sharedInstance().getInitialDelay();
-	private final Color defaultBackgroundColor = (Color) UIManager.get("ToolTip.background");
+	private static final int defaultInitDelay = ToolTipManager.sharedInstance().getInitialDelay();
+	private static final Color defaultBackgroundColor = (Color) UIManager.get("ToolTip.background");
 
 	/**
 	 * Creates a {@code JLabelInfo} instance with the specified
@@ -66,11 +64,13 @@ public class JLabelInfo extends JLabel {
 
 		MouseListener ml = new MouseAdapter() {
 
+			@Override
 			public void mouseEntered(MouseEvent me) {
 				ToolTipManager.sharedInstance().setInitialDelay(0);
 				UIManager.put("ToolTip.background", backgroundColor);
 			}
 
+			@Override
 			public void mouseExited(MouseEvent me) {
 				ToolTipManager.sharedInstance().setInitialDelay(defaultInitDelay);
 				UIManager.put("ToolTip.background", defaultBackgroundColor);

--- a/src/main/java/org/isf/utils/jobjects/JLabelInfo.java
+++ b/src/main/java/org/isf/utils/jobjects/JLabelInfo.java
@@ -1,0 +1,91 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2023 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.utils.jobjects;
+
+import java.awt.Color;
+import java.awt.Point;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.SwingConstants;
+import javax.swing.ToolTipManager;
+import javax.swing.UIManager;
+
+/**
+ * JLabelInfo.java
+ *
+ * @author Mwithi
+ */
+public class JLabelInfo extends JLabel {
+
+	private final int defaultInitDelay = ToolTipManager.sharedInstance().getInitialDelay();
+	private final Color defaultBackgroundColor = (Color) UIManager.get("ToolTip.background");
+
+	/**
+	 * Creates a {@code JLabelInfo} instance with the specified
+	 * tooltip, icon and default background color, delay is set to zero milliseconds
+	 * 
+	 * @param tooltip
+	 * @param icon
+	 */
+	public JLabelInfo(ImageIcon icon, String tooltip) {
+		new JLabelInfo(icon, tooltip, defaultBackgroundColor);
+	}
+
+	/**
+	 * Creates a {@code JLabelInfo} instance with the specified
+	 * tooltip, icon and background color, delay is set to zero milliseconds
+	 * 
+	 * @param tooltip
+	 * @param icon
+	 * @param backgroundColor
+	 */
+	public JLabelInfo(ImageIcon icon, String tooltip, Color backgroundColor) {
+
+		MouseListener ml = new MouseAdapter() {
+
+			public void mouseEntered(MouseEvent me) {
+				ToolTipManager.sharedInstance().setInitialDelay(0);
+				UIManager.put("ToolTip.background", backgroundColor);
+			}
+
+			public void mouseExited(MouseEvent me) {
+				ToolTipManager.sharedInstance().setInitialDelay(defaultInitDelay);
+				UIManager.put("ToolTip.background", defaultBackgroundColor);
+			}
+		};
+
+		addMouseListener(ml);
+		setIcon(icon);
+		setHorizontalAlignment(SwingConstants.RIGHT);
+		setToolTipText(tooltip);
+	}
+
+	@Override
+	public Point getToolTipLocation(MouseEvent event) {
+		return new Point(30, 0);
+	}
+
+}


### PR DESCRIPTION
Implement OP-1141 by adding info with default credentials as a tool tip text in a button, and adopting a simple HTML format for presentation. 

Paired with: https://github.com/informatici/openhospital-core/pull/1256

![image](https://github.com/informatici/openhospital-gui/assets/2938553/2577d824-ece2-4e5e-a7bb-8c72c00d127d)



Presenting the text is conditioned to the existent of `default_credentials.properties` file as a resource.

NOTE: since it's a temporary file and anyone can easily translate it, we are not caring about translations





