### PR TITLE
Fix for log file path

### DIFF
--- a/rsc/log4j2-spring.properties.dist
+++ b/rsc/log4j2-spring.properties.dist
@@ -13,8 +13,8 @@ appender.console.layout.pattern = [%d{dd/MMM/yyyy HH:mm:ss}] [%X{OHUserGroup}:%X
 # File Appender (with classes), daily rotation
 appender.rolling.type = RollingFile
 appender.rolling.name = RollingFile
-appender.rolling.fileName= LOG_DEST/openhospital.log
-appender.rolling.filePattern= LOG_DEST/openhospital.log.%d{yyyy-MM-dd}
+appender.rolling.fileName= LOG_DEST
+appender.rolling.filePattern= LOG_DEST.%d{yyyy-MM-dd}
 appender.rolling.layout.type = PatternLayout
 appender.rolling.layout.pattern = [%d{dd/MMM/yyyy HH:mm:ss}] [%X{OHUserGroup}:%X{OHUser}] %-p - %m (%l)%n
 appender.rolling.policies.type = Policies


### PR DESCRIPTION
Fix for log file path management: solves the bug that creates the file:

[$OH_PATH]/data/log/openhospital.log/openhospital.log (wrong)

instead of the:

[$OH_PATH]/data/log/openhospital.log (correct)

