### PR TITLE
OP-1216 Adapt GUI to DECIMAL/INT money and quantity types

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,8 +27,14 @@ jobs:
       - name: Determine PR source branch and fork repository
         id: vars
         run: |
+          # Skip tag pushes entirely
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" != refs/heads/* ]]; then
+            echo "Not a branch push ($GITHUB_REF). Exiting."
+            exit 0
+          fi
+
           # Set default FORK_REPO and BRANCH_NAME values.
-          BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF##*/}}"
+          BRANCH_NAME="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
           
           if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REPOSITORY" == "informatici/openhospital-gui" ]]; then
             # For pushes to the main repository, default to the main core repo

--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -1120,6 +1120,7 @@ angal.medicalstockwardedit.selectpatient.btn.key                                
 angal.medicalstockwardedit.title                                                                       = New / Edit
 angal.medicalstockwardedit.tooltip.associateapatientwiththismovement                                   = Associate a Patient with this movement
 angal.medicalstockwardedit.tooltip.removepatientassociationwiththismovement                            = Remove Patient association with this movement
+angal.medicalstockwardedit.transferquantitymustbeaninteger.msg                                         = Transfer quantities between wards must be whole units.
 angal.medstockmovtype.allowedcategoriesare.fmt.msg                                                     = Allowed categories are: {0}
 angal.medstockmovtype.category.nonoperational.txt                                                      = Non-Operational
 angal.medstockmovtype.category.operational.txt                                                         = Operational

--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -684,6 +684,7 @@ angal.hospital.visitendhour.txt                                                 
 angal.hospital.visitstarthour.txt                                                                      = Visit start hour
 angal.inventory.addamedical.label                                                                      = Add a medical
 angal.inventory.addmedicalsby.label                                                                    = Add medicals by
+angal.inventory.adjustmentquantitymustbeawholenumber.fmt.msg                                           = The inventory adjustment for {0} must be a whole number.
 angal.inventory.allinventoryrowshouldhavelotbeforevalidation.msg                                       = All the inventory rows should have lots before validation.
 angal.inventory.allinventoryrowswithnewlotshouldhaverealqtygreatterthanzero.msg                        = All inventory(ies) row(s) with new lot should have a real quantity greater than zero before validation.
 angal.inventory.allwardshaveaongoinginventory.msg                                                      = All wards have a ongoing (draft or validated) inventory.

--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -684,7 +684,6 @@ angal.hospital.visitendhour.txt                                                 
 angal.hospital.visitstarthour.txt                                                                      = Visit start hour
 angal.inventory.addamedical.label                                                                      = Add a medical
 angal.inventory.addmedicalsby.label                                                                    = Add medicals by
-angal.inventory.adjustmentquantitymustbeawholenumber.fmt.msg                                           = The inventory adjustment for {0} must be a whole number.
 angal.inventory.allinventoryrowshouldhavelotbeforevalidation.msg                                       = All the inventory rows should have lots before validation.
 angal.inventory.allinventoryrowswithnewlotshouldhaverealqtygreatterthanzero.msg                        = All inventory(ies) row(s) with new lot should have a real quantity greater than zero before validation.
 angal.inventory.allwardshaveaongoinginventory.msg                                                      = All wards have a ongoing (draft or validated) inventory.
@@ -752,6 +751,7 @@ angal.inventory.pleaseselectonlyoneinventory.msg                                
 angal.inventory.pleasevalidateinventoryagainsbeforeconfirmation.msg                                    = Please validate the inventory again before confirming it.
 angal.inventory.printing.error.msg                                                                     = An error occurred while printing.
 angal.inventory.productalreadyexist.fmt.msg                                                            = {0} already exists in the table. Do you want to add it anyway?
+angal.inventory.quantitiesmustbewholenumbers.fmt.msg                                                   = The inventory quantities for {0} must be whole numbers.
 angal.inventory.realqty.col                                                                            = Real quantity
 angal.inventory.reference.label                                                                        = Inventory's reference
 angal.inventory.referencealreadyused.msg                                                               = Reference is already used.

--- a/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
+++ b/src/main/java/org/isf/accounting/gui/PatientBillEdit.java
@@ -1238,8 +1238,8 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 									thisBill.getBillPatient(), // Patient
 									thisBill.isPatient() ? thisBill.getBillPatient().getName() : jTextFieldPatient.getText(), // Patient Name
 									paid ? "C" : "O", // CLOSED or OPEN TODO: enumerate bills status
-									total.doubleValue(), // Total
-									balance.doubleValue(), // Balance
+									total, // Total
+									balance, // Balance
 									user, // User
 									thisBill.getAdmission()); // Admission
 
@@ -1265,8 +1265,8 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 									thisBill.getBillPatient(), // Patient
 									thisBill.isPatient() ? thisBill.getPatName() : jTextFieldPatient.getText(), // Patient Name
 									paid ? "C" : "O", // CLOSED or OPEN
-									total.doubleValue(), // Total
-									balance.doubleValue(), // Balance
+									total, // Total
+									balance, // Balance
 									user, // User
 									thisBill.getAdmission()); // Admission
 
@@ -1356,13 +1356,13 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 						}
 
 						if (isValidPaymentDate(datePay)) {
-							addPayment(datePay, balance.doubleValue());
+							addPayment(datePay, balance);
 						} else {
 							return;
 						}
 					} else {
 						datePay = TimeTools.getNow();
-						addPayment(datePay, balance.doubleValue());
+						addPayment(datePay, balance);
 					}
 				}
 				paid = true;
@@ -1445,11 +1445,11 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 					}
 
 					if (isValidPaymentDate(datePay)) {
-						addPayment(datePay, amount.doubleValue());
+						addPayment(datePay, amount);
 					}
 				} else {
 					datePay = TimeTools.getNow();
-					addPayment(datePay, amount.doubleValue());
+					addPayment(datePay, amount);
 				}
 			});
 		}
@@ -1520,11 +1520,11 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 					}
 
 					if (isValidPaymentDate(datePay)) {
-						addPayment(datePay, amount.doubleValue());
+						addPayment(datePay, amount);
 					}
 				} else {
 					datePay = TimeTools.getNow();
-					addPayment(datePay, amount.doubleValue());
+					addPayment(datePay, amount);
 				}
 			});
 		}
@@ -1584,7 +1584,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 							if (price == null) {
 								return;
 							}
