### PR TITLE
OP-1404 Add i18n messages for Operation row validation

### DIFF
--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -1453,6 +1453,12 @@ angal.operation.type                                                            
 angal.operationrow.clear.btn                                                                           = Clear
 angal.operationrow.clear.btn.key                                                                       = L
 angal.operationrow.not.found.msg                                                                       = Operation row not found.
+angal.operationrow.pleaseinsertanoperation.msg                                                         = Please select an operation.
+angal.operationrow.pleaseinsertaprescriber.msg                                                         = Please insert a prescriber.
+angal.operationrow.pleaseinsertavaliddate.msg                                                          = Please insert a valid date.
+angal.operationrow.theprescriberistoolongmaxchars.fmt.msg                                              = The prescriber is too long (max. {0} chars).
+angal.operationrow.theremarksaretoolongmaxchars.fmt.msg                                                = The remarks are too long (max. {0} chars).
+angal.operationrow.theresultistoolongmaxchars.fmt.msg                                                  = The result is too long (max. {0} chars).
 angal.operationrowedit.operation                                                                       = Operation
 angal.operationrowedit.remark                                                                          = Remarks
 angal.operationrowedit.saveerror                                                                       = Error occurs during processing

--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -1453,7 +1453,7 @@ angal.operation.type                                                            
 angal.operationrow.clear.btn                                                                           = Clear
 angal.operationrow.clear.btn.key                                                                       = L
 angal.operationrow.not.found.msg                                                                       = Operation row not found.
-angal.operationrow.pleaseinsertanoperation.msg                                                         = Please select an operation.
+angal.operationrow.pleaseinsertanoperation.msg                                                         = Please insert an operation.
 angal.operationrow.pleaseinsertaprescriber.msg                                                         = Please insert a prescriber.
 angal.operationrow.pleaseinsertavaliddate.msg                                                          = Please insert a valid date.
 angal.operationrow.theprescriberistoolongmaxchars.fmt.msg                                              = The prescriber is too long (max. {0} chars).

--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -1456,6 +1456,7 @@ angal.operationrow.not.found.msg                                                
 angal.operationrow.pleaseinsertanoperation.msg                                                         = Please insert an operation.
 angal.operationrow.pleaseinsertaprescriber.msg                                                         = Please insert a prescriber.
 angal.operationrow.pleaseinsertavaliddate.msg                                                          = Please insert a valid date.
+angal.operationrow.pleaseselectaresult.msg                                                             = Please select a result.
 angal.operationrow.theprescriberistoolongmaxchars.fmt.msg                                              = The prescriber is too long (max. {0} chars).
 angal.operationrow.theremarksaretoolongmaxchars.fmt.msg                                                = The remarks are too long (max. {0} chars).
 angal.operationrow.theresultistoolongmaxchars.fmt.msg                                                  = The result is too long (max. {0} chars).

--- a/src/main/java/org/isf/operation/gui/OperationRowAdm.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowAdm.java
@@ -73,14 +73,14 @@ public class OperationRowAdm extends OperationRowBase implements AdmissionListen
 			MessageDialog.error(this, "angal.operationrowedit.warningdateafter");
 			return;
 		}
+		if (this.comboResult.getSelectedItem() == null) {
+			MessageDialog.error(this, "angal.operationrow.pleaseselectaresult.msg");
+			return;
+		}
 
 		OperationRow operationRow = new OperationRow();
 		operationRow.setOpDate(this.textDate.getLocalDateTime());
