### PR TITLE
OP-1350 Highlight new and changed inventory rows after validation

### DIFF
--- a/src/main/java/org/isf/medicalinventory/gui/InventoryEdit.java
+++ b/src/main/java/org/isf/medicalinventory/gui/InventoryEdit.java
@@ -78,6 +78,7 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.event.EventListenerList;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
 
 import org.isf.generaldata.GeneralData;
 import org.isf.generaldata.MessageBundle;
@@ -187,6 +188,9 @@ public class InventoryEdit extends ModalJFrame {
 	private DefaultTableModel model;
 	private List<MedicalInventoryRow> inventoryRowList = new ArrayList<>();
 	private List<MedicalInventoryRow> inventoryRowSearchList = new ArrayList<>();
+	private final Set<String> changedRowKeys = new HashSet<>();
+	private static final Color CHANGED_ROW_COLOR = new Color(255, 247, 188);
+	private final InventoryRowChangeTracker changeTracker = new InventoryRowChangeTracker();
 	private List<MedicalInventoryRow> inventoryRowsToDelete = new ArrayList<>();
 	private List<MedicalInventoryRow> inventoryRowListAdded = new ArrayList<>();
 	private List<Lot> lotsSaved = new ArrayList<>();
@@ -789,6 +793,7 @@ public class InventoryEdit extends ModalJFrame {
 				int answer = MessageDialog.yesNo(null, "angal.inventory.doyouwanttoactualizetheinventory.msg");
 				if (answer == JOptionPane.YES_OPTION) {
 					try {
+						Map<String, Double> theoreticQtyBeforeActualize = changeTracker.snapshotTheoreticQty(inventoryRowSearchList);
 						inventory.setStatus(status);
 						inventory = medicalInventoryManager.actualizeMedicalInventoryRow(inventory, allMedicals);
 						dateInventory = inventory.getInventoryDate();
@@ -796,6 +801,7 @@ public class InventoryEdit extends ModalJFrame {
 						statusLabel.setForeground(Color.BLUE);
 						confirmButton.setEnabled(true);
 						jTableInventoryRow.setModel(new InventoryRowModel());
+						markChangedRows(theoreticQtyBeforeActualize);
 						fireInventoryUpdated();
 					} catch (OHServiceException e1) {
 						OHServiceExceptionUtil.showMessages(e1);
@@ -1099,7 +1105,26 @@ public class InventoryEdit extends ModalJFrame {
 
 	private JTable getJTableInventoryRow() throws OHServiceException {
 		if (jTableInventoryRow == null) {
-			jTableInventoryRow = new JTable();
+			jTableInventoryRow = new JTable() {
+
+				private static final long serialVersionUID = 1L;
+
+				// done via prepareRenderer rather than a per-column cell renderer so the highlight also covers the
+				// default-rendered code/medical columns and overrides the decimal renderer's white background
+				@Override
+				public Component prepareRenderer(TableCellRenderer renderer, int row, int column) {
+					Component component = super.prepareRenderer(renderer, row, column);
+					if (!isRowSelected(row)) {
+						Object rowObject = getValueAt(row, -1);
+						if (rowObject instanceof MedicalInventoryRow invRow && changedRowKeys.contains(changeTracker.rowKey(invRow))) {
+							component.setBackground(CHANGED_ROW_COLOR);
+						} else {
+							component.setBackground(getBackground());
+						}
+					}
+					return component;
+				}
+			};
 			jTableInventoryRow.setFillsViewportHeight(true);
 			model = new InventoryRowModel();
 			jTableInventoryRow.setModel(model);
@@ -2000,6 +2025,10 @@ public class InventoryEdit extends ModalJFrame {
 		lotsDeleted.clear();
 		inventoryRowListAdded.clear();
 		lotsSaved.clear();
+		changedRowKeys.clear();
+		if (jTableInventoryRow != null) {
+			jTableInventoryRow.repaint();
+		}
 	}
 
 	private boolean checkParametersChanges(String wardCode, String chargeCode, String dischargeCode, Integer supplierId, String reference, LocalDateTime date) {
@@ -2155,6 +2184,16 @@ public class InventoryEdit extends ModalJFrame {
 		} else {
 			MessageDialog.info(null, "angal.inventory.notdataforthatfilter.msg");
 		}
+	}
+
+	/**
+	 * Flags the inventory rows that the validation/actualize step added or whose theoretical quantity it changed, so the
+	 * table highlights them; the flag is cleared on save (see {@link #resetVariables()}).
+	 */
+	private void markChangedRows(Map<String, Double> theoreticQtyBeforeActualize) {
+		changedRowKeys.clear();
+		changedRowKeys.addAll(changeTracker.findChangedRowKeys(theoreticQtyBeforeActualize, inventoryRowSearchList));
+		jTableInventoryRow.repaint();
 	}
 
 	class CenterTableCellRenderer extends DefaultTableCellRenderer {

--- a/src/main/java/org/isf/medicalinventory/gui/InventoryRowChangeTracker.java
+++ b/src/main/java/org/isf/medicalinventory/gui/InventoryRowChangeTracker.java
@@ -1,0 +1,76 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.medicalinventory.gui;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.isf.medicalinventory.model.MedicalInventoryRow;
+
+/**
+ * Computes which inventory rows are new or have a changed theoretical quantity after a validation/actualize step, so the
+ * inventory table can highlight them. The logic is kept out of the Swing screens ({@code InventoryEdit} and
+ * {@code InventoryWardEdit}) so it can be shared between them and unit-tested in isolation.
+ */
+public class InventoryRowChangeTracker {
+
+	/**
+	 * Snapshots the theoretical quantity of each row, keyed by {@link #rowKey(MedicalInventoryRow)}, to be compared after
+	 * the inventory is actualized.
+	 */
+	public Map<String, Double> snapshotTheoreticQty(List<MedicalInventoryRow> rows) {
+		Map<String, Double> snapshot = new HashMap<>();
+		for (MedicalInventoryRow invRow : rows) {
+			snapshot.put(rowKey(invRow), invRow.getTheoreticQty());
+		}
+		return snapshot;
+	}
+
+	/**
+	 * Returns the keys of the rows that were added (absent from the snapshot) or whose theoretical quantity changed with
+	 * respect to {@code theoreticQtyBefore}.
+	 */
+	public Set<String> findChangedRowKeys(Map<String, Double> theoreticQtyBefore, List<MedicalInventoryRow> currentRows) {
+		Set<String> changedRowKeys = new HashSet<>();
+		for (MedicalInventoryRow invRow : currentRows) {
+			String key = rowKey(invRow);
+			Double previousQty = theoreticQtyBefore.get(key);
+			if (previousQty == null || Double.compare(previousQty, invRow.getTheoreticQty()) != 0) {
+				changedRowKeys.add(key);
+			}
+		}
+		return changedRowKeys;
+	}
+
+	/**
+	 * Row identity used for the before/after diff; assumes one row per (medical, lot), which the validate/actualize path
+	 * guarantees by requiring every row to carry a lot.
+	 */
+	public String rowKey(MedicalInventoryRow invRow) {
+		String medicalCode = invRow.getMedical() != null ? invRow.getMedical().getProdCode() : "";
+		String lotCode = invRow.getLot() != null ? invRow.getLot().getCode() : "";
+		return medicalCode + '|' + lotCode;
+	}
+}

--- a/src/main/java/org/isf/medicalinventory/gui/InventoryWardEdit.java
+++ b/src/main/java/org/isf/medicalinventory/gui/InventoryWardEdit.java
@@ -79,6 +79,7 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.event.EventListenerList;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
 
 import org.isf.generaldata.GeneralData;
 import org.isf.generaldata.MessageBundle;
@@ -186,6 +187,9 @@ public class InventoryWardEdit extends ModalJFrame {
 	private DefaultTableModel model;
 	private List<MedicalInventoryRow> inventoryRowList = new ArrayList<>();
 	private List<MedicalInventoryRow> inventoryRowSearchList = new ArrayList<>();
+	private final Set<String> changedRowKeys = new HashSet<>();
+	private static final Color CHANGED_ROW_COLOR = new Color(255, 247, 188);
+	private final InventoryRowChangeTracker changeTracker = new InventoryRowChangeTracker();
 	private List<MedicalInventoryRow> inventoryRowsToDelete = new ArrayList<>();
 	private List<MedicalInventoryRow> inventoryRowListAdded = new ArrayList<>();
 	private List<Lot> lotsSaved = new ArrayList<>();
@@ -724,6 +728,7 @@ public class InventoryWardEdit extends ModalJFrame {
 				int answer = MessageDialog.yesNo(null, "angal.inventory.doyouwanttoactualizetheinventory.msg");
 				if (answer == JOptionPane.YES_OPTION) {
 					try {
+						Map<String, Double> theoreticQtyBeforeActualize = changeTracker.snapshotTheoreticQty(inventoryRowSearchList);
 						inventory.setStatus(status);
 						inventory = medicalInventoryManager.actualizeMedicalWardInventoryRow(inventory, allMedicals);
 						dateInventory = inventory.getInventoryDate();
@@ -731,6 +736,7 @@ public class InventoryWardEdit extends ModalJFrame {
 						statusLabel.setForeground(Color.BLUE);
 						confirmButton.setEnabled(true);
 						jTableInventoryRow.setModel(new InventoryRowModel());
+						markChangedRows(theoreticQtyBeforeActualize);
 						fireInventoryUpdated();
 					} catch (OHServiceException e1) {
 						OHServiceExceptionUtil.showMessages(e1);
@@ -1002,7 +1008,26 @@ public class InventoryWardEdit extends ModalJFrame {
 
 	private JTable getJTableInventoryRow() throws OHServiceException {
 		if (jTableInventoryRow == null) {
-			jTableInventoryRow = new JTable();
+			jTableInventoryRow = new JTable() {
+
+				private static final long serialVersionUID = 1L;
+
+				// done via prepareRenderer rather than a per-column cell renderer so the highlight also covers the
+				// default-rendered code/medical columns and overrides the decimal renderer's white background
+				@Override
+				public Component prepareRenderer(TableCellRenderer renderer, int row, int column) {
+					Component component = super.prepareRenderer(renderer, row, column);
+					if (!isRowSelected(row)) {
+						Object rowObject = getValueAt(row, -1);
+						if (rowObject instanceof MedicalInventoryRow invRow && changedRowKeys.contains(changeTracker.rowKey(invRow))) {
+							component.setBackground(CHANGED_ROW_COLOR);
+						} else {
+							component.setBackground(getBackground());
+						}
+					}
+					return component;
+				}
+			};
 			jTableInventoryRow.setFillsViewportHeight(true);
 			model = new InventoryRowModel();
 			jTableInventoryRow.setModel(model);
@@ -1888,6 +1913,10 @@ public class InventoryWardEdit extends ModalJFrame {
 		lotsDeleted.clear();
 		inventoryRowListAdded.clear();
 		lotsSaved.clear();
+		changedRowKeys.clear();
+		if (jTableInventoryRow != null) {
+			jTableInventoryRow.repaint();
+		}
 	}
 
 	private boolean checkParametersChanges(String reference, LocalDateTime date) {
@@ -2031,6 +2060,16 @@ public class InventoryWardEdit extends ModalJFrame {
 		} else {
 			MessageDialog.info(null, "angal.inventory.notdataforthatfilter.msg");
 		}
+	}
+
+	/**
+	 * Flags the inventory rows that the validation/actualize step added or whose theoretical quantity it changed, so the
+	 * table highlights them; the flag is cleared on save (see {@link #resetVariables()}).
+	 */
+	private void markChangedRows(Map<String, Double> theoreticQtyBeforeActualize) {
+		changedRowKeys.clear();
+		changedRowKeys.addAll(changeTracker.findChangedRowKeys(theoreticQtyBeforeActualize, inventoryRowSearchList));
+		jTableInventoryRow.repaint();
 	}
 
 	class CenterTableCellRenderer extends DefaultTableCellRenderer {

--- a/src/test/java/org/isf/medicalinventory/gui/InventoryRowChangeTrackerTest.java
+++ b/src/test/java/org/isf/medicalinventory/gui/InventoryRowChangeTrackerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.medicalinventory.gui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.isf.medicalinventory.model.MedicalInventoryRow;
+import org.isf.medicals.model.Medical;
+import org.isf.medicalstock.model.Lot;
+import org.junit.jupiter.api.Test;
+
+class InventoryRowChangeTrackerTest {
+
+	private InventoryRowChangeTracker changeTracker = new InventoryRowChangeTracker();
+
+	@Test
+	void shouldKeyRowByMedicalCodeAndLot() {
+		MedicalInventoryRow row = inventoryRow("MED1", "LOT1", 10); // given
+
+		String key = changeTracker.rowKey(row); // when
+
+		assertThat(key).isEqualTo("MED1|LOT1"); // then
+	}
+
+	@Test
+	void shouldSnapshotTheoreticQtyByRowKey() {
+		List<MedicalInventoryRow> rows = List.of(inventoryRow("MED1", "LOT1", 10), inventoryRow("MED2", "LOT2", 5)); // given
+
+		Map<String, Double> snapshot = changeTracker.snapshotTheoreticQty(rows); // when
+
+		assertThat(snapshot).containsExactlyInAnyOrderEntriesOf(Map.of("MED1|LOT1", 10.0, "MED2|LOT2", 5.0)); // then
+	}
+
+	@Test
+	void shouldFlagRowWhoseTheoreticQtyChanged() {
+		Map<String, Double> before = Map.of("MED1|LOT1", 10.0); // given
+		List<MedicalInventoryRow> current = List.of(inventoryRow("MED1", "LOT1", 7));
+
+		Set<String> changed = changeTracker.findChangedRowKeys(before, current); // when
+
+		assertThat(changed).containsExactlyInAnyOrder("MED1|LOT1"); // then
+	}
+
+	@Test
+	void shouldFlagNewlyAddedRow() {
+		Map<String, Double> before = Map.of("MED1|LOT1", 10.0); // given
+		List<MedicalInventoryRow> current = List.of(inventoryRow("MED1", "LOT1", 10), inventoryRow("MED2", "LOT2", 5));
+
+		Set<String> changed = changeTracker.findChangedRowKeys(before, current); // when
+
+		assertThat(changed).containsExactlyInAnyOrder("MED2|LOT2"); // then
+	}
+
+	@Test
+	void shouldNotFlagUnchangedRows() {
+		Map<String, Double> before = Map.of("MED1|LOT1", 10.0, "MED2|LOT2", 5.0); // given
+		List<MedicalInventoryRow> current = List.of(inventoryRow("MED1", "LOT1", 10), inventoryRow("MED2", "LOT2", 5));
+
+		Set<String> changed = changeTracker.findChangedRowKeys(before, current); // when
+
+		assertThat(changed).isEmpty(); // then
+	}
+
+	private MedicalInventoryRow inventoryRow(String medicalCode, String lotCode, double theoreticQty) {
+		Medical medical = new Medical();
+		medical.setProdCode(medicalCode);
+		MedicalInventoryRow row = new MedicalInventoryRow();
+		row.setMedical(medical);
+		row.setLot(new Lot(lotCode));
+		row.setTheoreticQty(theoreticQty);
+		return row;
+	}
+}


### PR DESCRIPTION
## OP-1350 — Highlight new and changed inventory rows after validation

JIRA: https://openhospital.atlassian.net/browse/OP-1350

When inventory validation detects that products/lots/quantities changed in the underlying stock and the operator chooses to **actualize** the inventory, the rows that were added or whose theoretical quantity changed are highlighted (light amber) in the inventory table; the highlight clears on save.

### Approach (GUI only)
The component is oh-gui and there is no persisted "changed" flag on `MedicalInventoryRow`, so the highlight is computed GUI-side: snapshot each row's theoretical quantity (keyed by medical code + lot code) before actualize, diff after the model is rebuilt, keep the changed keys in a set the table reads while painting, and clear it (and repaint) on save (`resetVariables()`).

The diff logic is extracted into a small, unit-tested `InventoryRowChangeTracker` shared by the main-store (`InventoryEdit`) and ward (`InventoryWardEdit`) editors — mirroring the existing extract-and-test pattern (`ExamFilterFactory`, `DiseaseFinder`). The screens keep only the Swing wiring: a `prepareRenderer` override on the inventory `JTable` highlights every column of a changed row uniformly (including the default-rendered code/medical columns), reading the changed-keys set.

### Verification
`InventoryRowChangeTrackerTest` 5/5; gui `mvn package` green (48 tests), no checkstyle violations. Confirmed end-to-end on the real Swing GUI: after a validate → actualize, only the changed/added row is highlighted amber, all others stay white, and the highlight clears on save.

Note: while testing this end to end I found and fixed a separate pre-existing bug that prevented saving a new main-store inventory at all (StaleObjectStateException) — filed and fixed as OP-1414 (core PR https://github.com/informatici/openhospital-core/pull/1618). That fix is what made this end-to-end verification possible.
