### PR TITLE
OP-1388 Ask for an optional reason when deleting a stock movement

### DIFF
--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -931,7 +931,8 @@ angal.medicalstock.chooseavalidpreparationdate                                  
 angal.medicalstock.clickdrugs                                                                          = Double click to show lot details
 angal.medicalstock.codeordescription.txt                                                               = Code or Description
 angal.medicalstock.cost.col                                                                            = Cost
-angal.medicalstock.deletemovementreason.msg                                                            = Do you want to delete this movement? You can optionally provide a reason:
+angal.medicalstock.deletemovementreason.msg                                                            = Do you want to delete this movement? Please provide a reason:
+angal.medicalstock.deletemovementreasonrequired.msg                                                    = A reason is required to delete the movement.
 angal.medicalstock.deletemovementsuccess.msg                                                           = Last movement successfully deleted.
 angal.medicalstock.discharge.btn                                                                       = Discharge
 angal.medicalstock.discharge.btn.key                                                                   = R

--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -931,6 +931,7 @@ angal.medicalstock.chooseavalidpreparationdate                                  
 angal.medicalstock.clickdrugs                                                                          = Double click to show lot details
 angal.medicalstock.codeordescription.txt                                                               = Code or Description
 angal.medicalstock.cost.col                                                                            = Cost
+angal.medicalstock.deletemovementreason.msg                                                            = Do you want to delete this movement? You can optionally provide a reason:
 angal.medicalstock.deletemovementsuccess.msg                                                           = Last movement successfully deleted.
 angal.medicalstock.discharge.btn                                                                       = Discharge
 angal.medicalstock.discharge.btn.key                                                                   = R

--- a/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
@@ -892,21 +892,21 @@ public class MovStockBrowser extends ModalJFrame {
 				if (!isAutomaticLot()) {
 					model = new MovBrowserModel(medicalSelected,
 									medicalTypeSelected, wardSelected, movementTypeSelected,
-									TimeTools.getBeginningOfDay(movDateFrom.getDateStartOfDay()),
-									TimeTools.getBeginningOfNextDay(movDateTo.getDateStartOfDay()),
-									TimeTools.getBeginningOfDay(lotPrepFrom.getDateStartOfDay()),
-									TimeTools.getBeginningOfNextDay(lotPrepTo.getDateStartOfDay()),
-									TimeTools.getBeginningOfDay(lotDueFrom.getDateStartOfDay()),
-									TimeTools.getBeginningOfNextDay(lotDueTo.getDateStartOfDay()));
+									beginningOfDayOrNull(movDateFrom.getDateStartOfDay()),
+									beginningOfNextDayOrNull(movDateTo.getDateStartOfDay()),
+									beginningOfDayOrNull(lotPrepFrom.getDateStartOfDay()),
+									beginningOfNextDayOrNull(lotPrepTo.getDateStartOfDay()),
+									beginningOfDayOrNull(lotDueFrom.getDateStartOfDay()),
+									beginningOfNextDayOrNull(lotDueTo.getDateStartOfDay()));
 				} else {
 					model = new MovBrowserModel(medicalSelected,
 									medicalTypeSelected, wardSelected, movementTypeSelected,
-									TimeTools.getBeginningOfDay(movDateFrom.getDateStartOfDay()),
-									TimeTools.getBeginningOfNextDay(movDateTo.getDateStartOfDay()),
+									beginningOfDayOrNull(movDateFrom.getDateStartOfDay()),
+									beginningOfNextDayOrNull(movDateTo.getDateStartOfDay()),
 									null,
 									null,
-									TimeTools.getBeginningOfDay(lotDueFrom.getDateStartOfDay()),
-									TimeTools.getBeginningOfNextDay(lotDueTo.getDateStartOfDay()));
+									beginningOfDayOrNull(lotDueFrom.getDateStartOfDay()),
+									beginningOfNextDayOrNull(lotDueTo.getDateStartOfDay()));
 				}
 
 				if (moves != null)
@@ -920,6 +920,14 @@ public class MovStockBrowser extends ModalJFrame {
 			}
 		});
 		return filterButton;
