### PR TITLE
OP-1419 Add --add-opens to GUI launchers to fix DICOM preview NPE on JDK 16+

### DIFF
--- a/oh.bat
+++ b/oh.bat
@@ -346,7 +346,7 @@ REM ###### Start Open Hospital #####
 echo Starting Open Hospital GUI...
 
 cd /d %OH_PATH%\%OH_DIR%
-%JAVA_BIN% -client -Xms64m -Xmx1024m -Dsun.java2d.dpiaware=false -Djava.library.path=%NATIVE_LIB_PATH% -cp %CLASSPATH% org.isf.Application
+%JAVA_BIN% -client --add-opens java.desktop/javax.imageio.stream=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED -Xms64m -Xmx1024m -Dsun.java2d.dpiaware=false -Djava.library.path=%NATIVE_LIB_PATH% -cp %CLASSPATH% org.isf.Application
 
 REM # Shutdown MySQL
 echo Shutting down MySQL...

--- a/oh.ps1
+++ b/oh.ps1
@@ -1232,7 +1232,7 @@ function start_gui {
 	#$JAVA_ARGS="-client -Dlog4j.configuration=`"`'$OH_PATH\$OH_DIR\rsc\$LOG4J_SETTINGS`'`" -Dsun.java2d.dpiaware=false -Djava.library.path=`"`'$NATIVE_LIB_PATH`'`" -cp `"`'$OH_CLASSPATH`'`" org.isf.Application"
 
 	# log4j configuration is now read directly
-$JAVA_ARGS="-client -Xms64m -Xmx1024m -Dsun.java2d.dpiaware=false -Djava.library.path=`"$NATIVE_LIB_PATH`" -cp `"`'$OH_CLASSPATH`'`" org.isf.Application"
+$JAVA_ARGS="-client --add-opens java.desktop/javax.imageio.stream=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED -Xms64m -Xmx1024m -Dsun.java2d.dpiaware=false -Djava.library.path=`"$NATIVE_LIB_PATH`" -cp `"`'$OH_CLASSPATH`'`" org.isf.Application"
 
 	Start-Process -FilePath "$JAVA_BIN" -ArgumentList $JAVA_ARGS -Wait -NoNewWindow -RedirectStandardOutput "$LOG_DIR/$LOG_FILE" -RedirectStandardError "$LOG_DIR/$LOG_FILE_ERR"
 	

--- a/oh.sh
+++ b/oh.sh
@@ -1089,7 +1089,7 @@ function start_gui {
 	# OH GUI launch
 	cd "$OH_PATH/$OH_DIR" # workaround for hard coded paths
 
-	$JAVA_BIN -client -Xms64m -Xmx1024m -Dsun.java2d.dpiaware=false -Djava.library.path=${NATIVE_LIB_PATH} -classpath $OH_CLASSPATH org.isf.Application >> ../$LOG_DIR/$LOG_FILE 2>&1
+	$JAVA_BIN -client --add-opens java.desktop/javax.imageio.stream=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED -Xms64m -Xmx1024m -Dsun.java2d.dpiaware=false -Djava.library.path=${NATIVE_LIB_PATH} -classpath $OH_CLASSPATH org.isf.Application >> ../$LOG_DIR/$LOG_FILE 2>&1
 
 	if [ $? -ne 0 ]; then
 		echo "An error occurred while starting Open Hospital. Exiting."

--- a/ohmac.sh
+++ b/ohmac.sh
@@ -551,7 +551,7 @@ function start_gui {
 	echo "Starting Open Hospital GUI..."
 	# OH GUI launch	
 	
-	$JAVA_BIN -client -Xms64m -Xmx1024m -Dsun.java2d.dpiaware=false -Djava.library.path=${NATIVE_LIB_PATH} -classpath $OH_CLASSPATH org.isf.Application >> $OH_DIR/$LOG_DIR/$LOG_FILE 2>&1
+	$JAVA_BIN -client --add-opens java.desktop/javax.imageio.stream=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED -Xms64m -Xmx1024m -Dsun.java2d.dpiaware=false -Djava.library.path=${NATIVE_LIB_PATH} -classpath $OH_CLASSPATH org.isf.Application >> $OH_DIR/$LOG_DIR/$LOG_FILE 2>&1
 
 	if [ $? -ne 0 ]; then
 		echo "An error occurred while starting Open Hospital. Exiting."


### PR DESCRIPTION
On JDK 16+ the JPMS strong encapsulation blocks dcm4che's OpenCV-based `StreamSegment` from reflectively reading the `ImageInputStream` buffer, so the DICOM preview decode returns null and `DicomViewGui.composeCenter` throws a `NullPointerException` (reported in OP-219 when double-clicking a DICOM thumbnail).

This adds the same two flags that core PR #1625 sets for the test JVM to the `org.isf.Application` launch in all four launchers — `oh.sh`, `ohmac.sh`, `oh.bat` and `oh.ps1`:

```
--add-opens java.desktop/javax.imageio.stream=ALL-UNNAMED
--add-opens java.base/java.io=ALL-UNNAMED
```

The launchers start `org.isf.Application` from the classpath (unnamed module), so `ALL-UNNAMED` is the correct target. `--add-opens` is a standard option on every JDK 9+, so it does not affect startup on the bundled JRE 17.

Verification: decoding a real DICOM (the WRIX dataset attached to OP-219) through the GUI's `getImageFromDicom` path fails without the flags (`InaccessibleObjectException` on `FileCacheImageInputStream.cache` → null → NPE) and succeeds with them (image decodes, 512×512).

Pairs with core PR #1625 (test-JVM argLine). Jira: OP-1419.

Note: on macOS the preview still cannot render because OH ships no macOS OpenCV native (only Windows/Linux) — tracked separately.
