### PR TITLE
OP-1301-fix-units-packets-management-in-main-store

### DIFF
--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -864,7 +864,9 @@ angal.medicalstock.multipledischarging.isabouttoend                             
 angal.medicalstock.multipledischarging.lotinformations                                                 = Lot Information
 angal.medicalstock.multipledischarging.lotnumberabb                                                    = Lot No.
 angal.medicalstock.multipledischarging.lyinginstock                                                    = Lying in stock:
+angal.medicalstock.multipledischarging.movementexceedstheavailablequantityformedical                   = Movement exceeds the available quantity ({0}) for medical {1}.
 angal.medicalstock.multipledischarging.noelementtosave                                                 = No elements to save
+angal.medicalstock.multipledischarging.nolotswithavailablequantityfoundformedicalpleasereport          = No lots with available quantity found for medical {0}; please report to system administrator.
 angal.medicalstock.multipledischarging.outofstock                                                      = Out of stock!
 angal.medicalstock.multipledischarging.packets                                                         = Packets
 angal.medicalstock.multipledischarging.pleaseinsertavalidvalue                                         = Insert a valid value

--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -823,7 +823,7 @@ angal.medicalstock.lotpreparationdate                                           
 angal.medicalstock.medtype.col                                                                         = Med Type
 angal.medicalstock.movement                                                                            = Movement
 angal.medicalstock.movementdatefromcannotbelaterthanmovementdateto                                     = Movement Date From cannot be later than movement Date To
-angal.medicalstock.movementquantityisgreaterthanthequantityof.msg                                      = Movement quantity ({0}) is greater than the quantity of the lot selected ({1}); split the movement or adjust Units/Packets.
+angal.medicalstock.movementquantityisgreaterthanthequantityof.fmt.msg                                      = Movement quantity ({0}) is greater than the quantity of the lot selected ({1}); split the movement or adjust Units/Packets.
 angal.medicalstock.multiplecharging.adateinthefutureisnotallowed.msg                                   = A date in the future is not allowed.
 angal.medicalstock.multiplecharging.chargetype                                                         = Charge Type
 angal.medicalstock.multiplecharging.chooseamedical                                                     = Choose a Medical

--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -823,7 +823,7 @@ angal.medicalstock.lotpreparationdate                                           
 angal.medicalstock.medtype.col                                                                         = Med Type
 angal.medicalstock.movement                                                                            = Movement
 angal.medicalstock.movementdatefromcannotbelaterthanmovementdateto                                     = Movement Date From cannot be later than movement Date To
-angal.medicalstock.movementquantityisgreaterthanthequantityof.fmt.msg                                      = Movement quantity ({0}) is greater than the quantity of the lot selected ({1}); split the movement or adjust Units/Packets.
+angal.medicalstock.movementquantityisgreaterthanthequantityof.fmt.msg                                  = Movement quantity ({0}) is greater than the quantity of the lot selected ({1}); split the movement or adjust Units/Packets.
 angal.medicalstock.multiplecharging.adateinthefutureisnotallowed.msg                                   = A date in the future is not allowed.
 angal.medicalstock.multiplecharging.chargetype                                                         = Charge Type
 angal.medicalstock.multiplecharging.chooseamedical                                                     = Choose a Medical

--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -864,9 +864,9 @@ angal.medicalstock.multipledischarging.isabouttoend                             
 angal.medicalstock.multipledischarging.lotinformations                                                 = Lot Information
 angal.medicalstock.multipledischarging.lotnumberabb                                                    = Lot No.
 angal.medicalstock.multipledischarging.lyinginstock                                                    = Lying in stock:
-angal.medicalstock.multipledischarging.movementexceedstheavailablequantityformedical                   = Movement exceeds the available quantity ({0}) for medical {1}.
+angal.medicalstock.multipledischarging.movementexceedstheavailablequantityformedical.fmt.msg           = Movement exceeds the available quantity ({0}) for medical {1}.
 angal.medicalstock.multipledischarging.noelementtosave                                                 = No elements to save
-angal.medicalstock.multipledischarging.nolotswithavailablequantityfoundformedicalpleasereport          = No lots with available quantity found for medical {0}; please report to system administrator.
+angal.medicalstock.multipledischarging.nolotswithavailablequantityfoundformedicalpleasereport.fmt.msg  = No lots with available quantity found for medical {0}; please report to system administrator.
 angal.medicalstock.multipledischarging.outofstock                                                      = Out of stock!
 angal.medicalstock.multipledischarging.packets                                                         = Packets
 angal.medicalstock.multipledischarging.pleaseinsertavalidvalue                                         = Insert a valid value

--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -823,7 +823,7 @@ angal.medicalstock.lotpreparationdate                                           
 angal.medicalstock.medtype.col                                                                         = Med Type
 angal.medicalstock.movement                                                                            = Movement
 angal.medicalstock.movementdatefromcannotbelaterthanmovementdateto                                     = Movement Date From cannot be later than movement Date To