+	}
+
+	private LocalDateTime beginningOfDayOrNull(LocalDateTime date) {
+		return date == null ? null : TimeTools.getBeginningOfDay(date);
+	}
+
+	private LocalDateTime beginningOfNextDayOrNull(LocalDateTime date) {
+		return date == null ? null : TimeTools.getBeginningOfNextDay(date);
 	}
 
 	private JButton getResetButton() {
@@ -1026,12 +1034,13 @@ public class MovStockBrowser extends ModalJFrame {
 			try {
 				Movement lastMovement = movBrowserManager.getLastMovement();
 				if (lastMovement.getCode() == selectedMovement.getCode()) {
-					int delete = MessageDialog.yesNo(null, "angal.medicalstock.doyoureallywanttodeletethismovement.msg");
-					if (delete == JOptionPane.YES_OPTION) {
-						movBrowserManager.deleteLastMovement(lastMovement);
-					} else {
+					String reason = (String) JOptionPane.showInputDialog(this,
+						MessageBundle.getMessage("angal.medicalstock.deletemovementreason.msg"),
+						MessageBundle.getMessage("angal.common.delete.btn"), JOptionPane.QUESTION_MESSAGE);
+					if (reason == null) {
 						return;
 					}
+					movBrowserManager.deleteLastMovement(lastMovement, reason);
 				} else {
 					MessageDialog.error(this, "angal.medicalstock.onlythelastmovementcanbedeleted.msg");
 					return;

--- a/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
@@ -1034,13 +1034,14 @@ public class MovStockBrowser extends ModalJFrame {
 			try {
 				Movement lastMovement = movBrowserManager.getLastMovement();
 				if (lastMovement.getCode() == selectedMovement.getCode()) {
-					String reason = (String) JOptionPane.showInputDialog(this,
-						MessageBundle.getMessage("angal.medicalstock.deletemovementreason.msg"),
-						MessageBundle.getMessage("angal.common.delete.btn"), JOptionPane.QUESTION_MESSAGE);
-					if (reason == null) {
+					JTextField reasonField = new JTextField(20);
+					Object[] message = { MessageBundle.getMessage("angal.medicalstock.deletemovementreason.msg"), reasonField };
+					int answer = JOptionPane.showConfirmDialog(this, message,
+						MessageBundle.getMessage("angal.common.delete.btn"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
+					if (answer != JOptionPane.YES_OPTION) {
 						return;
 					}
-					movBrowserManager.deleteLastMovement(lastMovement, reason);
+					movBrowserManager.deleteLastMovement(lastMovement, reasonField.getText());
 				} else {
 					MessageDialog.error(this, "angal.medicalstock.onlythelastmovementcanbedeleted.msg");
 					return;

--- a/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
@@ -1036,12 +1036,19 @@ public class MovStockBrowser extends ModalJFrame {
 				if (lastMovement.getCode() == selectedMovement.getCode()) {
 					JTextField reasonField = new JTextField(20);
 					Object[] message = { MessageBundle.getMessage("angal.medicalstock.deletemovementreason.msg"), reasonField };
-					int answer = JOptionPane.showConfirmDialog(this, message,
-						MessageBundle.getMessage("angal.common.delete.btn"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
-					if (answer != JOptionPane.YES_OPTION) {
-						return;
-					}
-					movBrowserManager.deleteLastMovement(lastMovement, reasonField.getText());
+					String reason;
+					do {
+						int answer = JOptionPane.showConfirmDialog(this, message,
+							MessageBundle.getMessage("angal.common.delete.btn"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
+						if (answer != JOptionPane.YES_OPTION) {
+							return;
+						}
+						reason = reasonField.getText().trim();
+						if (reason.isEmpty()) {
+							MessageDialog.error(this, "angal.medicalstock.deletemovementreasonrequired.msg");
+						}
+					} while (reason.isEmpty());
+					movBrowserManager.deleteLastMovement(lastMovement, reason);
 				} else {
 					MessageDialog.error(this, "angal.medicalstock.onlythelastmovementcanbedeleted.msg");
 					return;

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
@@ -404,12 +404,13 @@ public class WardPharmacy extends ModalJFrame implements
 				try {
 					MovementWard movWard = movWardBrowserManager.getLastMovementWard(wardSelected);
 					if (movWard.getCode() == selectedMovement.getCode()) {
-						int delete = MessageDialog.yesNo(null, "angal.medicalstock.doyoureallywanttodeletethismovement.msg");
-						if (delete == JOptionPane.YES_OPTION) {
-							movWardBrowserManager.deleteLastMovementWard(movWard);
-						} else {
+						String reason = (String) JOptionPane.showInputDialog(this,
+							MessageBundle.getMessage("angal.medicalstock.deletemovementreason.msg"),
+							MessageBundle.getMessage("angal.common.delete.btn"), JOptionPane.QUESTION_MESSAGE);
+						if (reason == null) {
 							return;
 						}
+						movWardBrowserManager.deleteLastMovementWard(movWard, reason);
 					} else {
 						MessageDialog.error(this, "angal.medicalstock.onlythelastmovementcanbedeleted.msg");
 						return;

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
@@ -406,12 +406,19 @@ public class WardPharmacy extends ModalJFrame implements
 					if (movWard.getCode() == selectedMovement.getCode()) {
 						JTextField reasonField = new JTextField(20);
 						Object[] message = { MessageBundle.getMessage("angal.medicalstock.deletemovementreason.msg"), reasonField };
-						int answer = JOptionPane.showConfirmDialog(this, message,
-							MessageBundle.getMessage("angal.common.delete.btn"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
-						if (answer != JOptionPane.YES_OPTION) {
-							return;
-						}
-						movWardBrowserManager.deleteLastMovementWard(movWard, reasonField.getText());
+						String reason;
+						do {
+							int answer = JOptionPane.showConfirmDialog(this, message,
+								MessageBundle.getMessage("angal.common.delete.btn"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
+							if (answer != JOptionPane.YES_OPTION) {
+								return;
+							}
+							reason = reasonField.getText().trim();
+							if (reason.isEmpty()) {
+								MessageDialog.error(this, "angal.medicalstock.deletemovementreasonrequired.msg");
+							}
+						} while (reason.isEmpty());
+						movWardBrowserManager.deleteLastMovementWard(movWard, reason);
 					} else {
 						MessageDialog.error(this, "angal.medicalstock.onlythelastmovementcanbedeleted.msg");
 						return;

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
@@ -404,13 +404,14 @@ public class WardPharmacy extends ModalJFrame implements
 				try {
 					MovementWard movWard = movWardBrowserManager.getLastMovementWard(wardSelected);
 					if (movWard.getCode() == selectedMovement.getCode()) {
-						String reason = (String) JOptionPane.showInputDialog(this,
-							MessageBundle.getMessage("angal.medicalstock.deletemovementreason.msg"),
-							MessageBundle.getMessage("angal.common.delete.btn"), JOptionPane.QUESTION_MESSAGE);
-						if (reason == null) {
+						JTextField reasonField = new JTextField(20);
+						Object[] message = { MessageBundle.getMessage("angal.medicalstock.deletemovementreason.msg"), reasonField };
+						int answer = JOptionPane.showConfirmDialog(this, message,
+							MessageBundle.getMessage("angal.common.delete.btn"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
+						if (answer != JOptionPane.YES_OPTION) {
 							return;
 						}
-						movWardBrowserManager.deleteLastMovementWard(movWard, reason);
+						movWardBrowserManager.deleteLastMovementWard(movWard, reasonField.getText());
 					} else {
 						MessageDialog.error(this, "angal.medicalstock.onlythelastmovementcanbedeleted.msg");
 						return;


### PR DESCRIPTION
## OP-1388 — Optional reason when deleting a stock movement

The Stock Movement Browser and Ward Pharmacy delete actions now prompt for an optional reason, which is passed to the core so the deletion is recorded in the audit log (see the paired core PR).

### Bundled bug fix
Also fixes a pre-existing bug: after deleting the last movement, **the deleted row stayed visible in the Stock Movement Browser table until the application was restarted**. The in-place refresh re-runs the Filter action, which threw a `NullPointerException` when the optional *Lot Preparation/Due Date* filters were left empty (`TimeTools.getBeginningOfDay(null)`). Those dates are now handled null-safely, so the row disappears immediately after deletion — and the Filter button no longer fails when the lot date filters are empty.

### Notes
- New i18n key `angal.medicalstock.deletemovementreason.msg` (English bundle).
- Requires the paired core PR informatici/openhospital-core#1595 (same branch name, so CI cross-builds against it).

JIRA: https://openhospital.atlassian.net/browse/OP-1388
