### PR TITLE
OP-1383 Fix XMPP i18n key typo and align language bundles

### DIFF
--- a/bundle/language_am_ET.properties
+++ b/bundle/language_am_ET.properties
@@ -1824,7 +1824,7 @@ angal.xmpp.isnowoffline.txt                                                     
 angal.xmpp.isnowonline.txt                                                                             = አሁን መስመር ላይ/ኦንላይን ነው።
 angal.xmpp.me.txt                                                                                      = እኔ
 angal.xmpp.sendfile.txt                                                                                = ፋይል ላክ
-angal.xmpp.thefiletransferofbetweenyouandendedsuccesfully.fmt.msg                                      = በእርስዎ እና በ{1} መካከል ያለው የ{0} ፋይል ማስተላለፍ በተሳካ ሁኔታ ተጠናቋል
+angal.xmpp.thefiletransferofbetweenyouandendedsuccessfully.fmt.msg                                     = በእርስዎ እና በ{1} መካከል ያለው የ{0} ፋይል ማስተላለፍ በተሳካ ሁኔታ ተጠናቋል
 angal.xmpp.userinfo.fmt.txt                                                                            = ተጠቃሚ፡ {0}\nመረጃ፡ {1}
 angal.xmpp.usersinfo.border                                                                            = የተጠቃሚ መረጃ
 angal.xmpp.wantstosharewithyouthisreport.fmt.msg                                                       = \n*** {0} ይህንን ሪፖርት ለእርስዎ ማጋራት ይፈልጋል፡ {1}\n

--- a/bundle/language_ar.properties
+++ b/bundle/language_ar.properties
@@ -1824,7 +1824,7 @@ angal.xmpp.isnowoffline.txt                                                     
 angal.xmpp.isnowonline.txt                                                                             = متصل الآن
 angal.xmpp.me.txt                                                                                      = أنا
 angal.xmpp.sendfile.txt                                                                                = إرسال ملف
-angal.xmpp.thefiletransferofbetweenyouandendedsuccesfully.fmt.msg                                      = تم إتمام نقل ملف {0} بينك وبين {1} بنجاح
+angal.xmpp.thefiletransferofbetweenyouandendedsuccessfully.fmt.msg                                     = تم إتمام نقل ملف {0} بينك وبين {1} بنجاح
 angal.xmpp.userinfo.fmt.txt                                                                            = مستخدم: {0}\nمعلومات: {1}
 angal.xmpp.usersinfo.border                                                                            = معلومات المستخدم
 angal.xmpp.wantstosharewithyouthisreport.fmt.msg                                                       = \n*** {0} wants to share with you this report: {1}\n

--- a/bundle/language_ar_SA.properties
+++ b/bundle/language_ar_SA.properties
@@ -1623,7 +1623,7 @@ angal.xmpp.isnowoffline.txt                                                     
 angal.xmpp.isnowonline.txt                                                                             = is now online
 angal.xmpp.me.txt                                                                                      = me
 angal.xmpp.sendfile.txt                                                                                = Send File
-angal.xmpp.thefiletransferofbetweenyouandendedsuccesfully.fmt.msg                                      = the file transfer of {0} between you and {1} ended successfully
+angal.xmpp.thefiletransferofbetweenyouandendedsuccessfully.fmt.msg                                     = the file transfer of {0} between you and {1} ended successfully
 angal.xmpp.userinfo.fmt.txt                                                                            = User: {0}\nInfo: {1}
 angal.xmpp.usersinfo.border                                                                            = User's Info
 angal.xmpp.wantstosharewithyouthisreport.fmt.msg                                                       = \n*** {0} wants to share with you this report: {1}\n

--- a/bundle/language_de.properties
+++ b/bundle/language_de.properties
@@ -1824,7 +1824,7 @@ angal.xmpp.isnowoffline.txt                                                     
 angal.xmpp.isnowonline.txt                                                                             = ist jetzt online
 angal.xmpp.me.txt                                                                                      = ich
 angal.xmpp.sendfile.txt                                                                                = Datei senden
