### PR TITLE
OP-1149 Update to Spring Boot 3.2.x

### DIFF
--- a/.ide-settings/eclipse/OpenHospital.importorder
+++ b/.ide-settings/eclipse/OpenHospital.importorder
@@ -1,8 +1,10 @@
 #Organize Import Order
-#Fri Jul 31 13:21:30 EDT 2020
-5=
-4=com
-3=org
+#Wed Mar 13 13:21:30 EDT 2024
+6=
+5=com
+4=org
+3=jakarta
 2=javax
 1=java
 0=\#
+

--- a/.ide-settings/idea/OpenHospital-code-style-configuration.xml
+++ b/.ide-settings/idea/OpenHospital-code-style-configuration.xml
@@ -1,4 +1,4 @@
-<code_scheme name="Open Hospital profile" version="173">
+<code_scheme name="Open Hospital profile" version="174">
   <option name="RIGHT_MARGIN" value="160" />
   <JavaCodeStyleSettings>
     <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
@@ -13,6 +13,8 @@
         <package name="java" withSubpackages="true" static="false" />
         <emptyLine />
         <package name="javax" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="jakarta" withSubpackages="true" static="false" />
         <emptyLine />
         <package name="org" withSubpackages="true" static="false" />
         <emptyLine />

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,6 @@
 		<oh.version>1.14.0-SNAPSHOT</oh.version>
 		<java.version>17</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring.framework.version>5.3.32</spring.framework.version>
-		<spring.boot.version>2.7.18</spring.boot.version>
 		<license.maven.plugin.version>4.3</license.maven.plugin.version>
 	</properties>
 
@@ -306,24 +304,9 @@
 			<version>2.0.12</version>
 		</dependency>
 		<dependency>
-			<groupId>org.igniterealtime.smack</groupId>
-			<artifactId>smack</artifactId>
-			<version>3.2.1</version>
-		</dependency>
-		<dependency>
-			<groupId>org.igniterealtime.smack</groupId>
-			<artifactId>smackx</artifactId>
-			<version>3.2.1</version>
-		</dependency>
-		<dependency>
 			<groupId>org.imgscalr</groupId>
 			<artifactId>imgscalr-lib</artifactId>
 			<version>4.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
-			<version>${spring.framework.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.jgoodies</groupId>
@@ -354,11 +337,6 @@
 			<groupId>com.github.lgooddatepicker</groupId>
 			<artifactId>LGoodDatePicker</artifactId>
 			<version>11.2.1</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot</artifactId>
-			<version>${spring.boot.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,10 @@
 	<groupId>org.isf</groupId>
 	<artifactId>OH-gui</artifactId>
 	<packaging>jar</packaging>
-	<version>1.14.0-SNAPSHOT</version>
+	<version>1.14.1-SNAPSHOT</version>
 
 	<properties>
-		<oh.version>1.14.0-SNAPSHOT</oh.version>
+		<oh.version>1.14.1-SNAPSHOT</oh.version>
 		<java.version>17</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<license.maven.plugin.version>4.3</license.maven.plugin.version>

--- a/rsc/version.properties
+++ b/rsc/version.properties
@@ -1,4 +1,4 @@
 # This file is not meant to be modified by the user
 VER_MAJOR=1
 VER_MINOR=14
-VER_RELEASE=0
+VER_RELEASE=1

--- a/src/main/java/org/isf/Application.java
+++ b/src/main/java/org/isf/Application.java
@@ -1,0 +1,33 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf;
+
+import org.isf.menu.gui.Menu;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+	public static void main(String... args) {
+		new Menu(args);
+	}
+}

--- a/src/main/java/org/isf/menu/gui/Menu.java
+++ b/src/main/java/org/isf/menu/gui/Menu.java
@@ -34,6 +34,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.plaf.FontUIResource;
 
+import org.isf.Application;
 import org.isf.generaldata.GeneralData;
 import org.isf.generaldata.MessageBundle;
 import org.isf.generaldata.Version;
@@ -41,8 +42,8 @@ import org.isf.menu.manager.Context;
 import org.isf.utils.jobjects.WaitCursorEventQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 public class Menu {
 
@@ -158,15 +159,15 @@ public class Menu {
 		}
 	}
 
-	public static void main(String[] args) {
-		ApplicationContext context = null;
-		try {
-			context = new ClassPathXmlApplicationContext("applicationContext.xml");
-		} catch (Exception e) {
-			LOGGER.error("Fatal: fail to load application context. {}", e.getMessage(), e);
-			System.exit(1);
-		}
+	public Menu(String[] args) {
+		ApplicationContext context = createApplicationContext(args);
 		Context.setApplicationContext(context);
 		SwingUtilities.invokeLater(() -> createAndShowGUI());
+	}
+
+	private static ApplicationContext createApplicationContext(String... args) {
+		return new SpringApplicationBuilder(Application.class)
+				.headless(false)
+				.run(args);
 	}
 }


### PR DESCRIPTION
See OP-1149

Note the **main** class is now `org.isf.Application` and not `org.isf.menu.gui.Menu`.   The reason for the change is because Spring Boot scans downward from the main class looking for beans, etc.

`ApplicationContext.xml` is no longer used (Spring has been moving away from xml files).  The information is now included in either `application.properties` or `application.yml`. Much of the information is gleaned from the class files themselves by scanning downward from the main class.

The CORE PR companion is:  https://github.com/informatici/openhospital-core/pull/1303