### PR TITLE
OP-1358 Mark wards/suppliers as virtual; show them in stock movements

### DIFF
--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -487,6 +487,7 @@ angal.common.update.btn.key                                                     
 angal.common.user.col                                                                                  = User
 angal.common.userid                                                                                    = User
 angal.common.userid.label                                                                              = User:
+angal.common.virtual.txt                                                                               = (virtual)
 angal.common.ward.col                                                                                  = Ward
 angal.common.ward.txt                                                                                  = Ward
 angal.common.weight.txt                                                                                = Weight
@@ -1746,6 +1747,7 @@ angal.supplier.deletesupplier.fmt.msg                                           
 angal.supplier.editsupplier.title                                                                      = Edit Supplier
 angal.supplier.email                                                                                   = E-mail
 angal.supplier.faxnumber                                                                               = Fax number
+angal.supplier.isvirtual.txt                                                                           = Virtual Supplier
 angal.supplier.newsupplier.title                                                                       = New Supplier
 angal.supplier.note                                                                                    = Note
 angal.supplier.pleaseinsertaname                                                                       = Please insert a name
@@ -1935,6 +1937,7 @@ angal.ward.insertavalidbedsnumber                                               
 angal.ward.insertavaliddoctorsnumber                                                                   = Insert a valid number of doctors.
 angal.ward.insertavaliddurationvalue.msg                                                               = Insert a valid visit duration value.
 angal.ward.insertavalidnursesnumber                                                                    = Insert a valid number of nurses.
+angal.ward.isvirtual.txt                                                                               = Virtual Ward
 angal.ward.maleward                                                                                    = Male Ward
 angal.ward.maternity.txt                                                                               = Maternity
 angal.ward.nameedit                                                                                    = Name *

--- a/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockMultipleCharging.java
@@ -47,12 +47,14 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.swing.DefaultCellEditor;
+import javax.swing.DefaultListCellRenderer;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+import javax.swing.JList;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -799,6 +801,19 @@ public class MovStockMultipleCharging extends JDialog {
 					jComboBoxSupplier.addItem(sup);
 				}
 			}
+			jComboBoxSupplier.setRenderer(new DefaultListCellRenderer() {
+
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+					super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+					if (value instanceof Supplier supplier && supplier.isVirtual()) {
+						setText(supplier + " " + MessageBundle.getMessage("angal.common.virtual.txt"));
+					}
+					return this;
+				}
+			});
 		}
 		return jComboBoxSupplier;
 	}

--- a/src/main/java/org/isf/medicalstock/gui/MovStockMultipleDischarging.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockMultipleDischarging.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/medicalstock/gui/MovStockMultipleDischarging.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockMultipleDischarging.java
@@ -43,11 +43,13 @@ import java.util.ListIterator;
 import java.util.Map;
 
 import javax.swing.DefaultCellEditor;
+import javax.swing.DefaultListCellRenderer;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+import javax.swing.JList;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -745,6 +747,19 @@ public class MovStockMultipleDischarging extends JDialog {
 			for (Ward elem : wardsList) {
 				jComboBoxDestination.addItem(elem);
 			}
+			jComboBoxDestination.setRenderer(new DefaultListCellRenderer() {
+
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+					super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+					if (value instanceof Ward ward && ward.isVirtual()) {
+						setText(ward + " " + MessageBundle.getMessage("angal.common.virtual.txt"));
+					}
+					return this;
+				}
+			});
 		}
 		return jComboBoxDestination;
 	}

