### PR TITLE
OP-887 Add a permission-gated Export Patient Data action

### DIFF
--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -56,6 +56,8 @@ angal.admission.examination                                                     
 angal.admission.examination.btn                                                                        = Examination
 angal.admission.examination.btn.key                                                                    = X
 angal.admission.examination.txt                                                                        = Examination
+angal.admission.exportpatientdata.btn                                                                  = Export Patient Data
+angal.admission.exportpatientdata.btn.key                                                              = P
 angal.admission.fatherisalive                                                                          = Father is alive
 angal.admission.fatherisdead                                                                           = Father is dead
 angal.admission.fromhealthunit.border                                                                  = From Health Unit

--- a/src/main/java/org/isf/admission/gui/AdmittedPatientBrowser.java
+++ b/src/main/java/org/isf/admission/gui/AdmittedPatientBrowser.java
@@ -35,6 +35,10 @@ import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +53,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
+import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -89,13 +94,18 @@ import org.isf.lab.gui.LabNew;
 import org.isf.lab.model.Laboratory;
 import org.isf.menu.gui.MainMenu;
 import org.isf.menu.manager.Context;
+import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.opd.gui.OpdEditExtended;
 import org.isf.opd.model.Opd;
+import org.isf.patient.dto.PatientExport;
+import org.isf.patient.gui.PatientExportJson;
 import org.isf.patient.gui.PatientInsert;
 import org.isf.patient.gui.PatientInsertExtended;
 import org.isf.patient.gui.PatientInsertExtended.PatientListener;
 import org.isf.patient.manager.PatientBrowserManager;
+import org.isf.patient.manager.PatientExportManager;
 import org.isf.patient.model.Patient;
+import org.isf.permissions.manager.PermissionManager;
 import org.isf.therapy.gui.TherapyEdit;
 import org.isf.utils.db.NormalizeString;
 import org.isf.utils.exception.OHServiceException;
@@ -161,6 +171,8 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 	private PatientBrowserManager patientBrowserManager = Context.getApplicationContext().getBean(PatientBrowserManager.class);
 	private AdmissionBrowserManager admissionBrowserManager = Context.getApplicationContext().getBean(AdmissionBrowserManager.class);
 	private ExaminationBrowserManager examinationBrowserManager = Context.getApplicationContext().getBean(ExaminationBrowserManager.class);
+	private PatientExportManager patientExportManager = Context.getApplicationContext().getBean(PatientExportManager.class);
+	private PermissionManager permissionManager = Context.getApplicationContext().getBean(PermissionManager.class);
 
 	protected boolean altKeyReleased = true;
 	protected Timer ageTimer = new Timer(1000, e -> filterPatient(null));
@@ -707,6 +719,9 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 		if (MainMenu.checkUserGrants("btnadmpatientfolder")) {
 			buttonPanel.add(getButtonPatientFolderBrowser());
 		}
+		if (canExportPatientData()) {
+			buttonPanel.add(getButtonExportData());
+		}
 		if (MainMenu.checkUserGrants("btnadmtherapy")) {
 			buttonPanel.add(getButtonTherapy());
 		}
@@ -995,6 +1010,58 @@ public class AdmittedPatientBrowser extends ModalJFrame implements PatientInsert
 			new PatientFolderBrowser(myFrame, patient.getPatient()).showAsModal(this);
 		});
 		return buttonPatientFolderBrowser;
