### PR TITLE
Fix: log4j/log4j2 mixed syntax

### DIFF
--- a/rsc/.gitignore
+++ b/rsc/.gitignore
@@ -1,1 +1,10 @@
-/generalData.properties
+database.properties
+dicom.properties
+examination.properties
+log4j2-spring.properties
+settings.properties
+sms.properties
+telemetry.properties
+txtPrinter.properties
+xmpp.properties
+

--- a/rsc/log4j2-spring.properties.dist
+++ b/rsc/log4j2-spring.properties.dist
@@ -27,9 +27,9 @@ appender.rolling.policies.time.modulate = true
 # DB Appender (table columns)
 appender.jdbc.type = JDBC
 appender.jdbc.name = jdbc
-appender.jdbc.connectionSource.driverClassName = com.mysql.cj.jdbc.Driver
+appender.jdbc.connectionSource.driverClassName = org.mariadb.jdbc.Driver
 appender.jdbc.connectionSource.type = DriverManager
-appender.jdbc.connectionSource.connectionString = dbc:mysql://DBSERVER:DBPORT/DBNAME?autoReconnect=true
+appender.jdbc.connectionSource.connectionString = dbc:mariadb://DBSERVER:DBPORT/DBNAME?autoReconnect=true
 appender.jdbc.connectionSource.userName = DBUSER
 appender.jdbc.connectionSource.password = DBPASS
 appender.jdbc.tableName = logs
@@ -47,12 +47,13 @@ appender.jdbc.columnConfigs[2].name = MESSAGE
 appender.jdbc.columnConfigs[2].pattern = %mm%ex%n
 appender.jdbc.columnConfigs[2].isUnicode = false
 
-# Security settings - see log4j CVE-2021-44228
-log4j.formatMsgNoLookups=true 
--
 # Assigning appenders to packages (application loggers)
-log4j.logger.org.isf=LOG_LEVEL,RollingFile
-log4j.additivity.org.isf = false
+logger.isf.name = org.isf
+logger.isf.level = debug
+logger.isf.appenderRefs = stdout, rolling
+logger.isf.appenderRef.stdout.ref = STDOUT
+logger.isf.appenderRef.rolling.ref = RollingFile
+logger.isf.additivity = false
 
 # Assigning appenders to Hibernate packages (DB loggers)
 # - hibernate.SQL to DEBUG for SQL queries to be logged

--- a/rsc/log4j2.component.properties
+++ b/rsc/log4j2.component.properties
@@ -1,0 +1,6 @@
+# ===============================
+# Log4j2 Component Properties
+# ===============================
+
+# Security settings - see log4j CVE-2021-44228
+log4j2.formatMsgNoLookups = true


### PR DESCRIPTION
In **Log4j 2** with _.properties_ files, we shouldn't use keys that begin with `log4j.logger` or `log4j.additivity`:

- That's old Log4j 1.x syntax.
- Log4j 2 instead expects the form `logger.<name>.*`

The same goes for `log4j.formatMsgNoLookups=true`: 

- That property is now set via system property (-Dlog4j2.formatMsgNoLookups=true) 
- or in `log4j2.component.properties` (added this file)

OR we can just get rid of the `log4j2.formatMsgNoLookups` and leave to the SA to decide if to manage it or not.