-angal.xmpp.thefiletransferofbetweenyouandendedsuccesfully.fmt.msg                                      = Die Dateiübertragung von {0} zwischen Ihnen und {1} wurde erfolgreich beendet
+angal.xmpp.thefiletransferofbetweenyouandendedsuccessfully.fmt.msg                                     = Die Dateiübertragung von {0} zwischen Ihnen und {1} wurde erfolgreich beendet
 angal.xmpp.userinfo.fmt.txt                                                                            = Benutzer: {0}\nInfo: {1}
 angal.xmpp.usersinfo.border                                                                            = Benutzerinformation
 angal.xmpp.wantstosharewithyouthisreport.fmt.msg                                                       = \n*** {0} möchte diesen Bericht mit Ihnen teilen: {1}\n

--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -1970,7 +1970,6 @@ angal.xmpp.isnowoffline.txt                                                     
 angal.xmpp.isnowonline.txt                                                                             = is now online
 angal.xmpp.me.txt                                                                                      = me
 angal.xmpp.sendfile.txt                                                                                = Send File
-angal.xmpp.thefiletransferofbetweenyouandendedsuccesfully.fmt.msg                                      = the file transfer of {0} between you and {1} ended successfully
 angal.xmpp.thefiletransferofbetweenyouandendedsuccessfully.fmt.msg                                     = The file transfer of {0} between you and {1} ended successfully.
 angal.xmpp.userinfo.fmt.txt                                                                            = User: {0}\nInfo: {1}
 angal.xmpp.usersinfo.border                                                                            = User's Info

--- a/bundle/language_es.properties
+++ b/bundle/language_es.properties
@@ -1824,7 +1824,7 @@ angal.xmpp.isnowoffline.txt                                                     
 angal.xmpp.isnowonline.txt                                                                             = ahora está conectado
 angal.xmpp.me.txt                                                                                      = me
 angal.xmpp.sendfile.txt                                                                                = Enviar Archivo
-angal.xmpp.thefiletransferofbetweenyouandendedsuccesfully.fmt.msg                                      = la transferencia de archivos de {0} entre usted y {1} finalizó correctamente
+angal.xmpp.thefiletransferofbetweenyouandendedsuccessfully.fmt.msg                                     = la transferencia de archivos de {0} entre usted y {1} finalizó correctamente
 angal.xmpp.userinfo.fmt.txt                                                                            = Usuario: {0}\nInfo: {1}
 angal.xmpp.usersinfo.border                                                                            = Informaciones del Usuario
 angal.xmpp.wantstosharewithyouthisreport.fmt.msg                                                       = \n*** {0} quiere compartir contigo este informe: {1}\n

--- a/bundle/language_fr.properties
+++ b/bundle/language_fr.properties
@@ -1824,7 +1824,7 @@ angal.xmpp.isnowoffline.txt                                                     
 angal.xmpp.isnowonline.txt                                                                             = maintenant online
 angal.xmpp.me.txt                                                                                      = moi
 angal.xmpp.sendfile.txt                                                                                = Envoyer Fichier
-angal.xmpp.thefiletransferofbetweenyouandendedsuccesfully.fmt.msg                                      = le transfert de fichier de {0} entre vous et {1} s'est terminé avec succès
+angal.xmpp.thefiletransferofbetweenyouandendedsuccessfully.fmt.msg                                     = le transfert de fichier de {0} entre vous et {1} s'est terminé avec succès
 angal.xmpp.userinfo.fmt.txt                                                                            = User: {0}\nInfo: {1}
 angal.xmpp.usersinfo.border                                                                            = Informations Usagers
 angal.xmpp.wantstosharewithyouthisreport.fmt.msg                                                       = \n*** {0} veut partager avec vous ce rapport: {1}\n

--- a/bundle/language_it.properties
+++ b/bundle/language_it.properties
@@ -1824,7 +1824,7 @@ angal.xmpp.isnowoffline.txt                                                     
 angal.xmpp.isnowonline.txt                                                                             = è ora online
 angal.xmpp.me.txt                                                                                      = me
 angal.xmpp.sendfile.txt                                                                                = Inviare file
-angal.xmpp.thefiletransferofbetweenyouandendedsuccesfully.fmt.msg                                      = il trasferimento di file di {0} tra te e {1} è terminato con successo
+angal.xmpp.thefiletransferofbetweenyouandendedsuccessfully.fmt.msg                                     = il trasferimento di file di {0} tra te e {1} è terminato con successo
 angal.xmpp.userinfo.fmt.txt                                                                            = Utente: {0}\nInfo: {1}
 angal.xmpp.usersinfo.border                                                                            = Informazioni per l'utente
 angal.xmpp.wantstosharewithyouthisreport.fmt.msg                                                       = \n*** {0} vuole condividere con voi questo report: {1}\n

