### PR TITLE
OP-1417 Guard Webcam.getDefault() behind VIDEOMODULEENABLED (fix Apple Silicon crash)

### DIFF
--- a/src/main/java/org/isf/video/gui/PatientPhotoPanel.java
+++ b/src/main/java/org/isf/video/gui/PatientPhotoPanel.java
@@ -153,9 +153,12 @@ public class PatientPhotoPanel extends JPanel {
 				}
 			});
 
-			final Webcam webcam = Webcam.getDefault();
+			// only touch the webcam stack when the video module is enabled; Webcam.getDefault() loads a native library
+			// (BridJ) that is not available on every platform (e.g. Apple Silicon), and calling it unconditionally
+			// would throw an UnsatisfiedLinkError and break the whole patient form even with the video module off
+			final Webcam webcam = GeneralData.VIDEOMODULEENABLED ? Webcam.getDefault() : null;
 
-			if (GeneralData.VIDEOMODULEENABLED && webcam != null) {
+			if (webcam != null) {
 				JButton jGetPhotoButton = new JButton(MessageBundle.getMessage("angal.patientphoto.newphoto.btn"));
 				jGetPhotoButton.setMnemonic(MessageBundle.getMnemonic("angal.patientphoto.newphoto.btn.key"));
 				jGetPhotoButton.setMinimumSize(new Dimension(200, (int) jGetPhotoButton.getPreferredSize().getHeight()));


### PR DESCRIPTION
## OP-1417 — Patient form crashes on Apple Silicon

`PatientPhotoPanel` called `Webcam.getDefault()` unconditionally, before the `GeneralData.VIDEOMODULEENABLED` check on the next line. That call loads the bundled BridJ native library, which ships x86_64 only, so on an Apple Silicon (arm64) JVM it throws `UnsatisfiedLinkError` and the whole New/Edit Patient form fails to open — even when the video module is disabled (the default).

### Fix
Only call `Webcam.getDefault()` when the video module is enabled (the ternary keeps the variable effectively final for the photo-button lambda):

    final Webcam webcam = GeneralData.VIDEOMODULEENABLED ? Webcam.getDefault() : null;
    if (webcam != null) { ... }

No behaviour change when the video module is on.

### Testing
- `mvn compile` green.
- Verified on Apple Silicon (arm64 JVM, `VIDEOMODULEENABLED=no`): the New/Edit Patient form now opens with no `UnsatisfiedLinkError`; before the change it crashed on open.

### Scope
This stops the crash when the video module is disabled (the default) by not initializing the webcam at all. It does not make the webcam usable on Apple Silicon when the video module is *enabled* — the bundled BridJ native library is x86_64-only, which is a separate dependency limitation.
