### PR TITLE
OP-1242 Add Profession browser to manage patient professions

### DIFF
--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -1196,6 +1196,7 @@ angal.menu.btn.pharmacy                                                         
 angal.menu.btn.pretreatmenttype                                                                        = Pregnant Treatment
 angal.menu.btn.priceslists                                                                             = Price Lists
 angal.menu.btn.printing                                                                                = Reports
+angal.menu.btn.profession                                                                              = Profession
 angal.menu.btn.smsmanager                                                                              = SMS Manager
 angal.menu.btn.statistics                                                                              = Statistics
 angal.menu.btn.supplier                                                                                = Supplier
@@ -1256,6 +1257,7 @@ angal.menu.pharmacy                                                             
 angal.menu.pretreatmenttype                                                                            = PregnantTreatment
 angal.menu.priceslists                                                                                 = Prices Lists
 angal.menu.printing                                                                                    = Printing
+angal.menu.profession                                                                                  = Profession
 angal.menu.smsmanager                                                                                  = SMS Manager
 angal.menu.statistics                                                                                  = Statistics
 angal.menu.supplier                                                                                    = Supplier
@@ -1649,6 +1651,10 @@ angal.pricesothers.othm                                                         
 angal.pricesothers.pleaseselectanitemtodelete                                                          = Please select an item to delete
 angal.pricesothers.pleaseselectanitemtoedit                                                            = Please select an item to edit
 angal.pricesothers.thedatacouldnotbedeleted                                                            = The data could not be deleted
+angal.profession.deleteprofession.fmt.msg                                                              = Delete profession: "{0}"?
+angal.profession.editprofession.title                                                                  = Edit Profession
+angal.profession.newprofession.title                                                                   = New Profession
+angal.profession.professionbrowser.title                                                               = Profession Browser
 angal.serviceprinting.notavalidfile.msg                                                                = Not a valid file.
 angal.serviceprinting.selectacorrectaction.msg                                                         = Select a correct action.
 angal.serviceprinting.selectapathforthepdffile.msg                                                     = Select a path for the pdf file.