--- a/bundle/language_sq.properties
+++ b/bundle/language_sq.properties
@@ -1824,7 +1824,7 @@ angal.xmpp.isnowoffline.txt                                                     
 angal.xmpp.isnowonline.txt                                                                             = është online
 angal.xmpp.me.txt                                                                                      = unë
 angal.xmpp.sendfile.txt                                                                                = Dërgo dokumentin
-angal.xmpp.thefiletransferofbetweenyouandendedsuccesfully.fmt.msg                                      = transferimi i skedarit të {0} mes jush dhe {1} përfundoi me sukses
+angal.xmpp.thefiletransferofbetweenyouandendedsuccessfully.fmt.msg                                     = transferimi i skedarit të {0} mes jush dhe {1} përfundoi me sukses
 angal.xmpp.userinfo.fmt.txt                                                                            = Përdoruesi: {0}\nInfo: {1}
 angal.xmpp.usersinfo.border                                                                            = Info mbi përdoruesin
 angal.xmpp.wantstosharewithyouthisreport.fmt.msg                                                       = \n*** {0} dëshiron të ndajë me ju këtë raport: {1}\n

--- a/bundle/language_zh_CN.properties
+++ b/bundle/language_zh_CN.properties
@@ -1824,7 +1824,7 @@ angal.xmpp.isnowoffline.txt                                                     
 angal.xmpp.isnowonline.txt                                                                             = 已上线
 angal.xmpp.me.txt                                                                                      = 我
 angal.xmpp.sendfile.txt                                                                                = 发送文件
-angal.xmpp.thefiletransferofbetweenyouandendedsuccesfully.fmt.msg                                      = 文件转移 {0} 在你和 {1} 之间已成功
+angal.xmpp.thefiletransferofbetweenyouandendedsuccessfully.fmt.msg                                     = 文件转移 {0} 在你和 {1} 之间已成功
 angal.xmpp.userinfo.fmt.txt                                                                            = 用户: {0}\n信息: {1}
 angal.xmpp.usersinfo.border                                                                            = 用户信息
 angal.xmpp.wantstosharewithyouthisreport.fmt.msg                                                       = \n*** {0} 想与你共享此报告: {1}\n

--- a/src/main/java/org/isf/xmpp/gui/CommunicationFrame.java
+++ b/src/main/java/org/isf/xmpp/gui/CommunicationFrame.java
@@ -545,7 +545,7 @@ public class CommunicationFrame extends JFrame implements MessageListener, FileT
 				LOGGER.error(xmppException.getMessage(), xmppException);
 			}
 
-			printNotification((getArea(user, true)), MessageBundle.formatMessage("angal.xmpp.thefiletransferofbetweenyouandendedsuccesfully.fmt.msg",
+			printNotification((getArea(user, true)), MessageBundle.formatMessage("angal.xmpp.thefiletransferofbetweenyouandendedsuccessfully.fmt.msg",
 					request.getFileName(), user));
 			sendMessage(MessageBundle.formatMessage("angal.xmpp.filetransferofhasbeenaccepted.fmt.msg", request.getFileName()),
 					request.getRequestor(), false);


### PR DESCRIPTION
**Summary**
This PR fixes a typo in an XMPP translation key and aligns code and bundle keys to use the same canonical key name across locales.

**What changed**
Updated the XMPP notification key usage in the GUI code to the correctly spelled key.
Removed/replaced the misspelled key variant in language bundles.
Kept the message content unchanged; only key naming consistency was addressed.

**Why**
The previous typo created two near-identical keys and risked inconsistent usage over time.
Standardizing on one correct key prevents future drift and makes i18n maintenance safer.

**Scope**
Focused key normalization only.
No functional workflow changes beyond using the corrected key.
This is not a full orphan-key cleanup pass.

**Validation**
Verified the corrected key is referenced in code.
Verified the old, misspelled key is no longer referenced.
Confirmed locale bundles are aligned to the corrected key name.

**Risk**
Low.
Change is limited to i18n key identifiers and does not alter business logic.

