### PR TITLE
OP-278 Add reusable table sorting and filtering support

### DIFF
--- a/src/main/java/org/isf/admission/gui/AdmittedPatientBrowser.java
+++ b/src/main/java/org/isf/admission/gui/AdmittedPatientBrowser.java
@@ -52,6 +52,7 @@ import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.RowSorter;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
@@ -62,6 +63,7 @@ import javax.swing.WindowConstants;
 import javax.swing.border.Border;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableRowSorter;
 
 import org.isf.accounting.gui.PatientBillEdit;
 import org.isf.admission.gui.AdmissionBrowser.AdmissionListener;
@@ -104,6 +106,7 @@ import org.isf.utils.jobjects.GoodDateChooser;
 import org.isf.utils.jobjects.MessageDialog;
 import org.isf.utils.jobjects.ModalJFrame;
 import org.isf.utils.jobjects.VoLimitedTextField;
+import org.isf.utils.table.OHTableSortFilter;
 import org.isf.utils.time.TimeTools;
 import org.isf.ward.manager.WardBrowserManager;
 import org.isf.ward.model.Ward;
@@ -155,6 +158,8 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 	private boolean[] pColumnResizable = { false, false, false, false, true, false };
 	private AdmittedPatient patient;
 	private JTable table;
+	private AdmittedPatientBrowserModel model;
+	private TableRowSorter<AdmittedPatientBrowserModel> sorter;
 	private AdmittedPatientBrowser myFrame;
 
 	private WardBrowserManager wardBrowserManager = Context.getApplicationContext().getBean(WardBrowserManager.class);
@@ -207,9 +212,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 		lastKey = "";
 		filterPatient(searchString.getText());
 		try {
-			if (table.getRowCount() > 0) {
-				table.setRowSelectionInterval(row, row);
-			}
+			restoreSelectedViewRow(row);
 		} catch (Exception e1) {
 		}
 	}
@@ -235,9 +238,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 		lastKey = "";
 		filterPatient(searchString.getText());
 		try {
-			if (table.getRowCount() > 0) {
-				table.setRowSelectionInterval(row, row);
-			}
+			restoreSelectedViewRow(row);
 		} catch (Exception e1) {
 		}
 	}
@@ -277,9 +278,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 		lastKey = "";
 		filterPatient(searchString.getText());
 		try {
-			if (table.getRowCount() > 0) {
-				table.setRowSelectionInterval(row, row);
-			}
+			restoreSelectedViewRow(row);
 		} catch (Exception e1) {
 		}
 	}
@@ -296,9 +295,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 		lastKey = "";
 		filterPatient(searchString.getText());
 		try {
-			if (table.getRowCount() > 0) {
-				table.setRowSelectionInterval(0, 0);
-			}
+			restoreSelectedViewRow(0);
 		} catch (Exception e1) {
 		}
 		searchString.requestFocus();
@@ -324,7 +321,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 		lastKey = "";
 		filterPatient(searchString.getText());
 		try {
-			table.setRowSelectionInterval(row, row);
+			restoreSelectedViewRow(row);
 		} catch (Exception e1) {
 		}
 		searchString.requestFocus();
@@ -496,6 +493,11 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 						jSearchButton.doClick();
 					}
 				}
+
+				@Override
+				public void keyReleased(KeyEvent e) {
+					applyNaturalTextFilter();
+				}
 			});
 		} else {
 			searchString.addKeyListener(new KeyListener() {
@@ -644,7 +646,9 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 	}
 
 	private JScrollPane getScrollPane() {
-		table = new JTable(new AdmittedPatientBrowserModel(null));
+		model = new AdmittedPatientBrowserModel(null);
+		table = new JTable(model);
+		sorter = OHTableSortFilter.installSorter(table, model);
 		table.setAutoCreateColumnsFromModel(false);
 
 		for (int i = 0; i < pColumns.length; i++) {
@@ -725,7 +729,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 				MessageDialog.error(null, "angal.common.pleaseselectapatient.msg");
 				return;
 			}
-			patient = (AdmittedPatient) table.getValueAt(table.getSelectedRow(), -1);
+			patient = getSelectedAdmittedPatient();
 			PatientHistory ph = new PatientHistory();
 			ph.setPatientId(patient.getPatient().getCode());
 			PatientHistory patientHistory = Optional.ofNullable(patientHistoryManager.getByPatientId(patient.getPatient().getCode())).orElse(ph);
@@ -749,7 +753,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 					MessageDialog.error(null, "angal.common.pleaseselectapatient.msg");
 					return;
 				}
-				patient = (AdmittedPatient) table.getValueAt(table.getSelectedRow(), -1);
+				patient = getSelectedAdmittedPatient();
 				Patient pat = patient.getPatient();
 
 				PatientExamination patex;
@@ -805,7 +809,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 				MessageDialog.error(this, "angal.common.pleaseselectapatient.msg");
 				return;
 			}
-			patient = reloadSelectedPatient(table.getSelectedRow());
+			patient = reloadSelectedPatient();
 			if (GeneralData.PATIENTEXTENDED) {
 
 				PatientInsertExtended editrecord = new PatientInsertExtended(this, patient.getPatient(), false);
@@ -828,7 +832,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 				MessageDialog.error(this, "angal.common.pleaseselectapatient.msg");
 				return;
 			}
-			patient = (AdmittedPatient) table.getValueAt(table.getSelectedRow(), -1);
+			patient = getSelectedAdmittedPatient();
 			Patient pat = patient.getPatient();
 
 			int n = MessageDialog.yesNo(this, "angal.admission.deletepatient.fmt.msg", pat.getName());
@@ -867,7 +871,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 				MessageDialog.error(this, "angal.common.pleaseselectapatient.msg");
 				return;
 			}
