### PR TITLE
OP-1413 Pin commons-collections4 to 4.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,22 @@
 		<java.version>17</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<license.maven.plugin.version>5.0.0</license.maven.plugin.version>
+		<commons-collections4.version>4.5.0</commons-collections4.version>
 	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<!--
+				Force commons-collections4 4.5.0: jasperreports (via commons-beanutils2) needs 4.5.0, but poi-ooxml pulls 4.4 and wins version
+				mediation. With 4.4 any JRBeanCollectionDataSource print fails at runtime (missing ConcurrentReferenceHashMap). See OP-1413.
+			-->
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-collections4</artifactId>
+				<version>${commons-collections4.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
## OP-1413 — Bean-collection report printing broken (dependency convergence)

GUI part of OP-1413. Depends on / mirrors the CORE PR informatici/openhospital-core#1613.

The Laboratory Browser **Print table** (and any `JRBeanCollectionDataSource` print via `PrintManager.print`) fails at runtime with `NoClassDefFoundError: org/apache/commons/collections4/map/ConcurrentReferenceHashMap` because Maven resolves `commons-collections4:4.4` (pulled by poi-ooxml) while jasperreports 7.0.6 / commons-beanutils2 need **4.5.0**.

`dependencyManagement` is **not** inherited from the OH-core artifact, so the GUI module resolves 4.4 on its own and must pin 4.5.0 too (verified: before this change the GUI dependency tree shows 4.4).

### Fix
Add a `dependencyManagement` entry pinning `commons-collections4` to `4.5.0`.

### Verification
- GUI dependency tree now resolves collections4 **4.5.0**; `mvn package` green (43 tests).
- Real Swing run: Laboratory Browser → **Print table** now opens the report viewer (JasperViewer) correctly.

Companion PR:
- CORE: informatici/openhospital-core#1613