-		if (this.comboResult.getSelectedItem() != null) {
-			operationRow.setOpResult(operationBrowserManager.getResultDescriptionKey((String) comboResult.getSelectedItem()));
-		} else {
-			operationRow.setOpResult("");
-		}
+		operationRow.setOpResult(operationBrowserManager.getResultDescriptionKey((String) comboResult.getSelectedItem()));
 		try {
 			operationRow.setTransUnit(Float.parseFloat(this.textFieldUnit.getText()));
 		} catch (NumberFormatException e) {

--- a/src/main/java/org/isf/operation/gui/OperationRowBase.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowBase.java
@@ -80,6 +80,7 @@ abstract class OperationRowBase extends JPanel {
 	protected JButton searchOperationButton;
 	protected JComboBox<String> comboResult;
 	protected JTextArea textAreaRemark;
+	protected JButton btnAdd;
 
 	protected OperationBrowserManager operationBrowserManager = Context.getApplicationContext().getBean(OperationBrowserManager.class);
 	protected OperationRowBrowserManager operationRowBrowserManager = Context.getApplicationContext().getBean(OperationRowBrowserManager.class);
@@ -260,7 +261,7 @@ abstract class OperationRowBase extends JPanel {
 		flowLayout.setAlignment(FlowLayout.RIGHT);
 		panelListData.add(panelActions, BorderLayout.NORTH);
 
-		JButton btnAdd = new JButton(MessageBundle.getMessage("angal.operationrowlist.add.btn"));
+		btnAdd = new JButton(MessageBundle.getMessage("angal.operationrowlist.add.btn"));
 		btnAdd.setMnemonic(MessageBundle.getMnemonic("angal.operationrowlist.add.btn.key"));
 		btnAdd.addActionListener(actionEvent -> addToGrid());
 		panelActions.add(btnAdd);
@@ -433,6 +434,9 @@ abstract class OperationRowBase extends JPanel {
 		}
 		comboResult.setSelectedIndex(index);
 		/* *********** */
+		// OP-1404: a row was loaded for editing — turn the Add button into Update
+		btnAdd.setText(MessageBundle.getMessage("angal.common.update.btn"));
+		btnAdd.setMnemonic(MessageBundle.getMnemonic("angal.common.update.btn.key"));
 	}
 
 	public void deleteOpeRow(Component parentComponent, int idRow) {
@@ -477,6 +481,9 @@ abstract class OperationRowBase extends JPanel {
 		textFieldUnit.setText(""); //$NON-NLS-1$
 		tableData.clearSelection();
 		comboOperation.setEnabled(true);
+		// OP-1404: back to new-row mode — restore the Add label
+		btnAdd.setText(MessageBundle.getMessage("angal.operationrowlist.add.btn"));
+		btnAdd.setMnemonic(MessageBundle.getMnemonic("angal.operationrowlist.add.btn.key"));
 	}
 
 	public List<OperationRow> getOprowData() {

--- a/src/main/java/org/isf/operation/gui/OperationRowBase.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowBase.java
@@ -383,6 +383,8 @@ abstract class OperationRowBase extends JPanel {
 		for (String description : operationResults) {
 			comboResult.addItem(description);
 		}
+		// OP-1404: start with no result pre-selected, so the user must choose one explicitly instead of silently saving the first value.
+		comboResult.setSelectedIndex(-1);
 		return comboResult;
 	}
 
@@ -421,7 +423,9 @@ abstract class OperationRowBase extends JPanel {
 		}
 
 		/* ***** resultat **** */
-		int index = 0;
+		// OP-1404: leave the result unselected when the row has no (or an unknown) stored result,
+		// so editing an old row can't silently re-save the first value; the user must pick one.
+		int index = -1;
 		for (int i = 0; i < operationResults.size(); i++) {
 			if (opeRow.getOpResult() != null && operationBrowserManager.getResultDescriptionKey(operationResults.get(i)).equals(opeRow.getOpResult())) {
 				index = i;

--- a/src/main/java/org/isf/operation/gui/OperationRowOpd.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowOpd.java
@@ -65,15 +65,14 @@ public class OperationRowOpd extends OperationRowBase implements SurgeryListener
 			MessageDialog.error(this, "angal.operationrowedit.warningdateope");
 			return;
 		}
+		if (this.comboResult.getSelectedItem() == null) {
+			MessageDialog.error(this, "angal.operationrow.pleaseselectaresult.msg");
+			return;
+		}
 
 		OperationRow operationRow = new OperationRow();
 		operationRow.setOpDate(this.textDate.getLocalDateTime());
-		if (this.comboResult.getSelectedItem() != null) {
-			String opResult = operationBrowserManager.getResultDescriptionKey((String) comboResult.getSelectedItem());
-			operationRow.setOpResult(opResult);
-		} else {
-			operationRow.setOpResult(""); //$NON-NLS-1$
-		}
+		operationRow.setOpResult(operationBrowserManager.getResultDescriptionKey((String) comboResult.getSelectedItem()));
 		try {
 			operationRow.setTransUnit(Float.parseFloat(this.textFieldUnit.getText()));
 		} catch (NumberFormatException e) {
@@ -92,7 +91,6 @@ public class OperationRowOpd extends OperationRowBase implements SurgeryListener
 		} else {
 			OperationRow opeInter = oprowData.get(index);
 			opeInter.setOpDate(this.textDate.getLocalDateTime());
-			opeInter.setOpResult(this.comboResult.getSelectedItem().toString());
 			String opResult = operationBrowserManager.getResultDescriptionKey((String) comboResult.getSelectedItem());
 			opeInter.setOpResult(opResult);
 			opeInter.setTransUnit(Float.parseFloat(this.textFieldUnit.getText()));


### PR DESCRIPTION
## What & why

Adds the English messages used by the new `OperationRowBrowserManager` validation introduced in the core companion PR (OP-1404): mandatory `operation`/`prescriber`/date and the length limits for `result`/`remarks`.

## Changes

- `bundle/language_en.properties`: 6 new `angal.operationrow.*` keys (alphabetically placed, aligned to the `=` column convention). English bundle only, per repo convention.

## Companion PR

Core validation: informatici/openhospital-core (same branch `OP-1404-operation-validation`).

Jira: OP-1404