-							double amount = Double.parseDouble(price);
+							BigDecimal amount = new BigDecimal(price.trim());
 							oth.setPrice(amount);
 							isPrice = false;
 						} catch (Exception eee) {
@@ -1593,8 +1593,8 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 						}
 					}
 					if (othersHashMap.get(Integer.valueOf(oth.getItem())).isDischarge()) {
-						double amount = oth.getPrice();
-						oth.setPrice(-amount);
+						BigDecimal amount = oth.getPrice();
+						oth.setPrice(amount.negate());
 					}
 					if (othersHashMap.get(Integer.valueOf(oth.getItem())).isDaily()) {
 						int qty = 1;
@@ -1718,7 +1718,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			jButtonCustom.setHorizontalAlignment(SwingConstants.LEFT);
 			jButtonCustom.setIcon(new ImageIcon("rsc/icons/plus_button.png"));
 			jButtonCustom.addActionListener(actionEvent -> {
-				double amount;
+				BigDecimal amount;
 				Icon icon = new ImageIcon("rsc/icons/custom_dialog.png"); //$NON-NLS-1$
 				String desc = (String) JOptionPane.showInputDialog(this, MessageBundle.getMessage("angal.newbill.chooseadescription.txt"),
 								MessageBundle.getMessage("angal.newbill.customitem.title"), JOptionPane.PLAIN_MESSAGE, icon, null,
@@ -1730,7 +1730,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 					String price = (String) JOptionPane.showInputDialog(this, MessageBundle.getMessage("angal.newbill.howmuchisit.txt"),
 									MessageBundle.getMessage("angal.newbill.customitem.title"), JOptionPane.PLAIN_MESSAGE, icon, null, "0"); //$NON-NLS-2$
 					try {
-						amount = Double.parseDouble(price);
+						amount = new BigDecimal(price.trim());
 					} catch (Exception eee) {
 						MessageDialog.error(this, "angal.newbill.invalidpricepleasetryagain.msg");
 						return;
@@ -1770,9 +1770,8 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 	private void updateTotal() { // only positive items make the bill's total
 		total = BigDecimal.ZERO;
 		for (BillItems item : billItems) {
-			double amount = item.getItemAmount();
-			if (amount > 0) {
-				BigDecimal itemAmount = new BigDecimal(Double.toString(amount));
+			BigDecimal itemAmount = item.getItemAmount();
+			if (itemAmount.compareTo(BigDecimal.ZERO) > 0) {
 				total = total.add(itemAmount.multiply(new BigDecimal(item.getItemQuantity())));
 			}
 		}
@@ -1781,7 +1780,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 	private void updateBigTotal() { // the big total (to pay) is made by all items
 		bigTotal = BigDecimal.ZERO;
 		for (BillItems item : billItems) {
-			BigDecimal itemAmount = new BigDecimal(Double.toString(item.getItemAmount()));
+			BigDecimal itemAmount = item.getItemAmount();
 			bigTotal = bigTotal.add(itemAmount.multiply(new BigDecimal(item.getItemQuantity())));
 		}
 	}
@@ -1790,7 +1789,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		balance = BigDecimal.ZERO;
 		BigDecimal payments = BigDecimal.ZERO;
 		for (BillPayments pay : payItems) {
-			BigDecimal payAmount = new BigDecimal(Double.toString(pay.getAmount()));
+			BigDecimal payAmount = pay.getAmount();
 			payments = payments.add(payAmount);
 		}
 		balance = bigTotal.subtract(payments);
@@ -1804,7 +1803,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 
 	private void addItem(Price prc, int qty, boolean isPrice) {
 		if (prc != null) {
-			double amount = prc.getPrice();
+			BigDecimal amount = prc.getPrice();
 			try {
 				BillItems item = new BillItems(0, billBrowserManager.getBill(thisBill.getId()), isPrice, prc.getGroup() + prc.getItem(), prc.getDesc(), amount,
 								qty);
@@ -1833,8 +1832,8 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 		}
 	}
 
-	private void addPayment(LocalDateTime datePay, double qty) {
-		if (qty != 0) {
+	private void addPayment(LocalDateTime datePay, BigDecimal qty) {
+		if (qty.compareTo(BigDecimal.ZERO) != 0) {
 			try {
 				BillPayments pay = new BillPayments(0, billBrowserManager.getBill(thisBill.getId()), datePay, qty, user);
 				payItems.add(pay);
@@ -1905,7 +1904,7 @@ public class PatientBillEdit extends JDialog implements SelectionListener {
 			}
 			if (c == 2) {
 				BigDecimal qty = new BigDecimal(item.getItemQuantity());
-				BigDecimal amount = new BigDecimal(Double.toString(item.getItemAmount()));
+				BigDecimal amount = item.getItemAmount();
 				return amount.multiply(qty).doubleValue();
 			}
 			return null;

--- a/src/main/java/org/isf/accounting/gui/totals/BalanceTotal.java
+++ b/src/main/java/org/isf/accounting/gui/totals/BalanceTotal.java
@@ -37,7 +37,7 @@ public class BalanceTotal {
 	public BigDecimal getValue() {
 		return billPeriod.stream()
 				.filter(bill -> !bill.getStatus().equals("D"))
-				.map(bill -> new BigDecimal(Double.toString(bill.getBalance())))
+				.map(Bill::getBalance)
 				.reduce(BigDecimal.ZERO, BigDecimal::add);
 	}
 

--- a/src/main/java/org/isf/accounting/gui/totals/PaymentsTotal.java
+++ b/src/main/java/org/isf/accounting/gui/totals/PaymentsTotal.java
@@ -39,7 +39,7 @@ public class PaymentsTotal {
 	public BigDecimal getValue() {
 		return paymentsPeriod.stream()
 				.filter(payment -> notDeletedBills.contains(payment.getBill().getId()))
-				.map(payment -> new BigDecimal(Double.toString(payment.getAmount())))
+				.map(BillPayments::getAmount)
 				.reduce(BigDecimal.ZERO, BigDecimal::add);
 	}
 

--- a/src/main/java/org/isf/accounting/gui/totals/UserTotal.java
+++ b/src/main/java/org/isf/accounting/gui/totals/UserTotal.java
@@ -42,7 +42,7 @@ public class UserTotal {
 		return paymentsFromPeriod.stream()
 				.filter(payment -> notDeletedBills.contains(payment.getBill().getId()))
 				.filter(payment -> payment.getUser().equals(user))
-				.map(payment -> new BigDecimal(Double.toString(payment.getAmount())))
+				.map(BillPayments::getAmount)
 				.reduce(BigDecimal.ZERO, BigDecimal::add);
 	}
 

--- a/src/main/java/org/isf/medicalinventory/gui/InventoryEdit.java
+++ b/src/main/java/org/isf/medicalinventory/gui/InventoryEdit.java
@@ -752,7 +752,8 @@ public class InventoryEdit extends ModalJFrame {
 			String wardCode = inventory.getDestination();
 			String lastReference = inventory.getInventoryReference();
 			LocalDateTime lastInventoryDate = inventory.getInventoryDate();
-			List<MedicalInventoryRow> invRowWithoutRealQty = inventoryRowSearchList.stream().filter(invRow -> invRow.getRealQty() == 0 && invRow.isNewLot())
+			List<MedicalInventoryRow> invRowWithoutRealQty = inventoryRowSearchList.stream()
+				.filter(invRow -> invRow.getRealQty().compareTo(BigDecimal.ZERO) == 0 && invRow.isNewLot())
 				.collect(Collectors.toList());
 			if (!invRowWithoutRealQty.isEmpty()) {
 				MessageDialog.error(null, "angal.inventory.allinventoryrowswithnewlotshouldhaverealqtygreatterthanzero.msg");
@@ -848,7 +849,8 @@ public class InventoryEdit extends ModalJFrame {
 				String wardCode = inventory.getDestination();
 				String lastReference = inventory.getInventoryReference();
 				LocalDateTime lastDate = inventory.getInventoryDate();
-				List<MedicalInventoryRow> invRowWithoutRealQty = inventoryRowSearchList.stream().filter(invRow -> invRow.getRealQty() == 0 && invRow.isNewLot())
+				List<MedicalInventoryRow> invRowWithoutRealQty = inventoryRowSearchList.stream()
+					.filter(invRow -> invRow.getRealQty().compareTo(BigDecimal.ZERO) == 0 && invRow.isNewLot())
 					.collect(Collectors.toList());
 				if (!invRowWithoutRealQty.isEmpty()) {
 					MessageDialog.error(null, "angal.inventory.allinventoryrowswithnewlotshouldhaverealqtygreatterthanzero.msg");
@@ -1252,14 +1254,13 @@ public class InventoryEdit extends ModalJFrame {
 				} else if (c == 6) {
 					return medInvtRow.getTheoreticQty();
 				} else if (c == 7) {
-					double dblValue = medInvtRow.getRealQty();
-					return (int) dblValue;
+					return medInvtRow.getRealQty().intValue();
 				} else if (c == 8) {
-					double difference = medInvtRow.getRealQty() - medInvtRow.getTheoreticQty();
-					return difference == 0. ? "" : (int) difference;
+					BigDecimal difference = medInvtRow.getRealQty().subtract(medInvtRow.getTheoreticQty());
+					return difference.signum() == 0 ? "" : difference.intValue();
 				} else if (c == 9) {
 					if (lot != null && lot.getCost() != null) {
-						medInvtRow.setTotal(lot.getCost().multiply(BigDecimal.valueOf(medInvtRow.getRealQty())));
+						medInvtRow.setTotal(lot.getCost().multiply(medInvtRow.getRealQty()));
 						return lot.getCost();
 					}
 					return BigDecimal.ZERO;
@@ -1278,21 +1279,21 @@ public class InventoryEdit extends ModalJFrame {
 			if (r < inventoryRowSearchList.size()) {
 				MedicalInventoryRow invRow = inventoryRowSearchList.get(r);
 				if (c == 7) {
-					double doubleValue = 0.0;
+					BigDecimal newQty = BigDecimal.ZERO;
 					if (value != null) {
 						try {
-							doubleValue = Double.parseDouble(value.toString());
+							newQty = new BigDecimal(value.toString());
 						} catch (NumberFormatException e) {
 							return;
 						}
 					}
-					if (doubleValue < 0) {
+					if (newQty.signum() < 0) {
 						MessageDialog.error(null, "angal.inventory.invalidquantity.msg");
 						return;
 					}
-					invRow.setRealqty(doubleValue);
+					invRow.setRealqty(newQty);
 					if (invRow.getLot() != null && invRow.getLot().getCost() != null) {
-						BigDecimal total = invRow.getLot().getCost().multiply(BigDecimal.valueOf(invRow.getRealQty()));
+						BigDecimal total = invRow.getLot().getCost().multiply(invRow.getRealQty());
 						invRow.setTotal(total);
 					}
 					inventoryRowListAdded.add(invRow);
@@ -1574,7 +1575,7 @@ public class InventoryEdit extends ModalJFrame {
 		while (medicalListIterator.hasNext()) {
 			Medical med = medicalListIterator.next();
 			lots = movStockInsertingManager.getLotByMedical(med, false);
-			double actualQty = med.getInqty() - med.getOutqty();
+			BigDecimal actualQty = BigDecimal.valueOf(med.getInqty() - med.getOutqty());
 			if (lots.isEmpty()) {
 				inventoryRowTemp = new MedicalInventoryRow(0, actualQty, actualQty, null, med, null);
 				inventoryRowTemp.setNewLot(true); // missing parameter in the above constructor
@@ -1585,7 +1586,8 @@ public class InventoryEdit extends ModalJFrame {
 				ListIterator<Lot> lotListIterator = lots.listIterator();
 				while (lotListIterator.hasNext()) {
 					Lot lot = lotListIterator.next();
-					inventoryRowTemp = new MedicalInventoryRow(0, lot.getMainStoreQuantity(), lot.getMainStoreQuantity(), null, med, lot);
+					inventoryRowTemp = new MedicalInventoryRow(0, BigDecimal.valueOf(lot.getMainStoreQuantity()), BigDecimal.valueOf(lot.getMainStoreQuantity()), null,
+						med, lot);
 					if (!existInInventorySearchList(inventoryRowTemp)) {
 						inventoryRowsList.add(inventoryRowTemp);
 					}
@@ -1605,7 +1607,7 @@ public class InventoryEdit extends ModalJFrame {
 		while (medicalListIterator.hasNext()) {
 			Medical med = medicalListIterator.next();
 			lots = movStockInsertingManager.getLotByMedical(med, false);
-			double actualQty = med.getInqty() - med.getOutqty();
+			BigDecimal actualQty = BigDecimal.valueOf(med.getInqty() - med.getOutqty());
 			if (lots.isEmpty()) {
 				inventoryRowTemp = new MedicalInventoryRow(0, actualQty, actualQty, null, med, null);
 				inventoryRowTemp.setNewLot(true); // missing parameter in the above constructor
@@ -1616,7 +1618,8 @@ public class InventoryEdit extends ModalJFrame {
 				ListIterator<Lot> lotListIterator = lots.listIterator();
 				while (lotListIterator.hasNext()) {
 					Lot lot = lotListIterator.next();
-					inventoryRowTemp = new MedicalInventoryRow(0, lot.getMainStoreQuantity(), lot.getMainStoreQuantity(), null, med, lot);
+					inventoryRowTemp = new MedicalInventoryRow(0, BigDecimal.valueOf(lot.getMainStoreQuantity()), BigDecimal.valueOf(lot.getMainStoreQuantity()), null,
+						med, lot);
 					if (!existInInventorySearchList(inventoryRowTemp)) {
 						inventoryRowsList.add(inventoryRowTemp);
 					}
@@ -1645,7 +1648,7 @@ public class InventoryEdit extends ModalJFrame {
 		while (medicalListIterator.hasNext()) {
 			Medical med = medicalListIterator.next();
 			lots = movStockInsertingManager.getLotByMedical(med, false);
-			double actualQty = med.getInqty() - med.getOutqty();
+			BigDecimal actualQty = BigDecimal.valueOf(med.getInqty() - med.getOutqty());
 			if (lots.isEmpty()) {
 				inventoryRowTemp = new MedicalInventoryRow(0, actualQty, actualQty, null, med, null);
 				inventoryRowTemp.setNewLot(true); // missing parameter in the above constructor
@@ -1656,7 +1659,8 @@ public class InventoryEdit extends ModalJFrame {
 				ListIterator<Lot> lotListIterator = lots.listIterator();
 				while (lotListIterator.hasNext()) {
 					Lot lot = lotListIterator.next();
-					inventoryRowTemp = new MedicalInventoryRow(0, lot.getMainStoreQuantity(), lot.getMainStoreQuantity(), null, med, lot);
+					inventoryRowTemp = new MedicalInventoryRow(0, BigDecimal.valueOf(lot.getMainStoreQuantity()), BigDecimal.valueOf(lot.getMainStoreQuantity()), null,
+						med, lot);
 					if (!existInInventorySearchList(inventoryRowTemp)) {
 						inventoryRowsList.add(inventoryRowTemp);
 					}
@@ -1692,7 +1696,7 @@ public class InventoryEdit extends ModalJFrame {
 			Medical med = medicalListIterator.next();
 			lots = movStockInsertingManager.getLotByMedical(med, false);
 			if (lots.isEmpty()) {
-				inventoryRowTemp = new MedicalInventoryRow(0, 0.0, 0.0, null, med, null);
+				inventoryRowTemp = new MedicalInventoryRow(0, BigDecimal.ZERO, BigDecimal.ZERO, null, med, null);
 				inventoryRowTemp.setNewLot(true); // missing parameter in the above constructor
 				if (!existInInventorySearchList(inventoryRowTemp)) {
 					inventoryRowsList.add(inventoryRowTemp);
@@ -1707,7 +1711,8 @@ public class InventoryEdit extends ModalJFrame {
 				ListIterator<Lot> lotListIterator = lots.listIterator();
 				while (lotListIterator.hasNext()) {
 					Lot lot = lotListIterator.next();
-					inventoryRowTemp = new MedicalInventoryRow(0, lot.getMainStoreQuantity(), lot.getMainStoreQuantity(), null, med, lot);
+					inventoryRowTemp = new MedicalInventoryRow(0, BigDecimal.valueOf(lot.getMainStoreQuantity()), BigDecimal.valueOf(lot.getMainStoreQuantity()), null,
+						med, lot);
 					if (!existInInventorySearchList(inventoryRowTemp)) {
 						inventoryRowsList.add(inventoryRowTemp);
 						numberOfMedicalWithoutSameLotAdded = numberOfMedicalWithoutSameLotAdded + 1;
@@ -1718,7 +1723,7 @@ public class InventoryEdit extends ModalJFrame {
 		if (medicalWithLot != null && numberOfMedicalWithoutSameLotAdded == 0) {
 			int info = MessageDialog.yesNo(null, "angal.inventory.productalreadyexist.fmt.msg", medicalWithLot.getDescription());
 			if (info == JOptionPane.YES_OPTION) {
-				inventoryRowTemp = new MedicalInventoryRow(0, 0.0, 0.0, null, medicalWithLot, null);
+				inventoryRowTemp = new MedicalInventoryRow(0, BigDecimal.ZERO, BigDecimal.ZERO, null, medicalWithLot, null);
 				inventoryRowTemp.setNewLot(true); // missing parameter in the above constructor
 				inventoryRowsList.add(inventoryRowTemp);
 			}
@@ -2076,7 +2081,7 @@ public class InventoryEdit extends ModalJFrame {
 	private List<MedicalInventoryRow> loadNewInventoryTable(boolean withNonZeroQty, MedicalType medicalTypeSelected) throws OHServiceException {
 		List<MedicalInventoryRow> inventoryRowsList = getMedicalInventoryRows(null);
 		if (withNonZeroQty) {
-			inventoryRowsList = inventoryRowsList.stream().filter(inv -> inv.getTheoreticQty() > 0).collect(Collectors.toList());
+			inventoryRowsList = inventoryRowsList.stream().filter(inv -> inv.getTheoreticQty().compareTo(BigDecimal.ZERO) > 0).collect(Collectors.toList());
 		}
 		if (medicalTypeSelected != null) {
 			inventoryRowsList = inventoryRowsList.stream()

--- a/src/main/java/org/isf/medicalinventory/gui/InventoryEdit.java
+++ b/src/main/java/org/isf/medicalinventory/gui/InventoryEdit.java
@@ -1252,7 +1252,7 @@ public class InventoryEdit extends ModalJFrame {
 					}
 					return "";
 				} else if (c == 6) {
-					return medInvtRow.getTheoreticQty();
+					return medInvtRow.getTheoreticQty().intValue();
 				} else if (c == 7) {
 					return medInvtRow.getRealQty().intValue();
 				} else if (c == 8) {
@@ -1587,8 +1587,8 @@ public class InventoryEdit extends ModalJFrame {
 				ListIterator<Lot> lotListIterator = lots.listIterator();
 				while (lotListIterator.hasNext()) {
 					Lot lot = lotListIterator.next();
-					inventoryRowTemp = new MedicalInventoryRow(0, BigDecimal.valueOf(lot.getMainStoreQuantity()), BigDecimal.valueOf(lot.getMainStoreQuantity()), null,
-						med, lot);
+					BigDecimal mainStoreQty = BigDecimal.valueOf(lot.getMainStoreQuantity());
+					inventoryRowTemp = new MedicalInventoryRow(0, mainStoreQty, mainStoreQty, null, med, lot);
 					if (!existInInventorySearchList(inventoryRowTemp)) {
 						inventoryRowsList.add(inventoryRowTemp);
 					}
@@ -1619,8 +1619,8 @@ public class InventoryEdit extends ModalJFrame {
 				ListIterator<Lot> lotListIterator = lots.listIterator();
 				while (lotListIterator.hasNext()) {
 					Lot lot = lotListIterator.next();
-					inventoryRowTemp = new MedicalInventoryRow(0, BigDecimal.valueOf(lot.getMainStoreQuantity()), BigDecimal.valueOf(lot.getMainStoreQuantity()), null,
-						med, lot);
+					BigDecimal mainStoreQty = BigDecimal.valueOf(lot.getMainStoreQuantity());
+					inventoryRowTemp = new MedicalInventoryRow(0, mainStoreQty, mainStoreQty, null, med, lot);
 					if (!existInInventorySearchList(inventoryRowTemp)) {
 						inventoryRowsList.add(inventoryRowTemp);
 					}
@@ -1660,8 +1660,8 @@ public class InventoryEdit extends ModalJFrame {
 				ListIterator<Lot> lotListIterator = lots.listIterator();
 				while (lotListIterator.hasNext()) {
 					Lot lot = lotListIterator.next();
-					inventoryRowTemp = new MedicalInventoryRow(0, BigDecimal.valueOf(lot.getMainStoreQuantity()), BigDecimal.valueOf(lot.getMainStoreQuantity()), null,
-						med, lot);
+					BigDecimal mainStoreQty = BigDecimal.valueOf(lot.getMainStoreQuantity());
+					inventoryRowTemp = new MedicalInventoryRow(0, mainStoreQty, mainStoreQty, null, med, lot);
 					if (!existInInventorySearchList(inventoryRowTemp)) {
 						inventoryRowsList.add(inventoryRowTemp);
 					}
@@ -1712,8 +1712,8 @@ public class InventoryEdit extends ModalJFrame {
 				ListIterator<Lot> lotListIterator = lots.listIterator();
 				while (lotListIterator.hasNext()) {
 					Lot lot = lotListIterator.next();
-					inventoryRowTemp = new MedicalInventoryRow(0, BigDecimal.valueOf(lot.getMainStoreQuantity()), BigDecimal.valueOf(lot.getMainStoreQuantity()), null,
-						med, lot);
+					BigDecimal mainStoreQty = BigDecimal.valueOf(lot.getMainStoreQuantity());
+					inventoryRowTemp = new MedicalInventoryRow(0, mainStoreQty, mainStoreQty, null, med, lot);
 					if (!existInInventorySearchList(inventoryRowTemp)) {
 						inventoryRowsList.add(inventoryRowTemp);
 						numberOfMedicalWithoutSameLotAdded = numberOfMedicalWithoutSameLotAdded + 1;

--- a/src/main/java/org/isf/medicalinventory/gui/InventoryEdit.java
+++ b/src/main/java/org/isf/medicalinventory/gui/InventoryEdit.java
@@ -1287,7 +1287,8 @@ public class InventoryEdit extends ModalJFrame {
 							return;
 						}
 					}
-					if (newQty.signum() < 0) {
+					// main-store stock is integer: reject negative and fractional quantities
+					if (newQty.signum() < 0 || newQty.stripTrailingZeros().scale() > 0) {
 						MessageDialog.error(null, "angal.inventory.invalidquantity.msg");
 						return;
 					}

--- a/src/main/java/org/isf/medicalinventory/gui/InventoryWardEdit.java
+++ b/src/main/java/org/isf/medicalinventory/gui/InventoryWardEdit.java
@@ -1721,8 +1721,8 @@ public class InventoryWardEdit extends ModalJFrame {
 				ListIterator<Lot> lotListIterator = lots.listIterator();
 				while (lotListIterator.hasNext()) {
 					Lot lot = lotListIterator.next();
-					inventoryRowTemp = new MedicalInventoryRow(0, BigDecimal.valueOf(lot.getMainStoreQuantity()), BigDecimal.valueOf(lot.getMainStoreQuantity()), null,
-						med, lot);
+					BigDecimal mainStoreQty = BigDecimal.valueOf(lot.getMainStoreQuantity());
+					inventoryRowTemp = new MedicalInventoryRow(0, mainStoreQty, mainStoreQty, null, med, lot);
 					if (!existInInventorySearchList(inventoryRowTemp)) {
 						inventoryRowsList.add(inventoryRowTemp);
 						numberOfMedicalWithoutSameLotAdded = numberOfMedicalWithoutSameLotAdded + 1;

--- a/src/main/java/org/isf/medicalinventory/gui/InventoryWardEdit.java
+++ b/src/main/java/org/isf/medicalinventory/gui/InventoryWardEdit.java
@@ -207,9 +207,9 @@ public class InventoryWardEdit extends ModalJFrame {
 	private boolean[] columnVisible = { false, true, true, true, !GeneralData.AUTOMATICLOT_IN, true, true, true, true, GeneralData.LOTWITHCOST,
 			GeneralData.LOTWITHCOST };
 	private boolean[] columnCentered = { false, false, false, true, true, true, true, true, true, true, true };
-	private boolean[] columnDecimalNumber = { false, false, false, false, false, false, false, false, false, true, true };
-	private Class< ? >[] columnsClasses = { String.class, Integer.class, String.class, String.class, String.class, LocalDate.class, Integer.class,
-			Integer.class, Integer.class, BigDecimal.class, BigDecimal.class };
+	private boolean[] columnDecimalNumber = { false, false, false, false, false, false, true, true, true, true, true };
+	private Class< ? >[] columnsClasses = { String.class, Integer.class, String.class, String.class, String.class, LocalDate.class, BigDecimal.class,
+			BigDecimal.class, BigDecimal.class, BigDecimal.class, BigDecimal.class };
 	private MedicalInventory inventory;
 	private JLabel addMedicalLabel;
 	private JButton selectButton;
@@ -692,7 +692,8 @@ public class InventoryWardEdit extends ModalJFrame {
 			}
 			String lastReference = inventory.getInventoryReference();
 			LocalDateTime lastInventoryDate = inventory.getInventoryDate();
-			List<MedicalInventoryRow> invRowWithoutRealQty = inventoryRowSearchList.stream().filter(invRow -> invRow.getRealQty() == 0 && invRow.isNewLot())
+			List<MedicalInventoryRow> invRowWithoutRealQty = inventoryRowSearchList.stream()
+				.filter(invRow -> invRow.getRealQty().compareTo(BigDecimal.ZERO) == 0 && invRow.isNewLot())
 				.collect(Collectors.toList());
 			if (!invRowWithoutRealQty.isEmpty()) {
 				MessageDialog.error(null, "angal.inventory.allinventoryrowswithnewlotshouldhaverealqtygreatterthanzero.msg");
@@ -780,7 +781,8 @@ public class InventoryWardEdit extends ModalJFrame {
 				}
 				String lastReference = inventory.getInventoryReference();
 				LocalDateTime lastDate = inventory.getInventoryDate();
-				List<MedicalInventoryRow> invRowWithoutRealQty = inventoryRowSearchList.stream().filter(invRow -> invRow.getRealQty() == 0 && invRow.isNewLot())
+				List<MedicalInventoryRow> invRowWithoutRealQty = inventoryRowSearchList.stream()
+					.filter(invRow -> invRow.getRealQty().compareTo(BigDecimal.ZERO) == 0 && invRow.isNewLot())
 					.collect(Collectors.toList());
 				if (!invRowWithoutRealQty.isEmpty()) {
 					MessageDialog.error(null, "angal.inventory.allinventoryrowswithnewlotshouldhaverealqtygreatterthanzero.msg");
@@ -1155,14 +1157,13 @@ public class InventoryWardEdit extends ModalJFrame {
 				} else if (c == 6) {
 					return medInvtRow.getTheoreticQty();
 				} else if (c == 7) {
-					double dblValue = medInvtRow.getRealQty();
-					return (int) dblValue;
+					return medInvtRow.getRealQty();
 				} else if (c == 8) {
-					double difference = medInvtRow.getRealQty() - medInvtRow.getTheoreticQty();
-					return difference == 0. ? "" : (int) difference;
+					BigDecimal difference = medInvtRow.getRealQty().subtract(medInvtRow.getTheoreticQty());
+					return difference.signum() == 0 ? "" : difference;
 				} else if (c == 9) {
 					if (lot != null && lot.getCost() != null) {
-						medInvtRow.setTotal(lot.getCost().multiply(BigDecimal.valueOf(medInvtRow.getRealQty())));
+						medInvtRow.setTotal(lot.getCost().multiply(medInvtRow.getRealQty()));
 						return lot.getCost();
 					}
 					return BigDecimal.ZERO;
@@ -1181,21 +1182,21 @@ public class InventoryWardEdit extends ModalJFrame {
 			if (r < inventoryRowSearchList.size()) {
 				MedicalInventoryRow invRow = inventoryRowSearchList.get(r);
 				if (c == 7) {
-					double doubleValue = 0.0;
+					BigDecimal newQty = BigDecimal.ZERO;
 					if (value != null) {
 						try {
-							doubleValue = Double.parseDouble(value.toString());
+							newQty = new BigDecimal(value.toString());
 						} catch (NumberFormatException e) {
 							return;
 						}
 					}
-					if (doubleValue < 0) {
+					if (newQty.signum() < 0) {
 						MessageDialog.error(null, "angal.inventory.invalidquantity.msg");
 						return;
 					}
-					invRow.setRealqty(doubleValue);
+					invRow.setRealqty(newQty);
 					if (invRow.getLot() != null && invRow.getLot().getCost() != null) {
-						BigDecimal total = invRow.getLot().getCost().multiply(BigDecimal.valueOf(invRow.getRealQty()));
+						BigDecimal total = invRow.getLot().getCost().multiply(invRow.getRealQty());
 						invRow.setTotal(total);
 					}
 					inventoryRowListAdded.add(invRow);
@@ -1568,7 +1569,7 @@ public class InventoryWardEdit extends ModalJFrame {
 		while (medicalListIterator.hasNext()) {
 			Medical med = medicalListIterator.next();
 			lots = movStockInsertingManager.getLotByMedical(med, false);
-			double actualQty = 0.;
+			BigDecimal actualQty = BigDecimal.ZERO;
 			if (lots.isEmpty()) {
 				inventoryRowTemp = new MedicalInventoryRow(0, actualQty, actualQty, null, med, null);
 				inventoryRowTemp.setNewLot(true); // missing parameter in the above constructor
@@ -1580,7 +1581,7 @@ public class InventoryWardEdit extends ModalJFrame {
 				while (lotListIterator.hasNext()) {
 					Lot lot = lotListIterator.next();
 					int lotQuantityInWard = movWardBrowserManager.getCurrentQuantityInWard(ward, lot);
-					inventoryRowTemp = new MedicalInventoryRow(0, lotQuantityInWard, lotQuantityInWard, null, med, lot);
+					inventoryRowTemp = new MedicalInventoryRow(0, BigDecimal.valueOf(lotQuantityInWard), BigDecimal.valueOf(lotQuantityInWard), null, med, lot);
 					if (!existInInventorySearchList(inventoryRowTemp)) {
 						inventoryRowsList.add(inventoryRowTemp);
 					}
@@ -1602,7 +1603,7 @@ public class InventoryWardEdit extends ModalJFrame {
 		while (medicalListIterator.hasNext()) {
 			Medical med = medicalListIterator.next();
 			lots = movStockInsertingManager.getLotByMedical(med, false);
-			double actualQty = 0.;
+			BigDecimal actualQty = BigDecimal.ZERO;
 			if (lots.isEmpty()) {
 				inventoryRowTemp = new MedicalInventoryRow(0, actualQty, actualQty, null, med, null);
 				inventoryRowTemp.setNewLot(true); // missing parameter in the above constructor
@@ -1614,7 +1615,7 @@ public class InventoryWardEdit extends ModalJFrame {
 				while (lotListIterator.hasNext()) {
 					Lot lot = lotListIterator.next();
 					int lotQuantityInWard = movWardBrowserManager.getCurrentQuantityInWard(ward, lot);
-					inventoryRowTemp = new MedicalInventoryRow(0, lotQuantityInWard, lotQuantityInWard, null, med, lot);
+					inventoryRowTemp = new MedicalInventoryRow(0, BigDecimal.valueOf(lotQuantityInWard), BigDecimal.valueOf(lotQuantityInWard), null, med, lot);
 					if (!existInInventorySearchList(inventoryRowTemp)) {
 						inventoryRowsList.add(inventoryRowTemp);
 					}
@@ -1657,7 +1658,7 @@ public class InventoryWardEdit extends ModalJFrame {
 		while (medicalListIterator.hasNext()) {
 			Medical med = medicalListIterator.next();
 			lots = movStockInsertingManager.getLotByMedical(med, false);
-			double actualQty = 0.;
+			BigDecimal actualQty = BigDecimal.ZERO;
 			if (lots.isEmpty()) {
 				inventoryRowTemp = new MedicalInventoryRow(0, actualQty, actualQty, null, med, null);
 				inventoryRowTemp.setNewLot(true); // missing parameter in the above constructor
@@ -1669,7 +1670,7 @@ public class InventoryWardEdit extends ModalJFrame {
 				while (lotListIterator.hasNext()) {
 					Lot lot = lotListIterator.next();
 					int lotQuantityInWard = movWardBrowserManager.getCurrentQuantityInWard(ward, lot);
-					inventoryRowTemp = new MedicalInventoryRow(0, lotQuantityInWard, lotQuantityInWard, null, med, lot);
+					inventoryRowTemp = new MedicalInventoryRow(0, BigDecimal.valueOf(lotQuantityInWard), BigDecimal.valueOf(lotQuantityInWard), null, med, lot);
 					if (!existInInventorySearchList(inventoryRowTemp)) {
 						inventoryRowsList.add(inventoryRowTemp);
 					}
@@ -1705,7 +1706,7 @@ public class InventoryWardEdit extends ModalJFrame {
 			Medical med = medicalListIterator.next();
 			lots = movStockInsertingManager.getLotByMedical(med, false);
 			if (lots.isEmpty()) {
-				inventoryRowTemp = new MedicalInventoryRow(0, 0.0, 0.0, null, med, null);
+				inventoryRowTemp = new MedicalInventoryRow(0, BigDecimal.ZERO, BigDecimal.ZERO, null, med, null);
 				inventoryRowTemp.setNewLot(true); // missing parameter in the above constructor
 				if (!existInInventorySearchList(inventoryRowTemp)) {
 					inventoryRowsList.add(inventoryRowTemp);
@@ -1720,7 +1721,8 @@ public class InventoryWardEdit extends ModalJFrame {
 				ListIterator<Lot> lotListIterator = lots.listIterator();
 				while (lotListIterator.hasNext()) {
 					Lot lot = lotListIterator.next();
-					inventoryRowTemp = new MedicalInventoryRow(0, lot.getMainStoreQuantity(), lot.getMainStoreQuantity(), null, med, lot);
+					inventoryRowTemp = new MedicalInventoryRow(0, BigDecimal.valueOf(lot.getMainStoreQuantity()), BigDecimal.valueOf(lot.getMainStoreQuantity()), null,
+						med, lot);
 					if (!existInInventorySearchList(inventoryRowTemp)) {
 						inventoryRowsList.add(inventoryRowTemp);
 						numberOfMedicalWithoutSameLotAdded = numberOfMedicalWithoutSameLotAdded + 1;
@@ -1731,7 +1733,7 @@ public class InventoryWardEdit extends ModalJFrame {
 		if (medicalWithLot != null && numberOfMedicalWithoutSameLotAdded == 0) {
 			int info = MessageDialog.yesNo(null, "angal.inventory.productalreadyexist.fmt.msg", medicalWithLot.getDescription());
 			if (info == JOptionPane.YES_OPTION) {
-				inventoryRowTemp = new MedicalInventoryRow(0, 0.0, 0.0, null, medicalWithLot, null);
+				inventoryRowTemp = new MedicalInventoryRow(0, BigDecimal.ZERO, BigDecimal.ZERO, null, medicalWithLot, null);
 				inventoryRowTemp.setNewLot(true); // missing parameter in the above constructor
 				inventoryRowsList.add(inventoryRowTemp);
 			}
@@ -1952,7 +1954,7 @@ public class InventoryWardEdit extends ModalJFrame {
 	private List<MedicalInventoryRow> loadNewInventoryTable(boolean withNonZeroQty, MedicalType medicalTypeSelected) throws OHServiceException {
 		List<MedicalInventoryRow> inventoryRowsList = getMedicalInventoryRows(null);
 		if (withNonZeroQty) {
-			inventoryRowsList = inventoryRowsList.stream().filter(inv -> inv.getTheoreticQty() > 0).collect(Collectors.toList());
+			inventoryRowsList = inventoryRowsList.stream().filter(inv -> inv.getTheoreticQty().compareTo(BigDecimal.ZERO) > 0).collect(Collectors.toList());
 		}
 		if (medicalTypeSelected != null) {
 			inventoryRowsList = inventoryRowsList.stream()

--- a/src/main/java/org/isf/medicals/gui/MedicalEdit.java
+++ b/src/main/java/org/isf/medicals/gui/MedicalEdit.java
@@ -52,7 +52,6 @@ import org.isf.utils.exception.gui.OHServiceExceptionUtil;
 import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
 import org.isf.utils.jobjects.MessageDialog;
-import org.isf.utils.jobjects.VoDoubleTextField;
 import org.isf.utils.jobjects.VoIntegerTextField;
 import org.isf.utils.jobjects.VoLimitedTextField;
 import org.isf.utils.layout.SpringUtilities;
@@ -113,7 +112,7 @@ public class MedicalEdit extends JDialog {
 	private VoIntegerTextField pcsperpckField;
 	private VoLimitedTextField descriptionTextField;
 	private VoLimitedTextField codeTextField;
-	private VoDoubleTextField minQtiField;
+	private VoIntegerTextField minQtiField;
 	private JComboBox<MedicalType> typeComboBox;
 	private JCheckBox activeCheckbox;
 	private Medical oldMedical;
@@ -404,9 +403,9 @@ public class MedicalEdit extends JDialog {
 	private JTextField getMinQtiField() {
 		if (minQtiField == null) {
 			if (insert) {
-				minQtiField = new VoDoubleTextField(0, 3);
+				minQtiField = new VoIntegerTextField(0, 3);
 			} else {
-				minQtiField = new VoDoubleTextField(medical.getMinqty(), 3);
+				minQtiField = new VoIntegerTextField(medical.getMinqty(), 3);
 			}
 		}
 		return minQtiField;

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
@@ -590,7 +590,7 @@ public class WardPharmacy extends ModalJFrame implements
 		List<MedicalWard> medicalWardList = new ArrayList<>();
 		for (MedicalWard elem : drug) {
 			if (elem.getMedical().getDescription().equals(me)) {
-				if (elem.getQty() != 0.0) {
+				if (elem.getQty().signum() != 0) {
 					MedicalWard e = elem;
 					medicalWardList.add(e);
 				}

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacyNew.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacyNew.java
@@ -162,7 +162,7 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 	private Patient patientSelected;
 	private float patientWeight;
 	private Ward wardSelected;
-	private Object[] medClasses = { Medical.class, Double.class, String.class };
+	private Object[] medClasses = { Medical.class, BigDecimal.class, String.class };
 	private String[] medColumnNames = {
 			MessageBundle.getMessage("angal.wardpharmacy.medical.col").toUpperCase(),
 			MessageBundle.getMessage("angal.common.quantity.txt").toUpperCase(),
@@ -323,16 +323,16 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 		}
 	}
 
-	private boolean checkQuantityInLot(MedicalWard medWard, double qty) {
-		double wardQty = medWard.getQty();
-		if (qty > wardQty) {
+	private boolean checkQuantityInLot(MedicalWard medWard, BigDecimal qty) {
+		BigDecimal wardQty = medWard.getQty();
+		if (qty.compareTo(wardQty) > 0) {
 			MessageDialog.error(this, "angal.medicalstock.movementquantityisgreaterthanthequantityof.fmt.msg", qty, wardQty);
 			return false;
 		}
 		return true;
 	}
 
-	private MedicalWard automaticChoose(List<MedicalWard> drug, String me, double quantity) {
+	private MedicalWard automaticChoose(List<MedicalWard> drug, String me, BigDecimal quantity) {
 		drug.sort((o1, o2) -> {
 			if (o1.getLot().getDueDate() == null || o2.getLot().getDueDate() == null) {
 				return 0;
@@ -341,15 +341,15 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 		});
 
 		MedicalWard medWard = null;
-		double q = quantity;
+		BigDecimal q = quantity;
 		for (MedicalWard elem : drug) {
 			if (elem.getMedical().getDescription().equals(me)) {
 
-				if (elem.getQty() != 0.0) {
-					if (q > 0) {
-						if (elem.getQty() <= q) {
-							double maxquantity = elem.getQty();
-							q = q - maxquantity;
+				if (elem.getQty().signum() != 0) {
+					if (q.signum() > 0) {
+						if (elem.getQty().compareTo(q) <= 0) {
+							BigDecimal maxquantity = elem.getQty();
+							q = q.subtract(maxquantity);
 							medWard = elem;
 							addItem(medWard, maxquantity);
 
@@ -357,7 +357,7 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 							medWard = elem;
 
 							addItem(medWard, q);
-							q = 0;
+							q = BigDecimal.ZERO;
 						}
 					}
 
@@ -368,12 +368,12 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 		return medWard;
 	}
 
-	private MedicalWard chooseLot(List<MedicalWard> drug, String me, double quantity) {
+	private MedicalWard chooseLot(List<MedicalWard> drug, String me, BigDecimal quantity) {
 		List<MedicalWard> dr = new ArrayList<>();
 		MedicalWard medWard = null;
 		for (MedicalWard elem : drug) {
 			if (elem.getMedical().getDescription().equals(me)) {
-				if (elem.getQty() != 0.0) {
+				if (elem.getQty().signum() != 0) {
 					MedicalWard e = elem;
 					dr.add(e);
 				}
@@ -413,14 +413,14 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 		return medWard;
 	}
 
-	protected double askQuantity(String med, List<MedicalWard> drug) {
-		double qty = 0;
-		double totalQty = 0;
+	protected BigDecimal askQuantity(String med, List<MedicalWard> drug) {
+		BigDecimal qty = BigDecimal.ZERO;
+		BigDecimal totalQty = BigDecimal.ZERO;
 		String prodCode = null;
 		for (MedicalWard elem : drug) {
 
 			if (med.equals(elem.getMedical().getDescription())) {
-				totalQty += elem.getQty();
+				totalQty = totalQty.add(elem.getQty());
 				prodCode = elem.getMedical().getProdCode();
 			}
 
@@ -446,17 +446,17 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 
 			if (quantity != null) {
 				try {
-					qty = Double.parseDouble(quantity);
-					if (qty == 0) {
-						return 0;
+					qty = new BigDecimal(quantity.trim());
+					if (qty.signum() == 0) {
+						return BigDecimal.ZERO;
 					}
-					if (qty < 0) {
+					if (qty.signum() < 0) {
 						throw new NumberFormatException();
 					}
 
 				} catch (NumberFormatException nfe) {
 					MessageDialog.error(this, "angal.medicalstock.multipledischarging.pleaseinsertavalidvalue");
-					qty = 0;
+					qty = BigDecimal.ZERO;
 				}
 			} else {
 				return qty;
@@ -471,15 +471,15 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 			} else {
 				askQuantity(med, wardDrugs);
 			}
-		} while (qty == 0);
+		} while (qty.signum() == 0);
 
 		return qty;
 
 	}
 
-	private boolean checkQuantity(double totalQty, double qty) {
+	private boolean checkQuantity(BigDecimal totalQty, BigDecimal qty) {
 
-		if (qty > totalQty) {
+		if (qty.compareTo(totalQty) > 0) {
 			StringBuilder message = new StringBuilder();
 			message.append(MessageBundle.getMessage("angal.medicalstock.multipledischarging.thequantityisnotavailable")) //$NON-NLS-1$
 				.append('\n') // $NON-NLS-1$
@@ -498,7 +498,7 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 			jButtonAddMedical.setIcon(new ImageIcon("rsc/icons/plus_button.png")); //$NON-NLS-1$
 			jButtonAddMedical.addActionListener(actionEvent -> {
 				String medical = (String) jComboBoxMedicals.getSelectedItem();
-				double quantity = askQuantity(medical, wardDrugs);
+				BigDecimal quantity = askQuantity(medical, wardDrugs);
 			});
 		}
 		return jButtonAddMedical;
@@ -524,7 +524,7 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 		return jButtonRemoveMedical;
 	}
 
-	private void addItem(MedicalWard ward, double quantity) {
+	private void addItem(MedicalWard ward, BigDecimal quantity) {
 		if (ward != null) {
 
 			MedicalWard item = new MedicalWard(ward.getMedical(), quantity, ward.getId().getLot());
@@ -614,7 +614,7 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 				try {
 					for (MedicalWard medItem : medItems) {
 						manyMovementWard.add(new MovementWard(wardSelected, newDate, isPatient, patientSelected,
-							age, patientWeight, description, medItem.getMedical(), new BigDecimal(Double.toString(medItem.getQty())),
+							age, patientWeight, description, medItem.getMedical(), medItem.getQty(),
 							MessageBundle.getMessage("angal.medicalstockwardedit.pieces"), wardTo, null, medItem.getLot()));
 					}
 

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacyNew.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacyNew.java
@@ -29,6 +29,7 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -613,7 +614,7 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 				try {
 					for (MedicalWard medItem : medItems) {
 						manyMovementWard.add(new MovementWard(wardSelected, newDate, isPatient, patientSelected,
-							age, patientWeight, description, medItem.getMedical(), medItem.getQty(),
+							age, patientWeight, description, medItem.getMedical(), new BigDecimal(Double.toString(medItem.getQty())),
 							MessageBundle.getMessage("angal.medicalstockwardedit.pieces"), wardTo, null, medItem.getLot()));
 					}
 

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacyNew.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacyNew.java
@@ -162,7 +162,7 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 	private Patient patientSelected;
 	private float patientWeight;
 	private Ward wardSelected;
-	private Object[] medClasses = { Medical.class, Integer.class, String.class };
+	private Object[] medClasses = { Medical.class, Double.class, String.class };
 	private String[] medColumnNames = {
 			MessageBundle.getMessage("angal.wardpharmacy.medical.col").toUpperCase(),
 			MessageBundle.getMessage("angal.common.quantity.txt").toUpperCase(),
@@ -332,7 +332,7 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 		return true;
 	}
 
-	private MedicalWard automaticChoose(List<MedicalWard> drug, String me, int quantity) {
+	private MedicalWard automaticChoose(List<MedicalWard> drug, String me, double quantity) {
 		drug.sort((o1, o2) -> {
 			if (o1.getLot().getDueDate() == null || o2.getLot().getDueDate() == null) {
 				return 0;
@@ -341,15 +341,15 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 		});
 
 		MedicalWard medWard = null;
-		int q = quantity;
+		double q = quantity;
 		for (MedicalWard elem : drug) {
 			if (elem.getMedical().getDescription().equals(me)) {
 
 				if (elem.getQty() != 0.0) {
-					if (q != 0) {
+					if (q > 0) {
 						if (elem.getQty() <= q) {
-							q = (int) (q - elem.getQty());
-							int maxquantity = (int) (elem.getQty() - 0);
+							double maxquantity = elem.getQty();
+							q = q - maxquantity;
 							medWard = elem;
 							addItem(medWard, maxquantity);
 
@@ -368,7 +368,7 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 		return medWard;
 	}
 
-	private MedicalWard chooseLot(List<MedicalWard> drug, String me, int quantity) {
+	private MedicalWard chooseLot(List<MedicalWard> drug, String me, double quantity) {
 		List<MedicalWard> dr = new ArrayList<>();
 		MedicalWard medWard = null;
 		for (MedicalWard elem : drug) {
@@ -413,8 +413,8 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 		return medWard;
 	}
 
-	protected int askQuantity(String med, List<MedicalWard> drug) {
-		int qty = 0;
+	protected double askQuantity(String med, List<MedicalWard> drug) {
+		double qty = 0;
 		double totalQty = 0;
 		String prodCode = null;
 		for (MedicalWard elem : drug) {
@@ -446,7 +446,7 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 
 			if (quantity != null) {
 				try {
-					qty = Integer.parseInt(quantity);
+					qty = Double.parseDouble(quantity);
 					if (qty == 0) {
 						return 0;
 					}
@@ -498,7 +498,7 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 			jButtonAddMedical.setIcon(new ImageIcon("rsc/icons/plus_button.png")); //$NON-NLS-1$
 			jButtonAddMedical.addActionListener(actionEvent -> {
 				String medical = (String) jComboBoxMedicals.getSelectedItem();
-				int quantity = askQuantity(medical, wardDrugs);
+				double quantity = askQuantity(medical, wardDrugs);
 			});
 		}
 		return jButtonAddMedical;
@@ -524,7 +524,7 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 		return jButtonRemoveMedical;
 	}
 
-	private void addItem(MedicalWard ward, int quantity) {
+	private void addItem(MedicalWard ward, double quantity) {
 		if (ward != null) {
 
 			MedicalWard item = new MedicalWard(ward.getMedical(), quantity, ward.getId().getLot());

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacyNew.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacyNew.java
@@ -622,7 +622,7 @@ public class WardPharmacyNew extends JDialog implements SelectionListener {
 					fireMovementWardInserted();
 					dispose();
 				} catch (OHServiceException ex) {
-					MessageDialog.error(null, "angal.common.datacouldnotbesaved.msg");
+					OHServiceExceptionUtil.showMessages(ex, this);
 				}
 			});
 		}

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacyRectify.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacyRectify.java
@@ -134,7 +134,7 @@ public class WardPharmacyRectify extends JDialog {
 	private MovStockInsertingManager movStockInsertingManager = Context.getApplicationContext().getBean(MovStockInsertingManager.class);
 
 	private List<Medical> medicals; // list of all medicals available in the application
-	private Map<Integer, Double> wardMap; // map quantities by their medical_id
+	private Map<Integer, BigDecimal> wardMap; // map quantities by their medical_id
 	private JTextField jTextFieldLotNumber;
 	private JButton jButtonChooseLot;
 	private List<MedicalWard> wardDrugs; // list of drugs available in the selected ward
@@ -171,8 +171,8 @@ public class WardPharmacyRectify extends JDialog {
 		for (MedicalWard medWard : wardDrugs) {
 
 			if (wardMap.containsKey(medWard.getMedical().getCode())) {
-				Double quantity = wardMap.get(medWard.getMedical().getCode());
-				wardMap.put(medWard.getMedical().getCode(), quantity + medWard.getQty());
+				BigDecimal quantity = wardMap.get(medWard.getMedical().getCode());
+				wardMap.put(medWard.getMedical().getCode(), quantity.add(medWard.getQty()));
 			} else {
 				wardMap.put(medWard.getMedical().getCode(), medWard.getQty());
 			}
@@ -193,8 +193,8 @@ public class WardPharmacyRectify extends JDialog {
 		for (MedicalWard medWard : wardDrugs) {
 
 			if (wardMap.containsKey(medWard.getMedical().getCode())) {
-				Double qu = wardMap.get(medWard.getMedical().getCode());
-				wardMap.put(medWard.getMedical().getCode(), qu + medWard.getQty());
+				BigDecimal qu = wardMap.get(medWard.getMedical().getCode());
+				wardMap.put(medWard.getMedical().getCode(), qu.add(medWard.getQty()));
 			} else {
 				wardMap.put(medWard.getMedical().getCode(), medWard.getQty());
 			}
@@ -724,9 +724,9 @@ public class WardPharmacyRectify extends JDialog {
 						}
 					}
 					Integer code = med.getCode();
-					Double qty = wardMap.get(code);
+					BigDecimal qty = wardMap.get(code);
 					if (qty == null) {
-						qty = 0.0D;
+						qty = BigDecimal.ZERO;
 					}
 					jTextFieldStockQty.setText(qty.toString());
 					jSpinnerNewQty.setValue(qty);

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacyRectify.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacyRectify.java
@@ -367,20 +367,20 @@ public class WardPharmacyRectify extends JDialog {
 				return;
 			}
 
-			double lotQty = 0;
+			BigDecimal lotQty = BigDecimal.ZERO;
 			try {
-				lotQty = movWardBrowserManager.getCurrentQuantityInWard(selectedWard, selectedLot);
+				lotQty = BigDecimal.valueOf(movWardBrowserManager.getCurrentQuantityInWard(selectedWard, selectedLot));
 			} catch (OHServiceException e2) {
 				OHServiceExceptionUtil.showMessages(e2);
 			}
-			double newQty = spinnerNewQtyModel.getNumber().doubleValue();
-			double movQuantity = lotQty - newQty;
+			BigDecimal newQty = new BigDecimal(spinnerNewQtyModel.getNumber().toString());
+			BigDecimal movQuantity = lotQty.subtract(newQty);
 
-			if (movQuantity == 0. || newQty < 0) {
+			if (movQuantity.signum() == 0 || newQty.signum() < 0) {
 				MessageDialog.error(this, "angal.medicalstockward.rectify.pleaseinsertavalidvalue");
 				return;
 			}
-			if (newQty == 0.) {
+			if (newQty.signum() == 0) {
 				int ok = JOptionPane.showConfirmDialog(this, MessageBundle.getMessage("angal.medicalstockward.rectify.thiswillemptythelotproceed"));
 				if (ok != JOptionPane.OK_OPTION) {
 					return;
@@ -390,7 +390,7 @@ public class WardPharmacyRectify extends JDialog {
 			try {
 				movStockInsertingManager.storeLot(selectedLot.getCode(), selectedLot, med);
 				movWardBrowserManager.newMovementWard(new MovementWard(selectedWard, TimeTools.getNow(), false, null, 0, 0, reason, med,
-					new BigDecimal(Double.toString(movQuantity)),
+					movQuantity,
 					MessageBundle.getMessage("angal.medicalstockward.rectify.pieces"), selectedLot));
 				fireMovementWardInserted();
 				dispose();
@@ -492,7 +492,7 @@ public class WardPharmacyRectify extends JDialog {
 			}
 
 			jTextFieldLotNumber.setText(addLot.getCode());
-			jSpinnerNewQty.setValue(0);
+			jSpinnerNewQty.setValue(0.0d);
 			jLabelLotQty.setText("0");
 			jLabelInLot.setVisible(true);
 			if (GeneralData.LOTWITHCOST) {
@@ -522,7 +522,7 @@ public class WardPharmacyRectify extends JDialog {
 					return null;
 				}
 				jTextFieldLotNumber.setText(medWard.getLot().getCode());
-				jSpinnerNewQty.setValue(medWard.getQty());
+				jSpinnerNewQty.setValue(medWard.getQty().doubleValue());
 				jLabelLotQty.setText(medWard.getQty().toString());
 				jLabelInLot.setVisible(true);
 				selectedLot = medWard.getLot();
@@ -592,25 +592,25 @@ public class WardPharmacyRectify extends JDialog {
 	}
 
 	protected BigDecimal askCost() {
-		double cost = 0.;
+		BigDecimal cost = BigDecimal.ZERO;
 		do {
 			String input = JOptionPane.showInputDialog(this,
 				MessageBundle.getMessage("angal.medicalstockward.rectify.unitcost"), //$NON-NLS-1$
 				0.);
 			if (input != null) {
 				try {
-					cost = Double.parseDouble(input);
-					if (cost < 0) {
+					cost = new BigDecimal(input);
+					if (cost.signum() < 0) {
 						throw new NumberFormatException();
 					}
 				} catch (NumberFormatException nfe) {
 					MessageDialog.error(this, "angal.medicalstockward.rectify.pleaseinsertavalidvalue");
 				}
 			} else {
-				return BigDecimal.valueOf(cost);
+				return cost;
 			}
-		} while (cost == 0.);
-		return BigDecimal.valueOf(cost);
+		} while (cost.signum() == 0);
+		return cost;
 	}
 
 	protected int askQuantity(Medical med) {
@@ -657,14 +657,14 @@ public class WardPharmacyRectify extends JDialog {
 			jSpinnerNewQty = new JSpinner(spinnerNewQtyModel);
 			jSpinnerNewQty.setFont(FONT_BOLD);
 			jSpinnerNewQty.addChangeListener(changeEvent -> {
-				double stock = Double.parseDouble(jTextFieldStockQty.getText());
-				double newQty = spinnerNewQtyModel.getNumber().doubleValue();
-				if (stock > 0) {
+				BigDecimal stock = new BigDecimal(jTextFieldStockQty.getText());
+				BigDecimal newQty = new BigDecimal(spinnerNewQtyModel.getNumber().toString());
+				if (stock.signum() > 0) {
 					jButtonChooseLot.setEnabled(true);
 				}
-				if (newQty > stock) {
+				if (newQty.compareTo(stock) > 0) {
 					jButtonNewLot.setEnabled(true);
-				} else if (newQty < stock) {
+				} else if (newQty.compareTo(stock) < 0) {
 					jButtonNewLot.setEnabled(false);
 				}
 			});
@@ -729,7 +729,7 @@ public class WardPharmacyRectify extends JDialog {
 						qty = BigDecimal.ZERO;
 					}
 					jTextFieldStockQty.setText(qty.toString());
-					jSpinnerNewQty.setValue(qty);
+					jSpinnerNewQty.setValue(qty.doubleValue());
 				} catch (ClassCastException ex) {
 					jTextFieldStockQty.setText(""); //$NON-NLS-1$
 					jSpinnerNewQty.setValue(0.0D);

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacyRectify.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacyRectify.java
@@ -389,7 +389,8 @@ public class WardPharmacyRectify extends JDialog {
 
 			try {
 				movStockInsertingManager.storeLot(selectedLot.getCode(), selectedLot, med);
-				movWardBrowserManager.newMovementWard(new MovementWard(selectedWard, TimeTools.getNow(), false, null, 0, 0, reason, med, movQuantity,
+				movWardBrowserManager.newMovementWard(new MovementWard(selectedWard, TimeTools.getNow(), false, null, 0, 0, reason, med,
+					new BigDecimal(Double.toString(movQuantity)),
 					MessageBundle.getMessage("angal.medicalstockward.rectify.pieces"), selectedLot));
 				fireMovementWardInserted();
 				dispose();

--- a/src/main/java/org/isf/priceslist/gui/PriceModel.java
+++ b/src/main/java/org/isf/priceslist/gui/PriceModel.java
@@ -127,7 +127,7 @@ public class PriceModel extends AbstractTreeTableModel {
 				displayValue = price.getDesc();
 				break;
 			case 1:
-				displayValue = price.getPrice().doubleValue();
+				displayValue = price.getPrice() != null ? price.getPrice().doubleValue() : null;
 				break;
 			default:
 				break;

--- a/src/main/java/org/isf/priceslist/gui/PriceModel.java
+++ b/src/main/java/org/isf/priceslist/gui/PriceModel.java
@@ -61,6 +61,7 @@ package org.isf.priceslist.gui;
  * maintenance of any nuclear facility.
  */
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -113,7 +114,7 @@ public class PriceModel extends AbstractTreeTableModel {
 	@Override
 	public void setValueAt(Object aValue, Object node, int column) {
 		if (column == 1) {
-			((PriceNode) node).getPrice().setPrice((Double) aValue);
+			((PriceNode) node).getPrice().setPrice(BigDecimal.valueOf((Double) aValue));
 		}
 	}
 
@@ -126,7 +127,7 @@ public class PriceModel extends AbstractTreeTableModel {
 				displayValue = price.getDesc();
 				break;
 			case 1:
-				displayValue = price.getPrice();
+				displayValue = price.getPrice().doubleValue();
 				break;
 			default:
 				break;

--- a/src/main/java/org/isf/priceslist/gui/PricesBrowser.java
+++ b/src/main/java/org/isf/priceslist/gui/PricesBrowser.java
@@ -25,6 +25,7 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.FlowLayout;
 import java.awt.Font;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -333,28 +334,28 @@ public class PricesBrowser extends ModalJFrame {
 		examNodes = new PriceNode(new Price(null, "", "", cCategoriesNames[0], null)); //$NON-NLS-1$ //$NON-NLS-2$
 		for (Exam exa : examArray) {
 			Price p = priceHashTable.get(listSelected.getId() + cCategories[0] + exa.getCode());
-			double priceValue = p != null ? p.getPrice() : 0.;
+			BigDecimal priceValue = p != null ? p.getPrice() : BigDecimal.ZERO;
 			examNodes.addItem(new PriceNode(new Price(null, cCategories[0], exa.getCode(), exa.getDescription(), priceValue)));
 		}
 
 		opeNodes = new PriceNode(new Price(null, "", "", cCategoriesNames[1], null)); //$NON-NLS-1$ //$NON-NLS-2$
 		for (Operation ope : operArray) {
 			Price p = priceHashTable.get(listSelected.getId() + cCategories[1] + ope.getCode());
-			double priceValue = p != null ? p.getPrice() : 0.;
+			BigDecimal priceValue = p != null ? p.getPrice() : BigDecimal.ZERO;
 			opeNodes.addItem(new PriceNode(new Price(null, cCategories[1], ope.getCode(), ope.getDescription(), priceValue)));
 		}
 
 		medNodes = new PriceNode(new Price(null, "", "", cCategoriesNames[2], null)); //$NON-NLS-1$ //$NON-NLS-2$
 		for (Medical med : mediArray) {
 			Price p = priceHashTable.get(listSelected.getId() + cCategories[2] + med.getCode().toString());
-			double priceValue = p != null ? p.getPrice() : 0.;
+			BigDecimal priceValue = p != null ? p.getPrice() : BigDecimal.ZERO;
 			medNodes.addItem(new PriceNode(new Price(null, cCategories[2], med.getCode().toString(), med.getDescription(), priceValue)));
 		}
 
 		othNodes = new PriceNode(new Price(null, "", "", cCategoriesNames[3], null)); //$NON-NLS-1$ //$NON-NLS-2$
 		for (PricesOthers oth : othArray) {
 			Price p = priceHashTable.get(listSelected.getId() + cCategories[3] + oth.getId());
-			double priceValue = p != null ? p.getPrice() : 0.;
+			BigDecimal priceValue = p != null ? p.getPrice() : BigDecimal.ZERO;
 			othNodes.addItem(
 					new PriceNode(new Price(null, cCategories[3], Integer.toString(oth.getId()), oth.getDescription(), priceValue, !oth.isUndefined())));
 		}

--- a/src/test/java/org/isf/accounting/gui/TestBill.java
+++ b/src/test/java/org/isf/accounting/gui/TestBill.java
@@ -21,6 +21,8 @@
  */
 package org.isf.accounting.gui;
 
+import java.math.BigDecimal;
+
 import org.isf.accounting.model.Bill;
 
 public class TestBill {
@@ -28,7 +30,7 @@ public class TestBill {
 	public static Bill notDeletedBillWithBalance(int id, double amount) {
 		Bill bill = new Bill();
 		bill.setId(id);
-		bill.setBalance(java.math.BigDecimal.valueOf(amount));
+		bill.setBalance(BigDecimal.valueOf(amount));
 		return bill;
 	}
 
@@ -36,14 +38,14 @@ public class TestBill {
 		Bill bill = new Bill();
 		bill.setId(id);
 		bill.setStatus(status);
-		bill.setBalance(java.math.BigDecimal.valueOf(100));
+		bill.setBalance(BigDecimal.valueOf(100));
 		return bill;
 	}
 
 	public static Bill deletedBillWithBalance(int id, double amount) {
 		Bill bill = new Bill();
 		bill.setId(id);
-		bill.setBalance(java.math.BigDecimal.valueOf(amount));
+		bill.setBalance(BigDecimal.valueOf(amount));
 		bill.setStatus("D");
 		return bill;
 	}

--- a/src/test/java/org/isf/accounting/gui/TestBill.java
+++ b/src/test/java/org/isf/accounting/gui/TestBill.java
@@ -28,7 +28,7 @@ public class TestBill {
 	public static Bill notDeletedBillWithBalance(int id, double amount) {
 		Bill bill = new Bill();
 		bill.setId(id);
-		bill.setBalance(amount);
+		bill.setBalance(java.math.BigDecimal.valueOf(amount));
 		return bill;
 	}
 
@@ -36,14 +36,14 @@ public class TestBill {
 		Bill bill = new Bill();
 		bill.setId(id);
 		bill.setStatus(status);
-		bill.setBalance(100d);
+		bill.setBalance(java.math.BigDecimal.valueOf(100));
 		return bill;
 	}
 
 	public static Bill deletedBillWithBalance(int id, double amount) {
 		Bill bill = new Bill();
 		bill.setId(id);
-		bill.setBalance(amount);
+		bill.setBalance(java.math.BigDecimal.valueOf(amount));
 		bill.setStatus("D");
 		return bill;
 	}

--- a/src/test/java/org/isf/accounting/gui/TestPayment.java
+++ b/src/test/java/org/isf/accounting/gui/TestPayment.java
@@ -28,7 +28,7 @@ public class TestPayment {
 
 	public static BillPayments withAmountAndBill(double amount, Bill bill) {
 		BillPayments billPayments = new BillPayments();
-		billPayments.setAmount(amount);
+		billPayments.setAmount(java.math.BigDecimal.valueOf(amount));
 		billPayments.setBill(bill);
 		return billPayments;
 	}

--- a/src/test/java/org/isf/accounting/gui/TestPayment.java
+++ b/src/test/java/org/isf/accounting/gui/TestPayment.java
@@ -21,6 +21,8 @@
  */
 package org.isf.accounting.gui;
 
+import java.math.BigDecimal;
+
 import org.isf.accounting.model.Bill;
 import org.isf.accounting.model.BillPayments;
 
@@ -28,7 +30,7 @@ public class TestPayment {
 
 	public static BillPayments withAmountAndBill(double amount, Bill bill) {
 		BillPayments billPayments = new BillPayments();
-		billPayments.setAmount(java.math.BigDecimal.valueOf(amount));
+		billPayments.setAmount(BigDecimal.valueOf(amount));
 		billPayments.setBill(bill);
 		return billPayments;
 	}


### PR DESCRIPTION
## OP-1216 — Adapt the Swing GUI to the DECIMAL/INT type change

Adapts the GUI to the core type change (OP-1216) and fixes two issues found
while testing the feature end-to-end against a migrated demo database.

### Changes
- Accounting totals (Balance/Payments/User) and `PatientBillEdit` use the
  `BigDecimal` amount/balance getters directly.
- Price model/browser handle `BigDecimal` price (display narrows to `double`
  only for rendering); `MedicalEdit` and the Ward Pharmacy screens build
  movements with `BigDecimal`/`int` quantities.
- **Fix — fractional ward dispensing** (`WardPharmacyNew`): the dispense
  quantity was parsed with `Integer.parseInt`, so a half-unit (e.g. `2.5`) was
  rejected with "Insert a valid value" even though the ward movement quantity is
  DECIMAL. The charging quantity is now handled as `BigDecimal` end-to-end.
  Incoming ward stock stays integer, per the ticket.
- **`WardPharmacyRectify`**: the rectification arithmetic (`lotQty`, `newQty`,
  `movQuantity`) runs on `BigDecimal` and the movement quantity is passed
  through unchanged; the unit-cost prompt parses straight into `BigDecimal`.
  The quantity spinner keeps a `Double`-based model (`SpinnerNumberModel`
  increments a `BigDecimal` value through `longValue()`, which would break the
  0.5 stepping), and every `setValue` call is normalized to `Double`.
- **Inventory screens**: `InventoryWardEdit` and `InventoryEdit` adapted to the
  `BigDecimal` `MedicalInventoryRow`. The ward inventory accepts fractional
  real quantities (quantity columns use `BigDecimal` and the existing decimal
  renderer); the main-store inventory keeps integer entry and rejects
  fractional input with the standard invalid-quantity error, consistent with
  the integer main-store stock.
- **Fix — Price Lists screen crash** (`PriceModel`): `getValueAt` called
  `price.getPrice().doubleValue()`, but group/category nodes in the price tree
  have a null price, so the whole Price Lists screen rendered an empty tree
  (repeated `NullPointerException`). Guarded the null case.
- Tests updated for the new types.

### Verification
- `mvn package` green.
- Manual end-to-end on a migrated demo DB: a bill with items `0.1 + 0.2` totals
  exactly `0.3`; editing a price to `19.99` persists exactly; dispensing `2.5`
  from a ward stores the movement and out-quantity as `2.50`; a ward inventory
  row saved with real quantity `1.5` persists as an exact `1.50`; a ward
  rectification of `2.5` stores an exact `-2.50` movement; typing `2.5` in the
  main-store inventory is rejected, `3` is accepted.

Requires the core change. Companion PRs (same branch name for CI cross-build)
are linked in a comment below.

JIRA: https://openhospital.atlassian.net/browse/OP-1216