-			patient = reloadSelectedPatient(table.getSelectedRow());
+			patient = reloadSelectedPatient();
 			if (patient.getAdmission() != null) {
 				// edit previous admission or discharge
 				new AdmissionBrowser(myFrame, patient, true);
@@ -879,8 +883,8 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 		return buttonAdmission;
 	}
 
-	private AdmittedPatient reloadSelectedPatient(int selectedRow) {
-		AdmittedPatient selectedPatient = (AdmittedPatient) table.getValueAt(selectedRow, -1);
+	private AdmittedPatient reloadSelectedPatient() {
+		AdmittedPatient selectedPatient = getSelectedAdmittedPatient();
 		// Reloading patient, with profile initialised.
 		return admissionBrowserManager.loadAdmittedPatients(selectedPatient.getPatient().getCode());
 	}
@@ -893,7 +897,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 				MessageDialog.error(this, "angal.common.pleaseselectapatient.msg");
 				return;
 			}
-			patient = reloadSelectedPatient(table.getSelectedRow());
+			patient = reloadSelectedPatient();
 
 			if (patient != null) {
 				Opd opd = new Opd(0, ' ', -1, new Disease());
@@ -913,7 +917,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 				MessageDialog.error(this, "angal.common.pleaseselectapatient.msg");
 				return;
 			}
-			patient = reloadSelectedPatient(table.getSelectedRow());
+			patient = reloadSelectedPatient();
 			Laboratory laboratory = new Laboratory(0, new Exam("", "", new ExamType("", ""), 0, ""), TimeTools.getNow(), "P", "", new Patient(), "");
 			if (GeneralData.LABEXTENDED) {
 				if (GeneralData.LABMULTIPLEINSERT) {
@@ -939,7 +943,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 				MessageDialog.error(this, "angal.common.pleaseselectapatient.msg");
 				return;
 			}
-			patient = reloadSelectedPatient(table.getSelectedRow());
+			patient = reloadSelectedPatient();
 
 			if (patient != null) {
 				Patient pat = patient.getPatient();
@@ -958,7 +962,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 				MessageDialog.error(this, "angal.common.pleaseselectapatient.msg");
 				return;
 			}
-			patient = reloadSelectedPatient(table.getSelectedRow());
+			patient = reloadSelectedPatient();
 
 			PatientDataBrowser pdb = new PatientDataBrowser(myFrame, patient.getPatient());
 			pdb.addDeleteAdmissionListener(myFrame);
@@ -975,7 +979,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 				MessageDialog.error(this, "angal.common.pleaseselectapatient.msg");
 				return;
 			}
-			patient = reloadSelectedPatient(table.getSelectedRow());
+			patient = reloadSelectedPatient();
 			DicomGui dg = new DicomGui(patient.getPatient(), this);
 			dg.showAsModal(this);
 		});
@@ -990,7 +994,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 				MessageDialog.error(this, "angal.common.pleaseselectapatient.msg");
 				return;
 			}
-			patient = reloadSelectedPatient(table.getSelectedRow());
+			patient = reloadSelectedPatient();
 
 			new PatientFolderBrowser(myFrame, patient.getPatient()).showAsModal(this);
 		});
@@ -1005,7 +1009,7 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 				MessageDialog.error(this, "angal.common.pleaseselectapatient.msg");
 				return;
 			}
-			patient = reloadSelectedPatient(table.getSelectedRow());
+			patient = reloadSelectedPatient();
 
 			TherapyEdit therapy = new TherapyEdit(this, patient.getPatient(), patient.getAdmission() != null);
 			therapy.setLocationRelativeTo(null);
@@ -1024,11 +1028,11 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 				return;
 			}
 
-			int[] indexes = table.getSelectedRows();
+			int[] indexes = OHTableSortFilter.getSelectedModelRows(table);
 
 			Patient mergedPatient;
