### PR TITLE
OP-1084 Save table exports in the open CSV format

### DIFF
--- a/src/main/java/org/isf/medicals/gui/MedicalBrowser.java
+++ b/src/main/java/org/isf/medicals/gui/MedicalBrowser.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/medicals/gui/MedicalBrowser.java
+++ b/src/main/java/org/isf/medicals/gui/MedicalBrowser.java
@@ -56,6 +56,7 @@ import javax.swing.JTextField;
 import javax.swing.RowSorter.SortKey;
 import javax.swing.SortOrder;
 import javax.swing.WindowConstants;
+import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
 
@@ -475,20 +476,14 @@ public class MedicalBrowser extends ModalJFrame implements MedicalListener {
 			int iRetVal = fcExcel.showSaveDialog(this);
 			if (iRetVal == JFileChooser.APPROVE_OPTION) {
 				File exportFile = fcExcel.getSelectedFile();
-				if (!exportFile.getName().endsWith(".xls") && !exportFile.getName().endsWith(".xlsx")) {
-					if (fcExcel.getFileFilter().getDescription().contains("*.xlsx")) {
-						exportFile = new File(exportFile.getAbsoluteFile() + ".xlsx");
-					} else {
-						exportFile = new File(exportFile.getAbsoluteFile() + ".xls");
-					}
+				FileNameExtensionFilter selectedFilter = (FileNameExtensionFilter) fcExcel.getFileFilter();
+				String extension = selectedFilter.getExtensions()[0];
+				if (!exportFile.getName().endsWith(extension)) {
+					exportFile = new File(exportFile.getAbsoluteFile() + "." + extension);
 				}
 				ExcelExporter xlsExport = new ExcelExporter();
 				try {
-					if (exportFile.getName().endsWith(".xlsx")) {
-						xlsExport.exportTableToExcel(table, exportFile);
-					} else {
-						xlsExport.exportTableToExcelOLD(table, exportFile);
-					}
+					xlsExport.exportTable(table, exportFile);
 				} catch (IOException exc) {
 					JOptionPane.showMessageDialog(this,
 									exc.getMessage(),

--- a/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
+++ b/src/main/java/org/isf/medicalstock/gui/MovStockBrowser.java
@@ -68,6 +68,7 @@ import javax.swing.SwingConstants;
 import javax.swing.ToolTipManager;
 import javax.swing.UIManager;
 import javax.swing.WindowConstants;
+import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableColumn;
@@ -1076,20 +1077,14 @@ public class MovStockBrowser extends ModalJFrame {
 			int iRetVal = fcExcel.showSaveDialog(this);
 			if (iRetVal == JFileChooser.APPROVE_OPTION) {
 				File exportFile = fcExcel.getSelectedFile();
-				if (!exportFile.getName().endsWith(".xls") && !exportFile.getName().endsWith(".xlsx")) {
-					if (fcExcel.getFileFilter().getDescription().contains("*.xlsx")) {
-						exportFile = new File(exportFile.getAbsoluteFile() + ".xlsx");
-					} else {
-						exportFile = new File(exportFile.getAbsoluteFile() + ".xls");
-					}
+				FileNameExtensionFilter selectedFilter = (FileNameExtensionFilter) fcExcel.getFileFilter();
+				String extension = selectedFilter.getExtensions()[0];
+				if (!exportFile.getName().endsWith(extension)) {
+					exportFile = new File(exportFile.getAbsoluteFile() + "." + extension);
 				}
 				ExcelExporter xlsExport = new ExcelExporter();
 				try {
-					if (exportFile.getName().endsWith(".xlsx")) {
-						xlsExport.exportTableToExcel(movTable, exportFile);
-					} else {
-						xlsExport.exportTableToExcelOLD(movTable, exportFile);
-					}
+					xlsExport.exportTable(movTable, exportFile);
 				} catch (IOException exc) {
 					JOptionPane.showMessageDialog(this,
 									exc.getMessage(),

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
+++ b/src/main/java/org/isf/medicalstockward/gui/WardPharmacy.java
@@ -71,6 +71,7 @@ import javax.swing.JTextField;
 import javax.swing.ListSelectionModel;
 import javax.swing.WindowConstants;
 import javax.swing.border.TitledBorder;
+import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
@@ -1633,33 +1634,20 @@ public class WardPharmacy extends ModalJFrame implements
 				if (iRetVal == JFileChooser.APPROVE_OPTION) {
 					try {
 						File exportFile = fcExcel.getSelectedFile();
-						if (!exportFile.getName().endsWith(".xls") && !exportFile.getName().endsWith(".xlsx")) {
-							if (fcExcel.getFileFilter().getDescription().contains("*.xlsx")) {
-								exportFile = new File(exportFile.getAbsoluteFile() + ".xlsx");
-							} else {
-								exportFile = new File(exportFile.getAbsoluteFile() + ".xls");
-							}
+						FileNameExtensionFilter selectedFilter = (FileNameExtensionFilter) fcExcel.getFileFilter();
+						String extension = selectedFilter.getExtensions()[0];
+						if (!exportFile.getName().endsWith(extension)) {
+							exportFile = new File(exportFile.getAbsoluteFile() + "." + extension);
 						}
 						ExcelExporter xlsExport = new ExcelExporter();
 						int index = jTabbedPaneWard.getSelectedIndex();
-						if (exportFile.getName().endsWith(".xlsx")) {
-							if (index == 0) {
-								xlsExport.exportTableToExcel(jTableOutcomes, exportFile);
-							} else if (index == 1) {
-								xlsExport.exportTableToExcel(jTableIncomes, exportFile);
-							} else if (index == 2) {
-								// ignore the last column in the table as it is a button object
-								xlsExport.exportTableToExcel(jTableDrugs, exportFile, 3);
-							}
-						} else {
-							if (index == 0) {
-								xlsExport.exportTableToExcelOLD(jTableOutcomes, exportFile);
-							} else if (index == 1) {
-								xlsExport.exportTableToExcelOLD(jTableIncomes, exportFile);
-							} else if (index == 2) {
-								// ignore the last column in the table as it is a button object
-								xlsExport.exportTableToExcelOLD(jTableDrugs, exportFile, 3);
-							}
+						if (index == 0) {
+							xlsExport.exportTable(jTableOutcomes, exportFile);
+						} else if (index == 1) {
+							xlsExport.exportTable(jTableIncomes, exportFile);
+						} else if (index == 2) {
+							// ignore the last column in the table as it is a button object
+							xlsExport.exportTable(jTableDrugs, exportFile, 3);
 						}
 					} catch (IOException exc) {
 						JOptionPane.showMessageDialog(this,


### PR DESCRIPTION
## OP-1084 — Save table exports in the open CSV format

JIRA: https://openhospital.atlassian.net/browse/OP-1084

Wires the new open CSV format (added in the core PR) into the three table-export actions:

- `MedicalBrowser`, `MovStockBrowser`, `WardPharmacy` now take the extension from the **selected file filter** and delegate to `ExcelExporter.exportTable(...)`, which writes `.csv` in addition to `.xlsx`/`.xls`.

The five `GenericReport*` report exporters already used the generic `selectedFilter.getExtensions()[0]` pattern, so they pick up CSV automatically (no change needed) once the core chooser offers it and `JasperReportsManager` dispatches `.csv`.

Depends on the core PR (same branch name `OP-1084-csv-open-format`, so this build resolves the core fork branch).

### Verification
`mvn package` green (43 tests). Real run against a MariaDB demo database: exporting the Pharmaceutical Browser to CSV produced a valid RFC 4180 file (UTF-8+BOM, CRLF, no trailing separator, integer codes without grouping).
