### PR TITLE
OP-219 Let the user load a DICOM image into an existing series

### DIFF
--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -509,7 +509,10 @@ angal.dicom.image.zoom                                                          
 angal.dicom.load.btn                                                                                   = Load Image
 angal.dicom.load.btn.key                                                                               = L
 angal.dicom.loading                                                                                    = Loading...
+angal.dicom.newseries.txt                                                                              = New series
 angal.dicom.open.txt                                                                                   = Open Image
+angal.dicom.selectseries.title                                                                         = Select series
+angal.dicom.selectserieswheretoloadthefiles.msg                                                        = Select the series to load the file(s) into:
 angal.dicom.thefileisinanunknownformat.fmt.msg                                                         = The file is in an unknown format: {0}.
 angal.dicom.thefileisnotindicomformat.fmt.msg                                                          = The file is not in DICOM format: {0}.
 angal.dicom.thefileistoobigpleasesetdicommaxsizeproperty.fmt.msg                                       = The file is too big. Please set 'dicom.max.size' into dicom.properties ({0})

--- a/src/main/java/org/isf/dicom/gui/DicomGui.java
+++ b/src/main/java/org/isf/dicom/gui/DicomGui.java
@@ -30,8 +30,11 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.swing.GroupLayout;
 import javax.swing.GroupLayout.Alignment;
@@ -311,7 +314,10 @@ public class DicomGui extends ModalJFrame implements WindowListener {
 				dummyFileDicom.setDicomStudyDate(preLoadDialog.getDicomDate());
 				dummyFileDicom.setDicomType(preLoadDialog.getDicomType());
 
-				//TODO: to specify in which already existing series to load the file
+				//OP-219: let the user load the file(s) into an already existing series instead of always creating a new one
+				if (!chooseSeries(dummyFileDicom)) {
+					return; //user cancelled the series selection
+				}
 
 				if (selectedFile.isDirectory()) {
 					//folder
@@ -328,6 +334,104 @@ public class DicomGui extends ModalJFrame implements WindowListener {
 				}
 			}
 		});
+	}
+
+	/**
+	 * Lets the user load the incoming file(s) into one of the patient's already existing DICOM series, instead of
+	 * always creating a new one (OP-219). When an existing series is picked, its number is set on {@code dummyFileDicom}
+	 * so that {@link SourceFiles} reuses it; otherwise a new series is created as before. The series currently selected
+	 * in the thumbnail panel, if any, is pre-selected.
+	 *
+	 * @param dummyFileDicom the temporary {@link FileDicom} holding the settings for the file(s) to load
+	 * @return {@code false} if the user cancelled the selection, {@code true} otherwise
+	 */
+	private boolean chooseSeries(FileDicom dummyFileDicom) {
+		FileDicom[] patientFiles;
+		try {
+			patientFiles = DicomManagerFactory.getManager().loadPatientFiles(patient);
+		} catch (OHServiceException ohServiceException) {
+			OHServiceExceptionUtil.showMessages(ohServiceException, this);
+			return false;
+		}
+
+		List<SeriesItem> series = new ArrayList<>();
+		Set<String> seenSeries = new HashSet<>();
+		for (FileDicom patientFile : patientFiles) {
+			String seriesInstanceUID = patientFile.getDicomSeriesInstanceUID();
+			if (seriesInstanceUID != null && !seriesInstanceUID.isEmpty() && seenSeries.add(seriesInstanceUID)) {
+				series.add(new SeriesItem(patientFile));
+			}
+		}
+
+		if (series.isEmpty()) {
+			return true; //no existing series: keep the current behaviour and let a new series be created
+		}
+
+		SeriesItem newSeries = new SeriesItem(null);
+		List<SeriesItem> options = new ArrayList<>();
+		options.add(newSeries);
+		options.addAll(series);
+
+		SeriesItem preselected = newSeries;
+		if (!thumbnail.isSelectionEmpty()) {
+			FileDicom selectedInstance = thumbnail.getSelectedInstance();
+			String selectedSeriesUID = selectedInstance == null ? null : selectedInstance.getDicomSeriesInstanceUID();
+			for (SeriesItem item : series) {
+				if (item.getSeriesInstanceUID().equals(selectedSeriesUID)) {
+					preselected = item;
+					break;
+				}
+			}
+		}
+
+		SeriesItem choice = (SeriesItem) JOptionPane.showInputDialog(this,
+				MessageBundle.getMessage("angal.dicom.selectserieswheretoloadthefiles.msg"),
+				MessageBundle.getMessage("angal.dicom.selectseries.title"),
+				JOptionPane.QUESTION_MESSAGE, null, options.toArray(), preselected);
+
+		if (choice == null) {
+			return false; //user pressed CANCEL
+		}
+		FileDicom targetSeries = choice.getSeries();
+		if (targetSeries != null) {
+			//load into the chosen existing series: copy the identifiers the viewer uses (instance UID for grouping, number for lookups)
+			dummyFileDicom.setDicomSeriesNumber(targetSeries.getDicomSeriesNumber());
+			dummyFileDicom.setDicomSeriesInstanceUID(targetSeries.getDicomSeriesInstanceUID());
+			dummyFileDicom.setDicomSeriesUID(targetSeries.getDicomSeriesUID());
+			dummyFileDicom.setDicomSeriesDescription(targetSeries.getDicomSeriesDescription());
+		}
+		return true;
+	}
+
+	/**
+	 * Wraps an existing patient DICOM series shown in the selection dialog. A {@code null} series represents the
+	 * "new series" option.
+	 */
+	private static final class SeriesItem {
+
+		private final FileDicom series;
+
+		private SeriesItem(FileDicom series) {
+			this.series = series;
+		}
+
+		private FileDicom getSeries() {
+			return series;
+		}
+
+		private String getSeriesInstanceUID() {
+			return series.getDicomSeriesInstanceUID();
+		}
+
+		@Override
+		public String toString() {
+			if (series == null) {
+				return MessageBundle.getMessage("angal.dicom.newseries.txt");
+			}
+			String description = series.getDicomSeriesDescription();
+			String number = series.getDicomSeriesNumber();
+			return description == null || description.isEmpty() ? number : description + " (" + number + ')';
+		}
 	}
 
 	private void actionListenerJButtonDeleteDicom() {


### PR DESCRIPTION
## What
When loading an image in the DICOM viewer, the user can now choose to load it into an **already existing** series of the patient, instead of always creating a new one.

Resolves [OP-219](https://openhospital.atlassian.net/browse/OP-219).

## How
- In `DicomGui`, after the pre-load dialog (where the `//TODO` used to be), if the patient already has at least one series, a small dialog asks whether to create a **New series** or load into an existing one. The series currently selected in the thumbnail panel is pre-selected.
- When an existing series is chosen, its identifiers (series number, instance UID, UID, description) are copied onto the file so it joins that series.
- Added the i18n keys (`angal.dicom.newseries.txt`, `angal.dicom.selectseries.title`, `angal.dicom.selectserieswheretoloadthefiles.msg`) to the English bundle.

## Depends on
informatici/openhospital-core#1594 (same branch name) — the core honors the preselected series for actual DICOM files. The CI builds this PR against that core branch automatically.

## Testing
- `mvn package` (CI gate) green; core DICOM tests pass.
- Verified end-to-end against a running instance with two real `.dcm` files: picking the existing series loads both images into one series (confirmed in the viewer and in the DB: a single `DM_FILE_SER_INST_UID` with 2 rows).

## Note
The user-manual screenshot (oh-doc) can be refreshed as a follow-up, per the ticket.

[OP-219]: https://openhospital.atlassian.net/browse/OP-219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