### PR TITLE
Make the Bill Manager select-patient button uniform with New Bill (OP-359)

### DIFF
--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -311,6 +311,8 @@ angal.billbrowser.deletetheselectedbill.msg                                     
 angal.billbrowser.editbill                                                                             = Edit Bill
 angal.billbrowser.editbill.btn                                                                         = Edit Bill
 angal.billbrowser.editbill.btn.key                                                                     = E
+angal.billbrowser.findpatient.btn                                                                      = Find Patient
+angal.billbrowser.findpatient.btn.key                                                                  = F
 angal.billbrowser.fullreportallbills.txt                                                               = Full Report (all bills)
 angal.billbrowser.inout.col                                                                            = IN/OUT
 angal.billbrowser.lastpayment.col                                                                      = Last Payment

--- a/src/main/java/org/isf/accounting/gui/BillBrowser.java
+++ b/src/main/java/org/isf/accounting/gui/BillBrowser.java
@@ -791,7 +791,8 @@ public class BillBrowser extends ModalJFrame implements PatientBillListener {
 	private JPanel getPanelChoosePatient() {
 		JPanel priceListLabelPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
 
-		JButton jAffiliatePersonJButtonAdd = new JButton();
+		JButton jAffiliatePersonJButtonAdd = new JButton(MessageBundle.getMessage("angal.billbrowser.findpatient.btn"));
+		jAffiliatePersonJButtonAdd.setMnemonic(MessageBundle.getMnemonic("angal.billbrowser.findpatient.btn.key"));
 		jAffiliatePersonJButtonAdd.setIcon(new ImageIcon("rsc/icons/pick_patient_button.png"));
 		jAffiliatePersonJButtonAdd.setToolTipText(MessageBundle.getMessage("angal.billbrowser.selectapatient.tooltip"));
 
@@ -805,20 +806,16 @@ public class BillBrowser extends ModalJFrame implements PatientBillListener {
 		priceListLabelPanel.add(jAffiliatePersonJButtonAdd);
 		priceListLabelPanel.add(jAffiliatePersonJButtonSupp);
 
-		jAffiliatePersonJButtonAdd.addMouseListener(new MouseAdapter() {
+		jAffiliatePersonJButtonAdd.addActionListener(actionEvent -> {
+			SelectPatient selectPatient = new SelectPatient(BillBrowser.this, false, true);
+			selectPatient.addSelectionListener(BillBrowser.this);
+			selectPatient.setVisible(true);
+			Patient pat = selectPatient.getPatient();
 
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				SelectPatient selectPatient = new SelectPatient(BillBrowser.this, false, true);
-				selectPatient.addSelectionListener(BillBrowser.this);
-				selectPatient.setVisible(true);
-				Patient pat = selectPatient.getPatient();
-
-				try {
-					patientSelected(pat);
-				} catch (OHServiceException ohServiceException) {
-					MessageDialog.showExceptions(ohServiceException);
-				}
+			try {
+				patientSelected(pat);
+			} catch (OHServiceException ohServiceException) {
+				MessageDialog.showExceptions(ohServiceException);
 			}
 		});
 


### PR DESCRIPTION
## What
In **Patients Bills Management** (`BillBrowser`) the patient selector was an unlabeled, icon-only button — inconsistent with the clearly labeled **Find Patient** button used in the **New Bill** dialog (`PatientBillEdit`). This aligns the two.

Resolves [OP-359](https://openhospital.atlassian.net/browse/OP-359).

## How
- `BillBrowser.getPanelChoosePatient()`: the select-patient button now has a text label (`angal.billbrowser.findpatient.btn` → "Find Patient") and a mnemonic, matching `PatientBillEdit.getJButtonPickPatient()`.
- Its listener is switched from `MouseListener` to `ActionListener`, so the mnemonic also works from the keyboard (a `MouseListener` would not fire on keyboard activation). The action body is unchanged.
- Added the two i18n keys to `bundle/language_en.properties` (English bundle only, per repo convention), in alphabetical order. Mnemonic `F` was chosen to avoid clashing with the existing Bill Browser mnemonics (D, E, N, P, R, T, C).

## Notes
- Reused the existing `angal.billbrowser.selectapatient.tooltip` tooltip.
- A matching screenshot in the admin/user manual (openhospital-doc) can be refreshed as a follow-up.

[OP-359]: https://openhospital.atlassian.net/browse/OP-359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