-angal.medicalstock.movementquantityisgreaterthanthequantityof.msg                                      = Movement quantity is greater than the quantity of the lot selected; split the movement.
+angal.medicalstock.movementquantityisgreaterthanthequantityof.msg                                      = Movement quantity ({0}) is greater than the quantity of the lot selected ({1}); split the movement or adjust Units/Packets.
 angal.medicalstock.multiplecharging.adateinthefutureisnotallowed.msg                                   = A date in the future is not allowed.
 angal.medicalstock.multiplecharging.chargetype                                                         = Charge Type
 angal.medicalstock.multiplecharging.chooseamedical                                                     = Choose a Medical

--- a/src/main/java/org/isf/medicals/gui/MedicalBrowser.java
+++ b/src/main/java/org/isf/medicals/gui/MedicalBrowser.java
@@ -559,7 +559,7 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener {
 		buttonNew.setMnemonic(MessageBundle.getMnemonic("angal.common.new.btn.key"));
 		buttonNew.addActionListener(actionEvent -> {
 			// medical will reference the new record
-			medical = new Medical(null, new MedicalType("", ""), "", "", 0, 0, 0, 0, 0);
+			medical = new Medical(null, new MedicalType("", ""), "", "", 0, 0, 0, 0);
 			MedicalEdit newrecord = new MedicalEdit(medical, true, me);
 			newrecord.addMedicalListener(this);
 			newrecord.setVisible(true);

--- a/src/main/java/org/isf/medicalstock/gui/MovStockMultipleDischarging.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockMultipleDischarging.java
@@ -114,7 +114,7 @@ public class MovStockMultipleDischarging extends JDialog {
 			MessageBundle.getMessage("angal.medicalstock.multipledischarging.expiringdate").toUpperCase()
 	};
 	private final Class[] columnClasses = { String.class, String.class, Integer.class, Integer.class, String.class, Integer.class, String.class, String.class };
-	private boolean[] columnEditable = { false, false, false, false, true, false, false, false };
+	private boolean[] columnEditable = { false, false, false, true, true, false, false, false };
 	private int[] columnWidth = { 50, 100, 70, 50, 70, 50, 100, 80 };
 	private boolean[] columnResizable = { false, true, false, false, false, false, false, false };
 	private boolean[] columnVisible = { true, true, true, true, true, true, !GeneralData.AUTOMATICLOT_OUT, !GeneralData.AUTOMATICLOT_OUT };
@@ -315,12 +315,7 @@ public class MovStockMultipleDischarging extends JDialog {
 					String refNo = jTextFieldReference.getText();
 
 					Movement movement = new Movement(med, (MovementType) jComboBoxDischargeType.getSelectedItem(), null, lot, date, qty, null, refNo);
-					if (med.getPcsperpck() > 1) {
-						model.addItem(movement, PACKETS);
-					} else {
-						model.addItem(movement, UNITS);
-					}
-
+					model.addItem(movement, UNITS);
 					jTextFieldSearch.setText(""); //$NON-NLS-1$
 					jTextFieldSearch.requestFocus();
 				}
@@ -596,7 +591,7 @@ public class MovStockMultipleDischarging extends JDialog {
 	private boolean checkQuantityInLot(Lot lot, double qty) {
 		double lotQty = lot.getMainStoreQuantity();
 		if (qty > lotQty) {
-			MessageDialog.error(this, "angal.medicalstock.movementquantityisgreaterthanthequantityof.msg");
+			MessageDialog.error(this, "angal.medicalstock.movementquantityisgreaterthanthequantityof.msg", qty, lotQty);
 			return false;
 		}
 		return true;
@@ -862,6 +857,15 @@ public class MovStockMultipleDischarging extends JDialog {
 		@Override
 		public void setValueAt(Object value, int r, int c) {
 			Movement movement = movements.get(r);
+			if (c == 3) {
+				int oldQuantity = movement.getQuantity();
+				movement.setQuantity((int) value);
+
+				int total = calcTotal(movement, units.get(r));
+				if (!checkQuantityInMovement(movement, total)) {
+					movement.setQuantity(oldQuantity);
+				}
+			}
 			if (c == 4) {
 				int newOption = 0;
 				if (qtyOption[1].equals(value)) {

--- a/src/main/java/org/isf/medicalstock/gui/MovStockMultipleDischarging.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockMultipleDischarging.java
@@ -591,7 +591,7 @@ public class MovStockMultipleDischarging extends JDialog {
 	private boolean checkQuantityInLot(Lot lot, double qty) {
 		double lotQty = lot.getMainStoreQuantity();
 		if (qty > lotQty) {
-			MessageDialog.error(this, "angal.medicalstock.movementquantityisgreaterthanthequantityof.msg", qty, lotQty);
+			MessageDialog.error(this, "angal.medicalstock.movementquantityisgreaterthanthequantityof.fmt.msg", qty, lotQty);
 			return false;
 		}
 		return true;


### PR DESCRIPTION
See OP-1301.

Paired with https://github.com/informatici/openhospital-core/pull/1375.

- [x] Change default quantity to UNITS when discharging, with possibility to change to PACKETS afterwards
- [x] Enable quantity editing in the table directly (without deleting and reinserting the movement)