-			Patient patient1 = ((AdmittedPatient) table.getValueAt(indexes[0], -1)).getPatient();
-			Patient patient2 = ((AdmittedPatient) table.getValueAt(indexes[1], -1)).getPatient();
+			Patient patient1 = ((AdmittedPatient) model.getValueAt(indexes[0], -1)).getPatient();
+			Patient patient2 = ((AdmittedPatient) model.getValueAt(indexes[1], -1)).getPatient();
 
 			// Select most recent patient
 			if (patient1.getCode() > patient2.getCode()) {
@@ -1088,9 +1092,32 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 	}
 
 	private void filterPatient(String key) {
-		table.setModel(new AdmittedPatientBrowserModel(key));
+		List<? extends RowSorter.SortKey> sortKeys = sorter == null ? List.of() : new ArrayList<>(sorter.getSortKeys());
+		model = new AdmittedPatientBrowserModel(key);
+		sorter = OHTableSortFilter.installSorter(table, model);
+		sorter.setSortKeys(sortKeys);
+		applyNaturalTextFilter();
 		rowCounter.setText(MessageBundle.formatMessage("angal.admission.count.fmt.txt", table.getRowCount()));
 		searchString.requestFocus();
+	}
+
+	private void applyNaturalTextFilter() {
+		OHTableSortFilter.applyNaturalTextFilter(table, sorter, searchString.getText());
+		if (rowCounter != null && table != null) {
+			rowCounter.setText(MessageBundle.formatMessage("angal.admission.count.fmt.txt", table.getRowCount()));
+		}
+	}
+
+	private AdmittedPatient getSelectedAdmittedPatient() {
+		int selectedModelRow = OHTableSortFilter.getSelectedModelRow(table);
+		return (AdmittedPatient) model.getValueAt(selectedModelRow, -1);
+	}
+
+	private void restoreSelectedViewRow(int selectedViewRow) {
+		if (table.getRowCount() > 0 && selectedViewRow > -1) {
+			int row = Math.min(selectedViewRow, table.getRowCount() - 1);
+			table.setRowSelectionInterval(row, row);
+		}
 	}
 
 	private void searchPatient() {

--- a/src/main/java/org/isf/exa/gui/ExamBrowser.java
+++ b/src/main/java/org/isf/exa/gui/ExamBrowser.java
@@ -75,6 +75,7 @@ public class ExamBrowser extends ModalJFrame implements ExamListener {
 			MessageBundle.getMessage("angal.exa.default.col").toUpperCase()
 	};
 	private int[] pColumnWidth = { 60, 330, 160, 60, 200 };
+	private Class[] pColumnClass = { String.class, String.class, String.class, Integer.class, String.class };
 	private Exam exam;
 
 	private DefaultTableModel model ;
@@ -379,6 +380,11 @@ public class ExamBrowser extends ModalJFrame implements ExamListener {
 				return exam.getDefaultResult();
 			}
 			return null;
+		}
+
+		@Override
+		public Class<?> getColumnClass(int columnIndex) {
+			return pColumnClass[columnIndex];
 		}
 		
 		@Override

--- a/src/main/java/org/isf/exa/gui/ExamBrowser.java
+++ b/src/main/java/org/isf/exa/gui/ExamBrowser.java
@@ -26,6 +26,7 @@ import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.util.List;
+import java.util.Locale;
 
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -35,9 +36,14 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
+import javax.swing.JTextField;
 import javax.swing.ListSelectionModel;
+import javax.swing.RowFilter;
 import javax.swing.WindowConstants;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableRowSorter;
 
 import org.isf.exa.gui.ExamEdit.ExamListener;
 import org.isf.exa.manager.ExamBrowsingManager;