--- a/src/main/java/org/isf/supplier/gui/SupplierEdit.java
+++ b/src/main/java/org/isf/supplier/gui/SupplierEdit.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2023 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/supplier/gui/SupplierEdit.java
+++ b/src/main/java/org/isf/supplier/gui/SupplierEdit.java
@@ -112,6 +112,7 @@ public class SupplierEdit extends JDialog {
 	private JTextField emailTextField;
 	private JTextField noteTextField;
 	private JCheckBox isDeletedCheck;
+	private JCheckBox isVirtualCheck;
 	private Supplier supplier;
 	private boolean insert;
 
@@ -177,6 +178,7 @@ public class SupplierEdit extends JDialog {
 			JLabel emailLabel = new JLabel(MessageBundle.getMessage("angal.supplier.email") + ':');
 			JLabel noteLabel = new JLabel(MessageBundle.getMessage("angal.supplier.note") + ':');
 			JLabel isDeletedLabel = new JLabel(MessageBundle.getMessage("angal.supplier.deleted") + ':');
+			JLabel isVirtualLabel = new JLabel(MessageBundle.getMessage("angal.supplier.isvirtual.txt") + ':');
 			JLabel requiredLabel = new JLabel(MessageBundle.getMessage("angal.supplier.requiredfields"));
 			dataPanel = new JPanel(new SpringLayout());
 			dataPanel.add(idLabel);
@@ -199,9 +201,11 @@ public class SupplierEdit extends JDialog {
 				dataPanel.add(isDeletedLabel);
 				dataPanel.add(getIsDeleted());
 			}
+			dataPanel.add(isVirtualLabel);
+			dataPanel.add(getIsVirtual());
 			dataPanel.add(requiredLabel);
 			dataPanel.add(new JLabel(""));
-			SpringUtilities.makeCompactGrid(dataPanel, insert ? 9 : 10, 2, 5, 5, 5, 5);
+			SpringUtilities.makeCompactGrid(dataPanel, insert ? 10 : 11, 2, 5, 5, 5, 5);
 		}
 		return dataPanel;
 	}
@@ -262,6 +266,7 @@ public class SupplierEdit extends JDialog {
 				} else {
 					supplier.setSupDeleted('N');
 				}
+				supplier.setVirtual(isVirtualCheck.isSelected());
 				if (insert) {	// inserting
 					try {
 						Supplier insertedSupplier = supplierBrowserManager.saveOrUpdate(supplier);
@@ -420,6 +425,21 @@ public class SupplierEdit extends JDialog {
 			}
 		}
 		return isDeletedCheck;
+	}
+
+	/**
+	 * This method initializes isVirtualCheck
+	 *
+	 * @return javax.swing.JCheckBox
+	 */
+	private JCheckBox getIsVirtual() {
+		if (isVirtualCheck == null) {
+			isVirtualCheck = new JCheckBox();
+			if (!insert) {
+				isVirtualCheck.setSelected(supplier.isVirtual());
+			}
+		}
+		return isVirtualCheck;
 	}
 
 }