+	}
+
+	private boolean canExportPatientData() {
+		String currentUser = UserBrowsingManager.getCurrentUser();
+		if (currentUser == null) {
+			return false;
+		}
+		try {
+			return permissionManager.retrievePermissionsByUsername(currentUser).stream()
+							.anyMatch(permission -> "patient.export".equals(permission.getName()));
+		} catch (OHServiceException e) {
+			OHServiceExceptionUtil.showMessages(e);
+			return false;
+		}
+	}
+
+	private JButton getButtonExportData() {
+		JButton buttonExportData = new JButton(MessageBundle.getMessage("angal.admission.exportpatientdata.btn"));
+		buttonExportData.setMnemonic(MessageBundle.getMnemonic("angal.admission.exportpatientdata.btn.key"));
+		buttonExportData.addActionListener(actionEvent -> {
+			if (table.getSelectedRow() < 0) {
+				MessageDialog.error(this, "angal.common.pleaseselectapatient.msg");
+				return;
+			}
+			patient = reloadSelectedPatient(table.getSelectedRow());
+
+			if (patient != null) {
+				int code = patient.getPatient().getCode();
+				JFileChooser fileChooser = new JFileChooser();
+				fileChooser.setSelectedFile(new File("patient_" + code + "_export.json"));
+				if (fileChooser.showSaveDialog(this) != JFileChooser.APPROVE_OPTION) {
+					return;
+				}
+				File exportFile = fileChooser.getSelectedFile();
+				if (!exportFile.getName().endsWith(".json")) {
+					exportFile = new File(exportFile.getAbsolutePath() + ".json");
+				}
+				try {
+					PatientExport export = patientExportManager.exportPatientData(code);
+					if (export == null) {
+						MessageDialog.error(this, "angal.common.pleaseselectapatient.msg");
+						return;
+					}
+					Files.write(exportFile.toPath(), PatientExportJson.toJson(export).getBytes(StandardCharsets.UTF_8));
+				} catch (OHServiceException e) {
+					OHServiceExceptionUtil.showMessages(e);
+				} catch (IOException e) {
+					MessageDialog.error(this, "angal.common.datacouldnotbesaved.msg");
+				}
+			}
+		});
+		return buttonExportData;
 	}
 
 	private JButton getButtonTherapy() {

--- a/src/main/java/org/isf/patient/gui/PatientExportJson.java
+++ b/src/main/java/org/isf/patient/gui/PatientExportJson.java
@@ -1,0 +1,77 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.patient.gui;
+
+import org.isf.patconsensus.model.PatientConsensus;
+import org.isf.patient.dto.PatientExport;
+import org.isf.patient.model.Patient;
+import org.isf.patient.model.PatientProfilePhoto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+/**
+ * Serializes a {@link PatientExport} aggregate to pretty-printed JSON in an open format,
+ * for GDPR Art. 20 (right to data portability) exports.
+ */
+public final class PatientExportJson {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper()
+					.registerModule(new JavaTimeModule())
+					.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+					.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+					.addMixIn(Patient.class, PatientMixIn.class);
+
+	private PatientExportJson() {
+	}
+
+	/**
+	 * Serializes the given export aggregate to pretty-printed JSON. Dates are rendered in ISO-8601 format.
+	 * The patient profile photo is excluded (binary data, loaded lazily) as well as the patient consensus
+	 * (bidirectional association, not part of the export scope) and the derived search/information strings.
+	 *
+	 * @param export the aggregate to serialize
+	 * @return the JSON representation of the export
+	 * @throws JsonProcessingException if the aggregate cannot be serialized
+	 */
+	public static String toJson(PatientExport export) throws JsonProcessingException {
+		return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(export);
+	}
+
+	private abstract static class PatientMixIn {
+
+		@JsonIgnore
+		abstract PatientProfilePhoto getPatientProfilePhoto();
+
+		@JsonIgnore
+		abstract PatientConsensus getPatientConsensus();
+
+		@JsonIgnore
+		abstract String getSearchString();
+
+		@JsonIgnore
+		abstract String getInformations();
+	}
+}

--- a/src/test/java/org/isf/patient/gui/PatientExportJsonTest.java
+++ b/src/test/java/org/isf/patient/gui/PatientExportJsonTest.java
@@ -1,0 +1,138 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.patient.gui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.isf.admission.model.Admission;
+import org.isf.patconsensus.model.PatientConsensus;
+import org.isf.patient.dto.PatientExport;
+import org.isf.patient.model.Patient;
+import org.isf.patient.model.PatientProfilePhoto;
+import org.isf.patvac.model.PatientVaccine;
+import org.isf.vaccine.model.Vaccine;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class PatientExportJsonTest {
+
+	@Test
+	void shouldSerializeAllGroupsToValidJson() throws Exception {
+		// given:
+		PatientExport export = buildPatientExport();
+
+		// when:
+		String json = PatientExportJson.toJson(export);
+		JsonNode root = new ObjectMapper().readTree(json);
+
+		// then:
+		assertThat(root.get("patient")).isNotNull();
+		assertThat(root.get("patient").get("firstName").asText()).isEqualTo("John");
+		for (String group : new String[] { "admissions", "opds", "laboratories", "therapies", "operations", "vaccines", "examinations", "bills", "billItems",
+						"billPayments" }) {
+			assertThat(root.get(group)).as("group '%s' must be present", group).isNotNull();
+			assertThat(root.get(group).isArray()).as("group '%s' must be an array", group).isTrue();
+		}
+		assertThat(root.get("vaccines")).isNotEmpty();
+		assertThat(root.get("admissions")).isNotEmpty();
+	}
+
+	@Test
+	void shouldSerializeDatesInIsoFormat() throws Exception {
+		// given:
+		PatientExport export = buildPatientExport();
+
+		// when:
+		String json = PatientExportJson.toJson(export);
+		JsonNode root = new ObjectMapper().readTree(json);
+
+		// then:
+		assertThat(root.get("patient").get("birthDate").asText()).isEqualTo("1980-05-20");
+		assertThat(root.get("vaccines").get(0).get("vaccineDate").asText()).startsWith("2023-05-10T09:30");
+	}
+
+	@Test
+	void shouldNotSerializeProfilePhotoNorConsensus() throws Exception {
+		// given:
+		PatientExport export = buildPatientExport();
+
+		// when:
+		String json = PatientExportJson.toJson(export);
+		JsonNode root = new ObjectMapper().readTree(json);
+
+		// then:
+		assertThat(root.get("patient").has("patientProfilePhoto")).isFalse();
+		assertThat(root.get("patient").has("patientConsensus")).isFalse();
+		assertThat(root.get("patient").has("searchString")).isFalse();
+		assertThat(root.get("patient").has("informations")).isFalse();
+		// the mix-in must also apply to patients nested in the connected records
+		assertThat(root.get("vaccines").get(0).get("patient").has("patientProfilePhoto")).isFalse();
+		assertThat(root.get("vaccines").get(0).get("patient").has("patientConsensus")).isFalse();
+	}
+
+	private PatientExport buildPatientExport() {
+		Patient patient = new Patient();
+		patient.setCode(1);
+		patient.setFirstName("John");
+		patient.setSecondName("Doe");
+		patient.setBirthDate(LocalDate.of(1980, 5, 20));
+		patient.setSex('M');
+		patient.setPatientProfilePhoto(new PatientProfilePhoto());
+		patient.setPatientConsensus(new PatientConsensus(true, false, patient));
+
+		Admission admission = new Admission();
+		admission.setId(10);
+		admission.setPatient(patient);
+		admission.setAdmDate(LocalDateTime.of(2023, 5, 9, 8, 0));
+		List<Admission> admissions = new ArrayList<>();
+		admissions.add(admission);
+
+		Vaccine vaccine = new Vaccine();
+		vaccine.setCode("1");
+		vaccine.setDescription("Vaccine");
+		PatientVaccine patientVaccine = new PatientVaccine(20, 1, LocalDateTime.of(2023, 5, 10, 9, 30), patient, vaccine, 0);
+		List<PatientVaccine> vaccines = new ArrayList<>();
+		vaccines.add(patientVaccine);
+
+		PatientExport export = new PatientExport();
+		export.setPatient(patient);
+		export.setAdmissions(admissions);
+		export.setOpds(Collections.emptyList());
+		export.setLaboratories(Collections.emptyList());
+		export.setTherapies(Collections.emptyList());
+		export.setOperations(Collections.emptyList());
+		export.setVaccines(vaccines);
+		export.setExaminations(Collections.emptyList());
+		export.setBills(Collections.emptyList());
+		export.setBillItems(Collections.emptyList());
+		export.setBillPayments(Collections.emptyList());
+		return export;
+	}
+}


### PR DESCRIPTION
See [OP-887](https://openhospital.atlassian.net/browse/OP-887). Depends on informatici/openhospital-core#1633 (same branch name, fork cross-build).

Adds an "Export Patient Data" button to the Patient Browser, visible only to users holding the new `patient.export` permission. It writes the full patient aggregate as JSON through a `JFileChooser` (proposed name `patient_<code>_export.json`).

Verified on the live application against the demo database: the button appears for the admin group and disappears after removing the group grant (checked in SINGLEUSER mode as well, which reads the real group permissions); the exported JSON matches the database record counts for the selected patient.

Clinical sheet audit (requested by the ticket, report-only here): the active `patient_clinical_sheet_ver3` template is missing vaccines — confirming the ticket's note — and also therapies and visits. Adding them needs a subdataset/band change plus recompiling three committed `.jasper` binaries, proposed as a follow-up ticket rather than bundled here.

User-manual screenshots will follow up separately (captured on Linux, to keep the standard dialog icons).


[OP-887]: https://openhospital.atlassian.net/browse/OP-887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