@@ -73,6 +79,8 @@ public class ExamBrowser extends ModalJFrame implements ExamListener {
 
 	private DefaultTableModel model ;
 	private JTable table;
+	private JTextField searchField;
+	private TableRowSorter<DefaultTableModel> sorter;
 	private final JFrame myFrame;
 	private JButton jButtonNew;
 	private JButton jButtonEdit;
@@ -109,6 +117,8 @@ public class ExamBrowser extends ModalJFrame implements ExamListener {
 			buttonPanel = new JPanel(new FlowLayout(FlowLayout.CENTER, 5, 5));
 			buttonPanel.add(new JLabel(MessageBundle.getMessage("angal.exa.selecttype")));
 			buttonPanel.add(getJComboBoxExamType());
+			buttonPanel.add(new JLabel(MessageBundle.getMessage("angal.common.search.txt")));
+			buttonPanel.add(getSearchField());
 			buttonPanel.add(getJButtonNew());
 			buttonPanel.add(getJButtonEdit());
 			buttonPanel.add(getJButtonDelete());
@@ -143,6 +153,8 @@ public class ExamBrowser extends ModalJFrame implements ExamListener {
 		if (table == null) {
 			model = new ExamBrowsingModel();
 			table = new JTable(model);
+			sorter = new TableRowSorter<>(model);
+			table.setRowSorter(sorter);
 			table.setAutoCreateColumnsFromModel(false);
 			table.getColumnModel().getColumn(0).setMinWidth(pColumnWidth[0]);
 			table.getColumnModel().getColumn(1).setMinWidth(pColumnWidth[1]);
@@ -152,13 +164,76 @@ public class ExamBrowser extends ModalJFrame implements ExamListener {
 			table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 			table.getSelectionModel().addListSelectionListener(selectionEvent -> {
 				if (!selectionEvent.getValueIsAdjusting()) {
-					selectedrow = table.convertRowIndexToModel(table.getSelectedRow());
+					int selectedViewRow = table.getSelectedRow();
+					if (selectedViewRow < 0) {
+						selectedrow = -1;
+						exam = null;
+						jButtonShow.setEnabled(false);
+						return;
+					}
+					selectedrow = table.convertRowIndexToModel(selectedViewRow);
 					exam = (Exam) model.getValueAt(selectedrow, -1);
 					jButtonShow.setEnabled(exam.getProcedure() != 3);
 				}
 			});
 		}
 		return table;
+	}
+
+	private JTextField getSearchField() {
+		if (searchField == null) {
+			searchField = new JTextField(15);
+			searchField.getDocument().addDocumentListener(new DocumentListener() {
+
+				@Override
+				public void insertUpdate(DocumentEvent e) {
+					applySearchFilter();
+				}
+
+				@Override
+				public void removeUpdate(DocumentEvent e) {
+					applySearchFilter();
+				}
+
+				@Override
+				public void changedUpdate(DocumentEvent e) {
+					applySearchFilter();
+				}
+			});
+		}
+		return searchField;
+	}
+
+	private void applySearchFilter() {
+		if (sorter == null || searchField == null) {
+			return;
+		}
+		String searchText = searchField.getText().trim().toLowerCase(Locale.ROOT);
+		if (searchText.isEmpty()) {
+			sorter.setRowFilter(null);
+			return;
+		}
+		String[] chunks = searchText.split("\\s+");
+		sorter.setRowFilter(new RowFilter<DefaultTableModel, Integer>() {
+
+			@Override
+			public boolean include(Entry<? extends DefaultTableModel, ? extends Integer> entry) {
+				for (String chunk : chunks) {
+					boolean found = false;
+					for (int i = 0; i < entry.getValueCount(); i++) {
+						String value = entry.getStringValue(i);
+						if (value != null && value.toLowerCase(Locale.ROOT).contains(chunk)) {
+							found = true;
+							break;
+						}
+					}
+					if (!found) {
+						return false;
+					}
+				}
+				return true;
+			}
+		});
 	}
 
 	private JButton getJButtonDelete() {
@@ -316,7 +391,10 @@ public class ExamBrowser extends ModalJFrame implements ExamListener {
 	public void examUpdated(AWTEvent e) {
 		reloadTable();
 		if (table.getRowCount() > 0 && selectedrow > -1) {
-			table.setRowSelectionInterval(selectedrow, selectedrow);
+			int selectedViewRow = table.convertRowIndexToView(selectedrow);
+			if (selectedViewRow > -1) {
+				table.setRowSelectionInterval(selectedViewRow, selectedViewRow);
+			}
 		}
 	}
 
@@ -336,6 +414,10 @@ public class ExamBrowser extends ModalJFrame implements ExamListener {
 			model = new ExamBrowsingModel(pSelection);
 		}
 		model.fireTableDataChanged();
+		table.setModel(model);
+		sorter = new TableRowSorter<>(model);
+		table.setRowSorter(sorter);
+		applySearchFilter();
 		table.updateUI();
 	}
 

--- a/src/main/java/org/isf/opd/gui/OpdBrowser.java
+++ b/src/main/java/org/isf/opd/gui/OpdBrowser.java
@@ -59,10 +59,13 @@ import javax.swing.JTextField;
 import javax.swing.ListSelectionModel;
 import javax.swing.SpringLayout;
 import javax.swing.SwingConstants;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableRowSorter;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.DefaultStyledDocument;
@@ -85,6 +88,7 @@ import org.isf.utils.jobjects.MessageDialog;
 import org.isf.utils.jobjects.ModalJFrame;
 import org.isf.utils.jobjects.VoLimitedTextField;
 import org.isf.utils.layout.SpringUtilities;
+import org.isf.utils.table.OHTableSortFilter;
 import org.isf.utils.time.TimeTools;
 import org.isf.ward.manager.WardBrowserManager;
 import org.isf.ward.model.Ward;
@@ -145,7 +149,9 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 	private List<Opd> pSur;
 	private JTable jTable;
 	private OpdBrowsingModel model;
+	private TableRowSorter<OpdBrowsingModel> sorter;
 	private int[] pColumnWidth = {50, 80, 100, 130, 70, 150, 30, 30, 195, 195, 50, 50};
+	private Class[] pColumnClass = {Integer.class, Integer.class, String.class, String.class, Integer.class, String.class, String.class, Integer.class, String.class, String.class, String.class, String.class};
 	private boolean[] columnResizable = { false, false, false, false, false, true, false, false, true, true, false, false };
 	private boolean[] columnsVisible = { true, true, GeneralData.OPDEXTENDED, true, GeneralData.OPDEXTENDED, GeneralData.OPDEXTENDED, true, true, true, true, true, !isSingleUser };
 	private int[] columnsAlignment = { SwingConstants.LEFT, SwingConstants.LEFT, SwingConstants.LEFT, SwingConstants.LEFT, SwingConstants.CENTER, SwingConstants.LEFT, SwingConstants.CENTER, SwingConstants.CENTER, SwingConstants.LEFT, SwingConstants.LEFT, SwingConstants.LEFT, SwingConstants.LEFT };
@@ -167,6 +173,7 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 	private JTextField opdCodeFilter;
 	private JTextField progYearFilter;
 	private JTextField patientCodeFilter;
+	private JTextField naturalTextFilter;
 	private JRadioButton radioMyPatients;
 	private JRadioButton radioAllPatients;
 
@@ -174,6 +181,7 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 		if (jTable == null) {
 			model = new OpdBrowsingModel();
 			jTable = new JTable(model);
+			sorter = OHTableSortFilter.installSorter(jTable, model);
 			jTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 			TableColumnModel columnModel = jTable.getColumnModel();
 			DefaultTableCellRenderer cellRenderer = new DefaultTableCellRenderer();
@@ -325,7 +333,7 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 					MessageDialog.error(this, "angal.common.pleaseselectarow.msg");
 					return;
 				}
-				selectedrow = jTable.getSelectedRow();
+				selectedrow = OHTableSortFilter.getSelectedModelRow(jTable);
 				Opd opd = (Opd) model.getValueAt(selectedrow, -1);
 				if (GeneralData.OPDEXTENDED) {
 					OpdEditExtended editrecord = new OpdEditExtended(myFrame, opd, false);
@@ -370,7 +378,8 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 					MessageDialog.error(this, "angal.common.pleaseselectarow.msg");
 					return;
 				}
-				Opd opd = (Opd) model.getValueAt(jTable.getSelectedRow(), -1);
+				int selectedModelRow = OHTableSortFilter.getSelectedModelRow(jTable);
+				Opd opd = (Opd) model.getValueAt(selectedModelRow, -1);
 
 				String message;
 				if (GeneralData.OPDEXTENDED) {
@@ -403,8 +412,9 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 				try {
 					if (n == JOptionPane.YES_OPTION) {
 						opdBrowserManager.deleteOpd(opd);
-						pSur.remove(pSur.size() - jTable.getSelectedRow() - 1);
-						model.fireTableDataChanged();
+						pSur.remove(pSur.size() - selectedModelRow - 1);
+						((AbstractTableModel) jTable.getModel()).fireTableDataChanged();
+						applySearchFilter();
 						jTable.updateUI();
 					}
 				} catch (OHServiceException ohServiceException) {
@@ -496,13 +506,33 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 		progYearFilter.addKeyListener(new SearchByProgYearListener());
 		patientCodeFilter = new JTextField(3);
 		patientCodeFilter.addKeyListener(new SearchByPatientIdListener());
+		naturalTextFilter = new JTextField(10);
+		naturalTextFilter.getDocument().addDocumentListener(new DocumentListener() {
+
+			@Override
+			public void insertUpdate(DocumentEvent e) {
+				applySearchFilter();
+			}
+
+			@Override
+			public void removeUpdate(DocumentEvent e) {
+				applySearchFilter();
+			}
+
+			@Override
+			public void changedUpdate(DocumentEvent e) {
+				applySearchFilter();
+			}
+		});
 		searchCodesPanel.add(new JLabel(MessageBundle.getMessage("angal.common.code.txt")));
 		searchCodesPanel.add(new JLabel(MessageBundle.getMessage("angal.opd.opdnumber.txt")));
 		searchCodesPanel.add(new JLabel(MessageBundle.getMessage("angal.common.patientID")));
+		searchCodesPanel.add(new JLabel(MessageBundle.getMessage("angal.common.search.txt")));
 		searchCodesPanel.add(opdCodeFilter);
 		searchCodesPanel.add(progYearFilter);
 		searchCodesPanel.add(patientCodeFilter);
-		SpringUtilities.makeCompactGrid(searchCodesPanel, 2, 3, 5, 5, 5, 5);
+		searchCodesPanel.add(naturalTextFilter);
+		SpringUtilities.makeCompactGrid(searchCodesPanel, 2, 4, 5, 5, 5, 5);
 		return searchCodesPanel;
 	}
 
@@ -528,6 +558,9 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 		if (patientCodeFilter != null) {
 			patientCodeFilter.setText("");
 		}
+		if (naturalTextFilter != null) {
+			naturalTextFilter.setText("");
+		}
 		resetDates();
 		jAgeFromTextField.setText("0");
 		ageFrom = 0;
@@ -536,6 +569,11 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 		radioAllGender.setSelected(true);
 		radioAllPatiens.setSelected(true);
 		radioAllPatients.setSelected(true);
+	}
+
+	private void applySearchFilter() {
+		OHTableSortFilter.applyNaturalTextFilter(jTable, sorter, naturalTextFilter.getText());
+		rowCounter.setText(rowCounterText + jTable.getRowCount());
 	}
 	
 	private JLabel getRowCounter() {
@@ -990,7 +1028,7 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 			} else if (c == ++i) {
 				return pat != null ? opd.getFullName() : null;
 			} else if (c == ++i) {
-				return opd.getSex();
+				return String.valueOf(opd.getSex());
 			} else if (c == ++i) {
 				return opd.getAge();
 			} else if (c == ++i) {
@@ -1012,6 +1050,11 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 		}
 
 		@Override
+		public Class<?> getColumnClass(int columnIndex) {
+			return pColumnClass[columnIndex];
+		}
+
+		@Override
 		public boolean isCellEditable(int arg0, int arg1) {
 			return false;
 		}
@@ -1023,19 +1066,22 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 		((OpdBrowsingModel) jTable.getModel()).fireTableDataChanged();
 		jTable.updateUI();
 		if (jTable.getRowCount() > 0 && selectedrow > -1) {
-			jTable.setRowSelectionInterval(selectedrow, selectedrow);
+			int selectedViewRow = jTable.convertRowIndexToView(selectedrow);
+			if (selectedViewRow > -1) {
+				jTable.setRowSelectionInterval(selectedViewRow, selectedViewRow);
+			}
 		}
-		rowCounter.setText(rowCounterText + pSur.size());
+		applySearchFilter();
 	}
 
 	@Override
 	public void surgeryInserted(AWTEvent e, Opd opd) {
 		pSur.add(pSur.size(), opd);
 		((OpdBrowsingModel) jTable.getModel()).fireTableDataChanged();
+		applySearchFilter();
 		if (jTable.getRowCount() > 0) {
 			jTable.setRowSelectionInterval(0, 0);
 		}
-		rowCounter.setText(rowCounterText + pSur.size());
 	}
 	
 	private JButton getFilterButton() {
@@ -1091,10 +1137,10 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 				opdCodeFilter.setText("");
 				progYearFilter.setText("");
 				patientCodeFilter.setText("");
-				model = new OpdBrowsingModel(ward, diseasetype, disease, dateFrom.getDate(), dateTo.getDate(), ageFrom, ageTo, sex, newPatient, user);
-				model.fireTableDataChanged();
+				new OpdBrowsingModel(ward, diseasetype, disease, dateFrom.getDate(), dateTo.getDate(), ageFrom, ageTo, sex, newPatient, user);
+				((AbstractTableModel) jTable.getModel()).fireTableDataChanged();
+				applySearchFilter();
 				jTable.updateUI();
-				rowCounter.setText(rowCounterText + pSur.size());
 			});
 		}
 		return filterButton;
@@ -1153,7 +1199,7 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 					opdList.add(opd.get());
 					pSur = opdList;
 					((AbstractTableModel) jTable.getModel()).fireTableDataChanged();
-					rowCounter.setText(rowCounterText + pSur.size());
+					applySearchFilter();
 				} else {
 					MessageDialog.info(OpdBrowser.this, "angal.common.nodatatoshow.msg");
 				}