--- a/src/main/java/org/isf/profession/gui/ProfessionBrowser.java
+++ b/src/main/java/org/isf/profession/gui/ProfessionBrowser.java
@@ -1,0 +1,273 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.profession.gui;
+
+import java.awt.AWTEvent;
+import java.awt.BorderLayout;
+import java.awt.Font;
+import java.util.List;
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.JTableHeader;
+
+import org.isf.generaldata.MessageBundle;
+import org.isf.menu.manager.Context;
+import org.isf.profession.gui.ProfessionEdit.ProfessionListener;
+import org.isf.profession.manager.ProfessionBrowserManager;
+import org.isf.profession.model.Profession;
+import org.isf.utils.exception.OHServiceException;
+import org.isf.utils.jobjects.MessageDialog;
+import org.isf.utils.jobjects.ModalJFrame;
+
+/**
+ * Browsing of table Profession
+ */
+public class ProfessionBrowser extends ModalJFrame implements ProfessionListener {
+
+	private static final long serialVersionUID = 1L;
+	private List<Profession> pProfession;
+	private String[] pColumns = {
+			MessageBundle.getMessage("angal.common.code.txt").toUpperCase(),
+			MessageBundle.getMessage("angal.common.description.txt").toUpperCase()
+	};
+	private int[] pColumnWidth = {80, 200};
+	private JPanel jContainPanel;
+	private JPanel jButtonPanel;
+	private JButton jNewButton;
+	private JButton jEditButton;
+	private JButton jCloseButton;
+	private JButton jDeleteButton;
+	private JTable jTable;
+	private ProfessionBrowserModel model;
+	private int selectedrow;
+	private ProfessionBrowserManager professionBrowserManager = Context.getApplicationContext().getBean(ProfessionBrowserManager.class);
+	private Profession profession;
+	private final JFrame myFrame;
+
+	/**
+	 * This method initializes
+	 */
+	public ProfessionBrowser() {
+		super();
+		myFrame = this;
+		initialize();
+		setVisible(true);
+	}
+
+	private void initialize() {
+		this.setTitle(MessageBundle.getMessage("angal.profession.professionbrowser.title"));
+		this.setContentPane(getJContainPanel());
+		pack();
+		setLocationRelativeTo(null);
+	}
+
+	private JPanel getJContainPanel() {
+		if (jContainPanel == null) {
+			jContainPanel = new JPanel();
+			jContainPanel.setLayout(new BorderLayout());
+			jContainPanel.add(getJButtonPanel(), BorderLayout.SOUTH);
+			jContainPanel.add(new JScrollPane(getJTable()), BorderLayout.CENTER);
+			validate();
+		}
+		return jContainPanel;
+	}
+
+	private JPanel getJButtonPanel() {
+		if (jButtonPanel == null) {
+			jButtonPanel = new JPanel();
+			jButtonPanel.add(getJNewButton(), null);
+			jButtonPanel.add(getJEditButton(), null);
+			jButtonPanel.add(getJDeleteButton(), null);
+			jButtonPanel.add(getJCloseButton(), null);
+		}
+		return jButtonPanel;
+	}
+
+	private JButton getJNewButton() {
+		if (jNewButton == null) {
+			jNewButton = new JButton(MessageBundle.getMessage("angal.common.new.btn"));
+			jNewButton.setMnemonic(MessageBundle.getMnemonic("angal.common.new.btn.key"));
+			jNewButton.addActionListener(actionEvent -> {
+				profession = new Profession("", "");
+				ProfessionEdit newrecord = new ProfessionEdit(myFrame, profession, true);
+				newrecord.addProfessionListener(this);
+				newrecord.setVisible(true);
+			});
+		}
+		return jNewButton;
+	}
+
+	/**
+	 * This method initializes jEditButton
+	 *
+	 * @return javax.swing.JButton
+	 */
+	private JButton getJEditButton() {
+		if (jEditButton == null) {
+			jEditButton = new JButton(MessageBundle.getMessage("angal.common.edit.btn"));
+			jEditButton.setMnemonic(MessageBundle.getMnemonic("angal.common.edit.btn.key"));
+			jEditButton.addActionListener(actionEvent -> {
+				if (jTable.getSelectedRow() < 0) {
+					MessageDialog.error(null, "angal.common.pleaseselectarow.msg");
+				} else {
+					selectedrow = jTable.getSelectedRow();
+					profession = (Profession) model.getValueAt(selectedrow, -1);
+					ProfessionEdit newrecord = new ProfessionEdit(myFrame, profession, false);
+					newrecord.addProfessionListener(this);
+					newrecord.setVisible(true);
+				}
+			});
+		}
+		return jEditButton;
+	}
+
+	/**
+	 * This method initializes jCloseButton
+	 *
+	 * @return javax.swing.JButton
+	 */
+	private JButton getJCloseButton() {
+		if (jCloseButton == null) {
+			jCloseButton = new JButton(MessageBundle.getMessage("angal.common.close.btn"));
+			jCloseButton.setMnemonic(MessageBundle.getMnemonic("angal.common.close.btn.key"));
+			jCloseButton.addActionListener(actionEvent -> dispose());
+		}
+		return jCloseButton;
+	}
+
+	/**
+	 * This method initializes jDeleteButton
+	 *
+	 * @return javax.swing.JButton
+	 */
+	private JButton getJDeleteButton() {
+		if (jDeleteButton == null) {
+			jDeleteButton = new JButton(MessageBundle.getMessage("angal.common.delete.btn"));
+			jDeleteButton.setMnemonic(MessageBundle.getMnemonic("angal.common.delete.btn.key"));
+			jDeleteButton.addActionListener(actionEvent -> {
+				if (jTable.getSelectedRow() < 0) {
+					MessageDialog.error(null, "angal.common.pleaseselectarow.msg");
+				} else {
+					Profession profession = (Profession) model.getValueAt(jTable.getSelectedRow(), -1);
+					int answer = MessageDialog.yesNo(null, "angal.profession.deleteprofession.fmt.msg", profession.getDescription());
+					try {
+						if (answer == JOptionPane.YES_OPTION) {
+							professionBrowserManager.deleteProfession(profession);
+							pProfession.remove(jTable.getSelectedRow());
+							model.fireTableDataChanged();
+							jTable.updateUI();
+						}
+					} catch (OHServiceException ohServiceException) {
+						MessageDialog.showExceptions(ohServiceException);
+					}
+				}
+			});
+		}
+		return jDeleteButton;
+	}
+
+	private JTable getJTable() {
+		if (jTable == null) {
+			model = new ProfessionBrowserModel();
+			jTable = new JTable(model);
+			jTable.getColumnModel().getColumn(0).setMinWidth(pColumnWidth[0]);
+			jTable.getColumnModel().getColumn(1).setMinWidth(pColumnWidth[1]);
+			JTableHeader header = jTable.getTableHeader();
+			header.setFont(new Font(null, Font.BOLD, 12));
+		}
+		return jTable;
+	}
+
+	class ProfessionBrowserModel extends DefaultTableModel {
+
+		private static final long serialVersionUID = 1L;
+
+		public ProfessionBrowserModel() {
+			try {
+				pProfession = professionBrowserManager.getProfessions();
+			} catch (OHServiceException ohServiceException) {
+				MessageDialog.showExceptions(ohServiceException);
+			}
+		}
+
+		@Override
+		public int getRowCount() {
+			if (pProfession == null) {
+				return 0;
+			}
+			return pProfession.size();
+		}
+
+		@Override
+		public String getColumnName(int c) {
+			return pColumns[c];
+		}
+
+		@Override
+		public int getColumnCount() {
+			return pColumns.length;
+		}
+
+		@Override
+		public Object getValueAt(int r, int c) {
+			if (c == 0) {
+				return pProfession.get(r).getCode();
+			} else if (c == -1) {
+				return pProfession.get(r);
+			} else if (c == 1) {
+				return pProfession.get(r).getDescription();
+			}
+			return null;
+		}
+
+		@Override
+		public boolean isCellEditable(int arg0, int arg1) {
+			return false;
+		}
+	}
+
+	@Override
+	public void professionUpdated(AWTEvent e) {
+		pProfession.set(selectedrow, profession);
+		((ProfessionBrowserModel) jTable.getModel()).fireTableDataChanged();
+		jTable.updateUI();
+		if (jTable.getRowCount() > 0 && selectedrow > -1) {
+			jTable.setRowSelectionInterval(selectedrow, selectedrow);
+		}
+	}
+
+	@Override
+	public void professionInserted(AWTEvent e) {
+		pProfession.add(0, profession);
+		((ProfessionBrowserModel) jTable.getModel()).fireTableDataChanged();
+		if (jTable.getRowCount() > 0) {
+			jTable.setRowSelectionInterval(0, 0);
+		}
+	}
+
+}

