### PR TITLE
OP-1065 Use the consolidated getLaboratoryForPrint in LabBrowser

### DIFF
--- a/src/main/java/org/isf/lab/gui/LabBrowser.java
+++ b/src/main/java/org/isf/lab/gui/LabBrowser.java
@@ -187,6 +187,7 @@ public class LabBrowser extends ModalJFrame implements LabListener, LabEditListe
 		return jButtonPanel;
 	}
 
+	@SuppressWarnings("deprecation") // getLaboratoryForPrint is deprecated but kept for this GUI print action (OP-1065)
 	private JButton getPrintTableButton() {
 		if (printTableButton == null) {
 			printTableButton = new JButton(MessageBundle.getMessage("angal.lab.printtable.btn"));
@@ -199,7 +200,7 @@ public class LabBrowser extends ModalJFrame implements LabListener, LabEditListe
 
 				try {
 					List<LaboratoryForPrint> labs;
-					labs = labManager.getLaboratoryForPrint(typeSelected, dateFrom.getDateStartOfDay(), dateTo.getDateEndOfDay());
+					labs = labManager.getLaboratoryForPrint(typeSelected, dateFrom.getDateStartOfDay(), dateTo.getDateEndOfDay(), null);
 					if (!labs.isEmpty()) {
 						printManager.print(MessageBundle.getMessage("angal.common.laboratory.txt"), labs, 0);
 					}


### PR DESCRIPTION
## OP-1065 — Optimize getLaboratoryForPrint methods (only for GUI)

GUI part of OP-1065 (sub-task of OP-1062). Depends on the CORE PR informatici/openhospital-core#1612.

`LabBrowser` is the only production caller of `getLaboratoryForPrint`. It now calls the single consolidated `(exam, from, to, patient)` method (passing `null` patient), and the enclosing print action carries `@SuppressWarnings("deprecation")` since the method is intentionally deprecated (GUI-only).

No behaviour change for the user: the print query is identical to before.

### Verification
- `mvn package` green (43 tests).
- Real Swing run: opened the Laboratory Browser and clicked **Print Table** → the report viewer opened with the lab data (full end-to-end print works).

Companion PR (same branch name → CI cross-builds the core fork branch):
- CORE: informatici/openhospital-core#1612