### PR TITLE
OP-1340 Fix when medical has no previous lots

### DIFF
--- a/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
@@ -467,7 +467,7 @@ public class MovStockMultipleCharging extends JDialog {
 		newLot.setMedical(med);
 
 		if (!setOrValidateCost(newLot, qty)) {
-			return null; // Exit if cost was invalid
+			return null;
 		}
 		return newLot;
 	}

--- a/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
@@ -436,13 +436,16 @@ public class MovStockMultipleCharging extends JDialog {
 								if (lot == null) {
 									return;
 								}
+								// Lot Cost
+								BigDecimal cost = new BigDecimal(0);
 								if (GeneralData.LOTWITHCOST) {
-									BigDecimal cost = askCost(qty);
+									cost = askCost(qty);
 									if (cost.compareTo(new BigDecimal(0)) == 0) {
 										return;
 									}
-									lot.setCost(cost);
 								}
+								isNewLot = true;
+								lot.setCost(cost);
 							}
 							// Lot Cost
 							BigDecimal cost = lot.getCost();

--- a/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
@@ -477,7 +477,7 @@ public class MovStockMultipleCharging extends JDialog {
 		if (GeneralData.LOTWITHCOST && (cost.equals(BigDecimal.ZERO) || lot.getCost() == null)) {
 			cost = askCost(qty);
 			if (cost.compareTo(BigDecimal.ZERO) == 0) {
-				return false; // Invalid cost, exit the method
+				return false;
 			}
 			lot.setCost(cost);
 		}

--- a/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
@@ -432,9 +432,16 @@ public class MovStockMultipleCharging extends JDialog {
 						do {
 							lot = chooseLot(med);
 							if (lot == null) {
-								lot = askLot();
+								lot = askLot(med);
 								if (lot == null) {
 									return;
+								}
+								if (GeneralData.LOTWITHCOST) {
+									BigDecimal cost = askCost(qty);
+									if (cost.compareTo(new BigDecimal(0)) == 0) {
+										return;
+									}
+									lot.setCost(cost);
 								}
 							}
 							// Lot Cost
@@ -542,7 +549,7 @@ public class MovStockMultipleCharging extends JDialog {
 		return total;
 	}
 
-	protected Lot askLot() {
+	protected Lot askLot(Medical med) {
 		LocalDateTime preparationDate;
 		LocalDateTime expiringDate;
 		Lot lot = null;
@@ -585,6 +592,7 @@ public class MovStockMultipleCharging extends JDialog {
 					expiringDate = expireDateChooser.getDateEndOfDay();
 					preparationDate = preparationDateChooser.getDateStartOfDay();
 					lot = new Lot(lotName, preparationDate, expiringDate);
+					lot.setMedical(med);
 				}
 			} else {
 				return null;

--- a/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
@@ -418,6 +418,7 @@ public class MovStockMultipleCharging extends JDialog {
 						LocalDateTime preparationDate = TimeTools.getNow().truncatedTo(ChronoUnit.MINUTES);
 						LocalDateTime expiringDate = askExpiringDate();
 						lot = new Lot("", preparationDate, expiringDate); //$NON-NLS-1$
+						lot.setMedical(med);
 						// Lot Cost
 						BigDecimal cost = new BigDecimal(0);
 						if (GeneralData.LOTWITHCOST) {

--- a/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
@@ -410,25 +410,13 @@ public class MovStockMultipleCharging extends JDialog {
 						return;
 					}
 
-					// Lot (PreparationDate && ExpiringDate)
+					// Lot
 					Lot lot;
 					boolean isNewLot = false;
 					boolean updateLot = false;
 					if (isAutomaticLotIn()) {
-						LocalDateTime preparationDate = TimeTools.getNow().truncatedTo(ChronoUnit.MINUTES);
-						LocalDateTime expiringDate = askExpiringDate();
-						lot = new Lot("", preparationDate, expiringDate); //$NON-NLS-1$
-						lot.setMedical(med);
-						// Lot Cost
-						BigDecimal cost = new BigDecimal(0);
-						if (GeneralData.LOTWITHCOST) {
-							cost = askCost(qty);
-							if (cost.compareTo(new BigDecimal(0)) == 0) {
-								return;
-							}
-						}
+						lot = createNewLot(med, qty);
 						isNewLot = true;
-						lot.setCost(cost);
 					} else {
 						do {
 							lot = chooseLot(med);
@@ -437,27 +425,18 @@ public class MovStockMultipleCharging extends JDialog {
 								if (lot == null) {
 									return;
 								}
-								// Lot Cost
-								BigDecimal cost = new BigDecimal(0);
-								if (GeneralData.LOTWITHCOST) {
-									cost = askCost(qty);
-									if (cost.compareTo(new BigDecimal(0)) == 0) {
-										return;
-									}
+								if (!setOrValidateCost(lot, qty)) {
+									return;
 								}
 								isNewLot = true;
-								lot.setCost(cost);
 							}
-							// Lot Cost
-							BigDecimal cost = lot.getCost();
-							if ((cost == null || cost.equals(new BigDecimal(0))) && GeneralData.LOTWITHCOST) {
+							// Lot without cost
+							if (needsCostUpdate(lot)) {
 								MessageDialog.warning(null, "angal.medicalstock.multiplecharging.selectedlotwithoutcostpleasespecify", lot.getCode());
-								cost = askCost(qty);
-								if (cost.compareTo(new BigDecimal(0)) == 0) {
+								if (!setOrValidateCost(lot, qty)) {
 									return;
 								}
 								updateLot = true;
-								lot.setCost(cost);
 							}
 						} while (lot == null);
 					}
@@ -479,6 +458,34 @@ public class MovStockMultipleCharging extends JDialog {
 			});
 		}
 		return jTextFieldSearch;
+	}
+
+	private Lot createNewLot(Medical med, int qty) {
+		LocalDateTime preparationDate = TimeTools.getNow().truncatedTo(ChronoUnit.MINUTES);
+		LocalDateTime expiringDate = askExpiringDate();
+		Lot newLot = new Lot("", preparationDate, expiringDate);
+		newLot.setMedical(med);
+
+		if (!setOrValidateCost(newLot, qty)) {
+			return null; // Exit if cost was invalid
+		}
+		return newLot;
+	}
+
+	private boolean setOrValidateCost(Lot lot, int qty) {
+		BigDecimal cost = lot.getCost() != null ? lot.getCost() : BigDecimal.ZERO;
+		if (GeneralData.LOTWITHCOST && (cost.equals(BigDecimal.ZERO) || lot.getCost() == null)) {
+			cost = askCost(qty);
+			if (cost.compareTo(BigDecimal.ZERO) == 0) {
+				return false; // Invalid cost, exit the method
+			}
+			lot.setCost(cost);
+		}
+		return true;
+	}
+
+	private boolean needsCostUpdate(Lot lot) {
+		return (lot.getCost() == null || lot.getCost().equals(BigDecimal.ZERO)) && GeneralData.LOTWITHCOST;
 	}
 
 	private GoodDateTimeSpinnerChooser getJDateChooser() {


### PR DESCRIPTION
See OP-1340.
The point was the missing Medical on a new lot obtained with `askLot` method. We miss the cost also.
So I tried to rearrange the code in a more (hopefully) functional way.