--- a/src/main/java/org/isf/profession/gui/ProfessionEdit.java
+++ b/src/main/java/org/isf/profession/gui/ProfessionEdit.java
@@ -1,0 +1,273 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.profession.gui;
+
+import java.awt.AWTEvent;
+import java.awt.BorderLayout;
+import java.util.EventListener;
+
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.SpringLayout;
+import javax.swing.WindowConstants;
+import javax.swing.event.EventListenerList;
+
+import org.isf.generaldata.MessageBundle;
+import org.isf.menu.manager.Context;
+import org.isf.profession.manager.ProfessionBrowserManager;
+import org.isf.profession.model.Profession;
+import org.isf.utils.exception.OHServiceException;
+import org.isf.utils.jobjects.MessageDialog;
+import org.isf.utils.jobjects.VoLimitedTextField;
+import org.isf.utils.layout.SpringUtilities;
+
+public class ProfessionEdit extends JDialog {
+
+	private static final long serialVersionUID = 1L;
+	private EventListenerList professionListeners = new EventListenerList();
+
+	public interface ProfessionListener extends EventListener {
+		void professionUpdated(AWTEvent e);
+		void professionInserted(AWTEvent e);
+	}
+
+	public void addProfessionListener(ProfessionListener l) {
+		professionListeners.add(ProfessionListener.class, l);
+	}
+
+	public void removeProfessionListener(ProfessionListener listener) {
+		professionListeners.remove(ProfessionListener.class, listener);
+	}
+
+	private void fireProfessionInserted() {
+		AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
+
+			private static final long serialVersionUID = 1L;
+		};
+
+		EventListener[] listeners = professionListeners.getListeners(ProfessionListener.class);
+		for (EventListener listener : listeners) {
+			((ProfessionListener) listener).professionInserted(event);
+		}
+	}
+
+	private void fireProfessionUpdated() {
+		AWTEvent event = new AWTEvent(new Object(), AWTEvent.RESERVED_ID_MAX + 1) {
+
+			private static final long serialVersionUID = 1L;
+		};
+
+		EventListener[] listeners = professionListeners.getListeners(ProfessionListener.class);
+		for (EventListener listener : listeners) {
+			((ProfessionListener) listener).professionUpdated(event);
+		}
+	}
+
+	private ProfessionBrowserManager professionBrowserManager = Context.getApplicationContext().getBean(ProfessionBrowserManager.class);
+
+	private JPanel jContentPane;
+	private JPanel dataPanel;
+	private JPanel buttonPanel;
+	private JButton cancelButton;
+	private JButton okButton;
+	private JTextField descriptionTextField;
+	private VoLimitedTextField codeTextField;
+	private String lastdescription;
+	private Profession profession;
+	private boolean insert;
+	private JPanel jDataPanel;
+
+	/**
+	 * This is the default constructor; we pass the arraylist and the selectedrow
+	 * because we need to update them
+	 */
+	public ProfessionEdit(JFrame owner, Profession old, boolean inserting) {
+		super(owner, true);
+		insert = inserting;
+		profession = old; //profession will be used for every operation
+		lastdescription = profession.getDescription();
+		initialize();
+	}
+
+	/**
+	 * This method initializes this
+	 */
+	private void initialize() {
+		this.setContentPane(getJContentPane());
+		if (insert) {
+			this.setTitle(MessageBundle.getMessage("angal.profession.newprofession.title"));
+		} else {
+			this.setTitle(MessageBundle.getMessage("angal.profession.editprofession.title"));
+		}
+		this.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+
+		this.pack();
+		this.setLocationRelativeTo(null);
+	}
+
+	/**
+	 * This method initializes jContentPane
+	 *
+	 * @return javax.swing.JPanel
+	 */
+	private JPanel getJContentPane() {
+		if (jContentPane == null) {
+			jContentPane = new JPanel();
+			jContentPane.setLayout(new BorderLayout());
+			jContentPane.add(getDataPanel(), BorderLayout.NORTH);
+			jContentPane.add(getButtonPanel(), BorderLayout.SOUTH);
+		}
+		return jContentPane;
+	}
+
+	/**
+	 * This method initializes dataPanel
+	 *
+	 * @return javax.swing.JPanel
+	 */
+	private JPanel getDataPanel() {
+		if (dataPanel == null) {
+			dataPanel = new JPanel();
+			dataPanel.add(getJDataPanel(), null);
+		}
+		return dataPanel;
+	}
+
+	/**
+	 * This method initializes buttonPanel
+	 *
+	 * @return javax.swing.JPanel
+	 */
+	private JPanel getButtonPanel() {
+		if (buttonPanel == null) {
+			buttonPanel = new JPanel();
+			buttonPanel.add(getOkButton(), null);
+			buttonPanel.add(getCancelButton(), null);
+		}
+		return buttonPanel;
+	}
+
+	/**
+	 * This method initializes cancelButton
+	 *
+	 * @return javax.swing.JButton
+	 */
+	private JButton getCancelButton() {
+		if (cancelButton == null) {
+			cancelButton = new JButton(MessageBundle.getMessage("angal.common.cancel.btn"));
+			cancelButton.setMnemonic(MessageBundle.getMnemonic("angal.common.cancel.btn.key"));
+			cancelButton.addActionListener(actionEvent -> dispose());
+		}
+		return cancelButton;
+	}
+
+	/**
+	 * This method initializes okButton
+	 *
+	 * @return javax.swing.JButton
+	 */
+	private JButton getOkButton() {
+		if (okButton == null) {
+			okButton = new JButton(MessageBundle.getMessage("angal.common.ok.btn"));
+			okButton.setMnemonic(MessageBundle.getMnemonic("angal.common.ok.btn.key"));
+			okButton.addActionListener(actionEvent -> {
+
+				try {
+					if (descriptionTextField.getText().equals(lastdescription)) {
+						dispose();
+					}
+					profession.setDescription(descriptionTextField.getText());
+					profession.setCode(codeTextField.getText());
+					if (insert) {      // inserting
+						professionBrowserManager.newProfession(profession);
+						fireProfessionInserted();
+						dispose();
+					} else {                          // updating
+						if (descriptionTextField.getText().equals(lastdescription)) {
+							dispose();
+						} else {
+							professionBrowserManager.updateProfession(profession);
+							fireProfessionUpdated();
+							dispose();
+						}
+					}
+				} catch (OHServiceException ohServiceException) {
+					MessageDialog.showExceptions(ohServiceException);
+				}
+			});
+		}
+		return okButton;
+	}
+
+	/**
+	 * This method initializes descriptionTextField
+	 *
+	 * @return javax.swing.JTextField
+	 */
+	private JTextField getDescriptionTextField() {
+		if (descriptionTextField == null) {
+			descriptionTextField = new JTextField(20);
+			if (!insert) {
+				descriptionTextField.setText(profession.getDescription());
+				lastdescription = profession.getDescription();
+			}
+		}
+		return descriptionTextField;
+	}
+
+	/**
+	 * This method initializes codeTextField
+	 *
+	 * @return javax.swing.JTextField
+	 */
+	private JTextField getCodeTextField() {
+		if (codeTextField == null) {
+			codeTextField = new VoLimitedTextField(50);
+			if (!insert) {
+				codeTextField.setText(profession.getCode());
+				codeTextField.setEnabled(false);
+			}
+		}
+		return codeTextField;
+	}
+
+	/**
+	 * This method initializes jDataPanel
+	 *
+	 * @return javax.swing.JPanel
+	 */
+	private JPanel getJDataPanel() {
+		if (jDataPanel == null) {
+			jDataPanel = new JPanel(new SpringLayout());
+			jDataPanel.add(new JLabel(MessageBundle.formatMessage("angal.common.codemaxchars.fmt.txt", 50) + ':'));
+			jDataPanel.add(getCodeTextField());
+			jDataPanel.add(new JLabel(MessageBundle.getMessage("angal.common.description.txt") + ':'));
+			jDataPanel.add(getDescriptionTextField());
+			SpringUtilities.makeCompactGrid(jDataPanel, 2, 2, 5, 5, 5, 5);
+		}
+		return jDataPanel;
+	}
+}


### PR DESCRIPTION
## What changed

Add a Swing admin browser to manage the patient profession lookup table, mirroring the DiseaseType browser.

- Add `ProfessionBrowser` and `ProfessionEdit` under Settings (General Data) with New/Edit/Delete; the patient Profession combo box is now populated from this configurable list.
- Render the table column headers in bold so they stand out from the rows.
- Add `angal.profession.*` bundle keys.

## Notes

Depends on informatici/openhospital-core#1616 (the Profession entity/manager) being merged first.