--- a/src/main/java/org/isf/ward/gui/WardEdit.java
+++ b/src/main/java/org/isf/ward/gui/WardEdit.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2023 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/ward/gui/WardEdit.java
+++ b/src/main/java/org/isf/ward/gui/WardEdit.java
@@ -114,6 +114,7 @@ public class WardEdit extends JDialog {
 	private JTextField durationTextField;
 	private JCheckBox isOpdCheck;
 	private JCheckBox isPharmacyCheck;
+	private JCheckBox isVirtualCheck;
 	private JCheckBox isMaleCheck;
 	private JCheckBox isFemaleCheck;
 	private Ward ward;
@@ -319,12 +320,20 @@ public class WardEdit extends JDialog {
 			gbcIsPharmacyCheck.gridy = 10;
 			dataPanel.add(getIsPharmacyCheck(), gbcIsPharmacyCheck);
 
+			GridBagConstraints gbcIsVirtualCheck = new GridBagConstraints();
+			gbcIsVirtualCheck.anchor = GridBagConstraints.WEST;
+			gbcIsVirtualCheck.insets = new Insets(0, 0, 5, 0);
+			gbcIsVirtualCheck.gridwidth = 2;
+			gbcIsVirtualCheck.gridx = 0;
+			gbcIsVirtualCheck.gridy = 11;
+			dataPanel.add(getIsVirtualCheck(), gbcIsVirtualCheck);
+
 			GridBagConstraints gbcIsMaleCheck = new GridBagConstraints();
 			gbcIsMaleCheck.anchor = GridBagConstraints.WEST;
 			gbcIsMaleCheck.insets = new Insets(0, 0, 5, 0);
 			gbcIsMaleCheck.gridwidth = 2;
 			gbcIsMaleCheck.gridx = 0;
-			gbcIsMaleCheck.gridy = 11;
+			gbcIsMaleCheck.gridy = 12;
 			dataPanel.add(getIsMaleCheck(), gbcIsMaleCheck);
 
 			GridBagConstraints gbcIsFemaleCheck = new GridBagConstraints();
@@ -332,7 +341,7 @@ public class WardEdit extends JDialog {
 			gbcIsFemaleCheck.insets = new Insets(0, 0, 5, 0);
 			gbcIsFemaleCheck.gridwidth = 2;
 			gbcIsFemaleCheck.gridx = 0;
-			gbcIsFemaleCheck.gridy = 12;
+			gbcIsFemaleCheck.gridy = 13;
 			dataPanel.add(getIsFemaleCheck(), gbcIsFemaleCheck);
 
 			JLabel requiredLabel = new JLabel(MessageBundle.getMessage("angal.ward.requiredfields"));
@@ -340,7 +349,7 @@ public class WardEdit extends JDialog {
 			gbcRequiredLabel.gridwidth = 2;
 			gbcRequiredLabel.anchor = GridBagConstraints.EAST;
 			gbcRequiredLabel.gridx = 0;
-			gbcRequiredLabel.gridy = 13;
+			gbcRequiredLabel.gridy = 14;
 			dataPanel.add(requiredLabel, gbcRequiredLabel);
 		}
 		return dataPanel;
@@ -436,6 +445,7 @@ public class WardEdit extends JDialog {
 				ward.setDocs(docs);
 				ward.setOpd(isOpdCheck.isSelected());
 				ward.setPharmacy(isPharmacyCheck.isSelected());
+				ward.setVirtual(isVirtualCheck.isSelected());
 				ward.setMale(isMaleCheck.isSelected());
 				ward.setFemale(isFemaleCheck.isSelected());
 				ward.setVisitDuration(duration);
@@ -639,6 +649,21 @@ public class WardEdit extends JDialog {
 			}
 		}
 		return isPharmacyCheck;
+	}
+
+	/**
+	 * This method initializes isVirtualCheck
+	 *
+	 * @return javax.swing.JCheckBox
+	 */
+	private JCheckBox getIsVirtualCheck() {
+		if (isVirtualCheck == null) {
+			isVirtualCheck = new JCheckBox(MessageBundle.getMessage("angal.ward.isvirtual.txt"));
+			if (!insert) {
+				isVirtualCheck.setSelected(ward.isVirtual());
+			}
+		}
+		return isVirtualCheck;
 	}
 
 	/**


### PR DESCRIPTION
## OP-1358 — Define virtual supplier and virtual wards (Phase 1) — GUI

Depends on core PR informatici/openhospital-core#1615.

- **WardEdit / SupplierEdit**: new 'Virtual' checkbox to flag a ward/supplier as virtual.
- **Main Store charge (supplier) and discharge (ward) combos** render virtual entries with a " (virtual)" suffix via a `ListCellRenderer`; entity `toString()` unchanged. Pharmaceutical Stock Ward already filters by `isPharmacy`, so virtual wards are automatically excluded there (unchanged).
- New i18n keys (English bundle): `angal.common.virtual.txt`, `angal.ward.isvirtual.txt`, `angal.supplier.isvirtual.txt`.

### Verified
`mvn package` 43 green. Real Swing run against MariaDB: WardEdit reads the flag, and the live discharge dialog renders a virtual ward as "INTERNAL MEDICINE (virtual)" while non-virtual wards stay plain.

Companion PRs: core informatici/openhospital-core#1615 · api/doc linked in a comment.