### PR TITLE
workflow: get fork and branch upon pull_request and push events

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,12 +14,41 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      
+      - name: Debug GitHub variables
+        run: |
+          echo "GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}"
+          echo "GITHUB_HEAD_REPOSITORY: ${GITHUB_HEAD_REPOSITORY}"
+          echo "GITHUB_HEAD_REF: ${GITHUB_HEAD_REF}"
+          echo "GITHUB_REPOSITORY: ${GITHUB_REPOSITORY}"
+          echo "GITHUB_REF: ${GITHUB_REF}"
+          echo "GITHUB_ACTOR: ${GITHUB_ACTOR}"
 
       - name: Determine PR source branch and fork repository
         id: vars
         run: |
-          echo "BRANCH_NAME=${GITHUB_HEAD_REF:-develop}" >> $GITHUB_ENV
-          echo "FORK_REPO=${GITHUB_HEAD_REPOSITORY:-informatici/openhospital-core}" >> $GITHUB_ENV
+          # Get branch name from either pull_request or push context
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            # Get branch and fork repo for PR events
+            echo "BRANCH_NAME=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+            echo "FORK_REPO=${GITHUB_HEAD_REPOSITORY:-informatici/openhospital-core}" >> $GITHUB_ENV
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            # Get branch name for push events
+            echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+            # Default FORK_REPO to main repository, with option to fallback if the fork exists
+            OWNER=${GITHUB_ACTOR}
+            if curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/${OWNER}/openhospital-core/branches/${GITHUB_REF##*/}" | grep -q "200"; then
+              echo "FORK_REPO=${OWNER}/openhospital-core" >> $GITHUB_ENV
+            else
+              echo "FORK_REPO=informatici/openhospital-core" >> $GITHUB_ENV
+            fi
+          fi
+
+      - name: Log variables
+        run: |
+          echo "FORK_REPO: ${{ env.FORK_REPO }}"
+          echo "BRANCH_NAME: ${{ env.BRANCH_NAME }}"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,10 +30,9 @@ jobs:
 
       - name: Checkout core
         run: |
-          git clone --depth=50 https://github.com/${{ env.FORK_REPO }}.git openhospital-core
+          git clone --depth=1 --no-single-branch https://github.com/${{ env.FORK_REPO }}.git openhospital-core
           pushd openhospital-core
-          git fetch origin ${{ env.BRANCH_NAME }} || git fetch origin develop
-          git checkout ${{ env.BRANCH_NAME }} || git checkout develop
+          git checkout -B ${{ env.BRANCH_NAME }} origin/${{ env.BRANCH_NAME }} || git checkout develop
           popd
         
       - name: Install core

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,9 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Determine PR source branch
-        id: extract_branch
-        run: echo "BRANCH_NAME=${GITHUB_HEAD_REF:-develop}" >> $GITHUB_ENV
+      - name: Determine PR source branch and fork repository
+        id: vars
+        run: |
+          echo "BRANCH_NAME=${GITHUB_HEAD_REF:-develop}" >> $GITHUB_ENV
+          echo "FORK_REPO=${GITHUB_HEAD_REPOSITORY:-informatici/openhospital-core}" >> $GITHUB_ENV
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -28,14 +30,17 @@ jobs:
 
       - name: Checkout core
         run: |
-          git clone --depth=50 https://github.com/informatici/openhospital-core.git openhospital-core
-          cd openhospital-core
+          git clone --depth=50 https://github.com/${{ env.FORK_REPO }}.git openhospital-core
+          pushd openhospital-core
           git fetch origin ${{ env.BRANCH_NAME }} || git fetch origin develop
           git checkout ${{ env.BRANCH_NAME }} || git checkout develop
-          cd ..
+          popd
         
       - name: Install core
-        run: cd openhospital-core && mvn install -DskipTests=true && cd ..
+        run: |
+          pushd openhospital-core
+          mvn install -DskipTests=true
+          popd
 
       - name: Build GUI with Maven
         run: mvn -B package --file pom.xml


### PR DESCRIPTION
Revised workflow in order to always get the correct origin fork and branch on both `pull_request` and `push` events