### PR TITLE
OP-1063 Insert laboratory exams via newLaboratory2 in the lab editors

### DIFF
--- a/src/main/java/org/isf/lab/gui/LabEdit.java
+++ b/src/main/java/org/isf/lab/gui/LabEdit.java
@@ -535,7 +535,11 @@ public class LabEdit extends ModalJFrame {
 				if (insert) {
 					lab.setAge(tmpAge);
 					try {
-						labManager.newLaboratory(lab, labRow);
+						List<LaboratoryRow> labRows = new ArrayList<>();
+						for (String description : labRow) {
+							labRows.add(new LaboratoryRow(lab, description));
+						}
+						labManager.newLaboratory2(lab, labRows);
 					} catch (OHServiceException e1) {
 						OHServiceExceptionUtil.showMessages(e1);
 					}

--- a/src/main/java/org/isf/lab/gui/LabEditExtended.java
+++ b/src/main/java/org/isf/lab/gui/LabEditExtended.java
@@ -638,7 +638,11 @@ public class LabEditExtended extends ModalJFrame {
 				if (insert) {
 					lab.setAge(labPat.getAge());
 					try {
-						labManager.newLaboratory(lab, labRow);
+						List<LaboratoryRow> labRows = new ArrayList<>();
+						for (String description : labRow) {
+							labRows.add(new LaboratoryRow(lab, description));
+						}
+						labManager.newLaboratory2(lab, labRows);
 					} catch (OHServiceException e1) {
 						OHServiceExceptionUtil.showMessages(e1);
 					}


### PR DESCRIPTION
Part of OP-1063 (**core + GUI + API**). Since core removes the deprecated v1 String-based `LabManager.newLaboratory(...)` (keeping the `LaboratoryRow`-based v2), the lab editors now build the procedure-2 results as `LaboratoryRow` objects and call `newLaboratory2`.

Changed: the insert branch of `LabEdit` and `LabEditExtended` only. The non-deprecated `updateLaboratory(Laboratory, List<String>)` path is unchanged.

Same branch name as the core PR so CI cross-builds the core fork branch. Verified with `mvn package` and a real-app run: inserting a procedure-2 exam (URINALYSIS) with multiple results persists the laboratory and its `LaboratoryRow` children correctly. Sibling PRs linked in a comment.