@@ -1183,7 +1229,7 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 				patientCodeFilter.setText("");
 				pSur = opdBrowserManager.getOpdByProgYear(code);
 				((AbstractTableModel) jTable.getModel()).fireTableDataChanged();
-				rowCounter.setText(rowCounterText + pSur.size());
+				applySearchFilter();
 				if (pSur.isEmpty()) {
 					MessageDialog.info(OpdBrowser.this, "angal.common.nodatatoshow.msg");
 				}
@@ -1214,7 +1260,7 @@ public class OpdBrowser extends ModalJFrame implements OpdEdit.SurgeryListener, 
 				try {
 					pSur = opdBrowserManager.getOpdList(code);
 					((AbstractTableModel) jTable.getModel()).fireTableDataChanged();
-					rowCounter.setText(rowCounterText + pSur.size());
+					applySearchFilter();
 					if (pSur.isEmpty()) {
 						MessageDialog.info(OpdBrowser.this, "angal.common.nodatatoshow.msg");
 					}

--- a/src/main/java/org/isf/utils/table/OHTableSortFilter.java
+++ b/src/main/java/org/isf/utils/table/OHTableSortFilter.java
@@ -1,0 +1,104 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright (C) 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.utils.table;
+
+import java.util.Locale;
+
+import javax.swing.JTable;
+import javax.swing.RowFilter;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableModel;
+import javax.swing.table.TableRowSorter;
+
+/**
+ * Utility methods for browser tables using {@link TableRowSorter}.
+ */
+public final class OHTableSortFilter {
+
+	private OHTableSortFilter() {
+	}
+
+	public static <T extends TableModel> TableRowSorter<T> installSorter(JTable table, T model) {
+		TableRowSorter<T> sorter = new TableRowSorter<>(model);
+		table.setModel(model);
+		table.setRowSorter(sorter);
+		return sorter;
+	}
+
+	public static <T extends TableModel> void applyNaturalTextFilter(JTable table, TableRowSorter<T> sorter, String text) {
+		if (sorter == null) {
+			return;
+		}
+
+		String filterText = text == null ? "" : text.trim().toLowerCase(Locale.ROOT);
+		if (filterText.isEmpty()) {
+			sorter.setRowFilter(null);
+			return;
+		}
+
+		String[] chunks = filterText.split("\\s+");
+		sorter.setRowFilter(new RowFilter<T, Integer>() {
+
+			@Override
+			public boolean include(Entry<? extends T, ? extends Integer> entry) {
+				for (String chunk : chunks) {
+					boolean found = false;
+					for (int viewColumn = 0; viewColumn < table.getColumnCount(); viewColumn++) {
+						if (!isColumnVisible(table, viewColumn)) {
+							continue;
+						}
+						String value = entry.getStringValue(table.convertColumnIndexToModel(viewColumn));
+						if (value != null && value.toLowerCase(Locale.ROOT).contains(chunk)) {
+							found = true;
+							break;
+						}
+					}
+					if (!found) {
+						return false;
+					}
+				}
+				return true;
+			}
+		});
+	}
+
+	public static int getSelectedModelRow(JTable table) {
+		int selectedRow = table.getSelectedRow();
+		if (selectedRow < 0) {
+			return -1;
+		}
+		return table.convertRowIndexToModel(selectedRow);
+	}
+
+	public static int[] getSelectedModelRows(JTable table) {
+		int[] selectedRows = table.getSelectedRows();
+		for (int i = 0; i < selectedRows.length; i++) {
+			selectedRows[i] = table.convertRowIndexToModel(selectedRows[i]);
+		}
+		return selectedRows;
+	}
+
+	private static boolean isColumnVisible(JTable table, int viewColumn) {
+		TableColumn column = table.getColumnModel().getColumn(viewColumn);
+		return column.getWidth() > 0 || column.getMinWidth() > 0 || column.getMaxWidth() > 0 || column.getPreferredWidth() > 0;
+	}
+}

--- a/src/main/java/org/isf/ward/gui/WardBrowser.java
+++ b/src/main/java/org/isf/ward/gui/WardBrowser.java
@@ -115,7 +115,21 @@ public class WardBrowser extends ModalJFrame implements WardListener {
 			MessageBundle.getMessage("angal.ward.duration.col").toUpperCase()
 	};
 	private int[] pColumnWidth = {45, 80, 60, 60, 80, 30, 30, 30, 30, 30, 30, 30, 30};
-	private Class[] pColumnClass = {String.class, String.class, String.class, String.class, String.class, String.class, String.class, String.class, Boolean.class, Boolean.class, Boolean.class, Boolean.class, int.class};
+	private Class[] pColumnClass = {
+		String.class,
+		String.class,
+		String.class,
+		String.class,
+		String.class,
+		Integer.class,
+		Integer.class,
+		Integer.class,
+		Boolean.class,
+		Boolean.class,
+		Boolean.class,
+		Boolean.class,
+		Integer.class
+	};
 	private int selectedrow;
 	private List<Ward> pWard;
 	private Ward ward;

--- a/src/main/java/org/isf/ward/gui/WardBrowser.java
+++ b/src/main/java/org/isf/ward/gui/WardBrowser.java
@@ -33,8 +33,12 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableRowSorter;
 
 import org.isf.generaldata.MessageBundle;
 import org.isf.menu.manager.Context;
@@ -42,6 +46,7 @@ import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.gui.OHServiceExceptionUtil;
 import org.isf.utils.jobjects.MessageDialog;
 import org.isf.utils.jobjects.ModalJFrame;
+import org.isf.utils.table.OHTableSortFilter;
 import org.isf.ward.gui.WardEdit.WardListener;
 import org.isf.ward.manager.WardBrowserManager;
 import org.isf.ward.model.Ward;
@@ -73,7 +78,10 @@ public class WardBrowser extends ModalJFrame implements WardListener {
 		((WardBrowserModel) table.getModel()).fireTableDataChanged();
 		table.updateUI();
 		if (table.getRowCount() > 0 && selectedrow > -1) {
-			table.setRowSelectionInterval(selectedrow, selectedrow);
+			int selectedViewRow = table.convertRowIndexToView(selectedrow);
+			if (selectedViewRow > -1) {
+				table.setRowSelectionInterval(selectedViewRow, selectedViewRow);
+			}
 		}
 	}
 
@@ -87,7 +95,9 @@ public class WardBrowser extends ModalJFrame implements WardListener {
 	private JButton jCloseButton;
 	private JScrollPane jScrollPane;
 	private JTable table;
+	private JTextField searchField;
 	private DefaultTableModel model;
+	private TableRowSorter<DefaultTableModel> sorter;
 	private String[] pColumns = {
 			MessageBundle.getMessage("angal.common.code.txt").toUpperCase(),
 			MessageBundle.getMessage("angal.common.name.txt").toUpperCase(),
@@ -155,6 +165,8 @@ public class WardBrowser extends ModalJFrame implements WardListener {
 	private JPanel getJButtonPanel() {
 		if (jButtonPanel == null) {
 			jButtonPanel = new JPanel(new WrapLayout());
+			jButtonPanel.add(new JLabel(MessageBundle.getMessage("angal.common.search.txt")));
+			jButtonPanel.add(getSearchField());
 			jButtonPanel.add(getJNewButton(), null);
 			jButtonPanel.add(getJEditButton(), null);
 			jButtonPanel.add(getJDeleteButton(), null);
@@ -176,8 +188,8 @@ public class WardBrowser extends ModalJFrame implements WardListener {
 				if (table.getSelectedRow() < 0) {
 					MessageDialog.error(null, "angal.common.pleaseselectarow.msg");
 				} else {
-					selectedrow = table.getSelectedRow();
-					ward = (Ward) model.getValueAt(table.getSelectedRow(), -1);
+					selectedrow = OHTableSortFilter.getSelectedModelRow(table);
+					ward = (Ward) model.getValueAt(selectedrow, -1);
 					WardEdit editrecord = new WardEdit(myFrame, ward, false);
 					editrecord.addWardListener(this);
 					editrecord.setVisible(true);
@@ -219,12 +231,13 @@ public class WardBrowser extends ModalJFrame implements WardListener {
 				if (table.getSelectedRow() < 0) {
 					MessageDialog.error(this, "angal.common.pleaseselectarow.msg");
 				} else {
-					Ward ward = (Ward) model.getValueAt(table.getSelectedRow(), -1);
+					int selectedModelRow = OHTableSortFilter.getSelectedModelRow(table);
+					Ward ward = (Ward) model.getValueAt(selectedModelRow, -1);
 					int answer = MessageDialog.yesNo(this, "angal.ward.deleteward.fmt.msg", ward.getDescription());
 					try {
 						if (answer == JOptionPane.YES_OPTION) {
 							wardBrowserManager.deleteWard(ward);
-							pWard.remove(table.getSelectedRow());
+							pWard.remove(selectedModelRow);
 							model.fireTableDataChanged();
 							table.updateUI();
 						}
@@ -250,6 +263,34 @@ public class WardBrowser extends ModalJFrame implements WardListener {
 		}
 		return jCloseButton;
 	}
+
+	private JTextField getSearchField() {
+		if (searchField == null) {
+			searchField = new JTextField(15);
+			searchField.getDocument().addDocumentListener(new DocumentListener() {
+
+				@Override
+				public void insertUpdate(DocumentEvent e) {
+					applySearchFilter();
+				}
+
+				@Override
+				public void removeUpdate(DocumentEvent e) {
+					applySearchFilter();
+				}
+
+				@Override
+				public void changedUpdate(DocumentEvent e) {
+					applySearchFilter();
+				}
+			});
+		}
+		return searchField;
+	}
+
+	private void applySearchFilter() {
+		OHTableSortFilter.applyNaturalTextFilter(table, sorter, searchField.getText());
+	}
 	
 	/**
 	 * This method initializes jScrollPane	
@@ -273,6 +314,7 @@ public class WardBrowser extends ModalJFrame implements WardListener {
 		if (table == null) {
 			model = new WardBrowserModel();
 			table = new JTable(model);
+			sorter = OHTableSortFilter.installSorter(table, model);
 			TableColumnModel columnModel = table.getColumnModel();
 			columnModel.getColumn(0).setMaxWidth(pColumnWidth[0]);
 			columnModel.getColumn(1).setPreferredWidth(pColumnWidth[1]);

--- a/src/main/java/org/isf/ward/gui/WardBrowser.java
+++ b/src/main/java/org/isf/ward/gui/WardBrowser.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import javax.swing.JButton;
 import javax.swing.JFrame;
+import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;


### PR DESCRIPTION
## Description

This PR works on OP-278 by adding reusable sorting and filtering support for selected OpenHospital GUI tables.

It uses `TableRowSorter` with natural text filtering, so searches are case-insensitive and can match multiple search terms across a row. I also updated selected-row handling so actions like Edit, Delete, and Results still use the correct row after sorting or filtering.

## Changes

- Added `TableRowSorter` and natural text filtering to Exam Browser
- Added `getColumnClass()` support in Exam Browser so the Procedure column sorts numerically
- Added a reusable `OHTableSortFilter` helper to avoid repeating the same sorter/filter setup in each browser
- Applied the reusable sorting/filtering pattern to Ward Browser
- Updated selected-row handling in the modified browsers to convert view rows back to model rows after sorting/filtering
- Fixed Ward Browser numeric column classes so beds/nurses/doctors/duration sort without cast exceptions
- Applied the reusable sorting/filtering pattern to OPD Browser

## Testing

- Ran `mvn -DskipTests compile`
- Ran `mvn -DskipTests package`
- Manually tested Exam Browser search, sorting, Edit, and Results
- Manually tested Ward Browser search, sorting, Edit, Delete validation/confirmation flow, and numeric column sorting
- Loaded demo data using `sql/load_demo_data.sql`
- Manually tested OPD Browser search, sorting, Edit, and Delete confirmation flow with demo data
- Manually tested Admitted Patient Browser search, sorting, existing filters, and selected-row actions