### PR TITLE
OP-1061 Use the hospital global currency for price lists

### DIFF
--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -1627,6 +1627,7 @@ angal.priceslist.pleaseinsertanameforthelist.msg                                
 angal.priceslist.pleaseselectalisttocopy                                                               = Please select a List to copy
 angal.priceslist.pleaseselectalisttodelete                                                             = Please select a List to delete
 angal.priceslist.pleaseselectalisttoedit                                                               = Please select a List to edit
+angal.priceslist.pleasesethospitalcurrency.msg                                                         = Please set the hospital currency in the Hospital information before defining a price list.
 angal.priceslist.pricebrowser.title                                                                    = Price Browser
 angal.priceslist.prices.txt                                                                            = Prices
 angal.priceslist.printing.btn                                                                          = Printing

--- a/src/main/java/org/isf/priceslist/gui/ListEdit.java
+++ b/src/main/java/org/isf/priceslist/gui/ListEdit.java
@@ -35,6 +35,7 @@ import javax.swing.SpringLayout;
 import javax.swing.event.EventListenerList;
 
 import org.isf.generaldata.MessageBundle;
+import org.isf.hospital.manager.HospitalBrowsingManager;
 import org.isf.menu.manager.Context;
 import org.isf.priceslist.manager.PriceListManager;
 import org.isf.priceslist.model.PriceList;
@@ -86,6 +87,8 @@ public class ListEdit extends JDialog {
 	}
 
 	private PriceListManager priceListManager = Context.getApplicationContext().getBean(PriceListManager.class);
+	private HospitalBrowsingManager hospitalManager = Context.getApplicationContext().getBean(HospitalBrowsingManager.class);
+	private String currencyCod;
 
 	private static final long serialVersionUID = 1L;
 	private JPanel jPanelData;
@@ -113,6 +116,11 @@ public class ListEdit extends JDialog {
 	}
 
 	private void initComponents() {
+		try {
+			currencyCod = hospitalManager.getHospitalCurrencyCod();
+		} catch (OHServiceException e) {
+			OHServiceExceptionUtil.showMessages(e);
+		}
 		add(getJPanelData(), BorderLayout.CENTER);
 		add(getJPanelButtons(), BorderLayout.SOUTH);
 		setSize(400, 200);
@@ -120,6 +128,11 @@ public class ListEdit extends JDialog {
 			this.setTitle(MessageBundle.getMessage("angal.priceslist.newlist.title"));
 		} else {
 			this.setTitle(MessageBundle.getMessage("angal.priceslist.editlist.title"));
+		}
+		if (currencyCod == null || currencyCod.isEmpty()) {
+			// without a global hospital currency the list cannot pass core validation: warn and block saving
+			MessageDialog.warning(null, "angal.priceslist.pleasesethospitalcurrency.msg");
+			getJButtonOK().setEnabled(false);
 		}
 	}
 
@@ -242,18 +255,16 @@ public class ListEdit extends JDialog {
 	private JTextField getJTextFieldCurrency() {
 		if (jTextFieldCurrency == null) {
 			jTextFieldCurrency = new VoLimitedTextField(10, 20);
-			if (!insert) {
-				jTextFieldCurrency.setText(list.getCurrency());
-			} else {
-				jTextFieldCurrency.setText(""); //$NON-NLS-1$
-			}
+			// Currency is no longer user input: all price lists share the global hospital currency
+			jTextFieldCurrency.setText(currencyCod != null ? currencyCod : ""); //$NON-NLS-1$
+			jTextFieldCurrency.setEnabled(false);
 		}
 		return jTextFieldCurrency;
 	}
 
 	private JLabel getJLabelCurrency() {
 		if (jLabelCurrency == null) {
-			jLabelCurrency = new JLabel(MessageBundle.getMessage("angal.priceslist.currencystar")); //$NON-NLS-1$
+			jLabelCurrency = new JLabel(MessageBundle.getMessage("angal.priceslist.currency.col"));
 		}
 		return jLabelCurrency;
 	}


### PR DESCRIPTION
## What & why

Per OP-1061, price lists should all share the hospital's global currency instead of letting the user type a currency per list (the per-list currency was just a label with no real relation; bills are already shown in the hospital currency).

GUI-only change (the `LST_CURRENCY` column/field is kept populated for future use).

## Changes

- `ListEdit` (New/Edit price list): the *Currency* field is now **read-only** and pre-filled with the hospital global currency (`HospitalBrowsingManager.getHospitalCurrencyCod()`), for both new and edited lists. The label drops the required-star (the user no longer types it).
- If no hospital currency is configured, the dialog shows a warning and disables OK — otherwise the empty currency would fail core validation (`PriceListManager` requires a currency).

## Testing

- Compiles; real-app run: editing a price list shows the read-only *Currency* = the hospital currency; typing does not change it; with no hospital currency configured the warning appears and saving is blocked.

## Companion PR

Documentation note: informatici/openhospital-doc (same branch `OP-1061-pricelist-global-currency`).

Jira: OP-1061
