### PR TITLE
OP-1429 Harden the operations panel and reuse VoFloatTextField

### DIFF
--- a/src/main/java/org/isf/operation/gui/OperationRowAdm.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowAdm.java
@@ -81,11 +81,7 @@ public class OperationRowAdm extends OperationRowBase implements AdmissionListen
 		OperationRow operationRow = new OperationRow();
 		operationRow.setOpDate(this.textDate.getLocalDateTime());
 		operationRow.setOpResult(operationBrowserManager.getResultDescriptionKey((String) comboResult.getSelectedItem()));
-		try {
-			operationRow.setTransUnit(Float.parseFloat(this.textFieldUnit.getText()));
-		} catch (NumberFormatException e) {
-			operationRow.setTransUnit(0.0F);
-		}
+		operationRow.setTransUnit(getTransUnitValue());
 		Operation op = (Operation) this.comboOperation.getSelectedItem();
 		operationRow.setOperation(op);
 		if (myAdmission != null) {
@@ -101,7 +97,7 @@ public class OperationRowAdm extends OperationRowBase implements AdmissionListen
 			opeInter.setOpDate(this.textDate.getLocalDateTime());
 			String opResult = operationBrowserManager.getResultDescriptionKey((String) comboResult.getSelectedItem());
 			opeInter.setOpResult(opResult);
-			opeInter.setTransUnit(Float.parseFloat(this.textFieldUnit.getText()));
+			opeInter.setTransUnit(getTransUnitValue());
 			op = (Operation) this.comboOperation.getSelectedItem();
 			opeInter.setOperation(op);
 			opeInter.setPrescriber(MainMenu.getUser().getUserName());

--- a/src/main/java/org/isf/operation/gui/OperationRowAdm.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowAdm.java
@@ -81,7 +81,7 @@ public class OperationRowAdm extends OperationRowBase implements AdmissionListen
 		OperationRow operationRow = new OperationRow();
 		operationRow.setOpDate(this.textDate.getLocalDateTime());
 		operationRow.setOpResult(operationBrowserManager.getResultDescriptionKey((String) comboResult.getSelectedItem()));
-		operationRow.setTransUnit(getTransUnitValue());
+		operationRow.setTransUnit(textFieldUnit.getValue());
 		Operation op = (Operation) this.comboOperation.getSelectedItem();
 		operationRow.setOperation(op);
 		if (myAdmission != null) {
@@ -97,7 +97,7 @@ public class OperationRowAdm extends OperationRowBase implements AdmissionListen
 			opeInter.setOpDate(this.textDate.getLocalDateTime());
 			String opResult = operationBrowserManager.getResultDescriptionKey((String) comboResult.getSelectedItem());
 			opeInter.setOpResult(opResult);
-			opeInter.setTransUnit(getTransUnitValue());
+			opeInter.setTransUnit(textFieldUnit.getValue());
 			op = (Operation) this.comboOperation.getSelectedItem();
 			opeInter.setOperation(op);
 			opeInter.setPrescriber(MainMenu.getUser().getUserName());

--- a/src/main/java/org/isf/operation/gui/OperationRowBase.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowBase.java
@@ -73,7 +73,7 @@ abstract class OperationRowBase extends JPanel {
 	private static final Logger LOGGER = LoggerFactory.getLogger(OperationRowBase.class);
 
 	protected JLabel labelDate;
-	protected JTextField textFieldUnit;
+	protected VoFloatTextField textFieldUnit;
 	protected GoodDateTimeSpinnerChooser textDate;
 	protected JComboBox<Operation> comboOperation;
 	protected JTextField searchOperationTextField;
@@ -391,15 +391,6 @@ abstract class OperationRowBase extends JPanel {
 
 	// Either return opeManager.getOperationOpd() or opeManager.getOperationAdm()
 	abstract List<Operation> getOperationCollection() throws OHServiceException;
-
-	// Returns the Trans Unit field value, or 0.0F when the field is empty or not a valid number
-	protected float getTransUnitValue() {
-		try {
-			return Float.parseFloat(textFieldUnit.getText());
-		} catch (NumberFormatException e) {
-			return 0.0F;
-		}
-	}
 
 	public void addToForm() {
 		int selectedRow = tableData.getSelectedRow();

--- a/src/main/java/org/isf/operation/gui/OperationRowBase.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowBase.java
@@ -392,8 +392,21 @@ abstract class OperationRowBase extends JPanel {
 	// Either return opeManager.getOperationOpd() or opeManager.getOperationAdm()
 	abstract List<Operation> getOperationCollection() throws OHServiceException;
 
+	// Returns the Trans Unit field value, or 0.0F when the field is empty or not a valid number
+	protected float getTransUnitValue() {
+		try {
+			return Float.parseFloat(textFieldUnit.getText());
+		} catch (NumberFormatException e) {
+			return 0.0F;
+		}
+	}
+
 	public void addToForm() {
-		OperationRow opeRow = oprowData.get(tableData.getSelectedRow());
+		int selectedRow = tableData.getSelectedRow();
+		if (selectedRow < 0) {
+			return;
+		}
+		OperationRow opeRow = oprowData.get(selectedRow);
 		/* ** for combo operation **** */
 		List<Operation> opeList = new ArrayList<>();
 		try {

--- a/src/main/java/org/isf/operation/gui/OperationRowOpd.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowOpd.java
@@ -73,7 +73,7 @@ public class OperationRowOpd extends OperationRowBase implements SurgeryListener
 		OperationRow operationRow = new OperationRow();
 		operationRow.setOpDate(this.textDate.getLocalDateTime());
 		operationRow.setOpResult(operationBrowserManager.getResultDescriptionKey((String) comboResult.getSelectedItem()));
-		operationRow.setTransUnit(getTransUnitValue());
+		operationRow.setTransUnit(textFieldUnit.getValue());
 		Operation op = (Operation) this.comboOperation.getSelectedItem();
 		operationRow.setOperation(op);
 		if (myOpd != null) {
@@ -89,7 +89,7 @@ public class OperationRowOpd extends OperationRowBase implements SurgeryListener
 			opeInter.setOpDate(this.textDate.getLocalDateTime());
 			String opResult = operationBrowserManager.getResultDescriptionKey((String) comboResult.getSelectedItem());
 			opeInter.setOpResult(opResult);
-			opeInter.setTransUnit(getTransUnitValue());
+			opeInter.setTransUnit(textFieldUnit.getValue());
 			op = (Operation) this.comboOperation.getSelectedItem();
 			opeInter.setOperation(op);
 			opeInter.setPrescriber(MainMenu.getUser().getUserName());
@@ -128,14 +128,26 @@ public class OperationRowOpd extends OperationRowBase implements SurgeryListener
 	public void saveAllOpeRow(List<OperationRow> listOpe, OperationRowBrowserManager rowManager, Opd opd) throws OHServiceException {
 		for (OperationRow opRow : listOpe) {
 			if ((opRow.getId() > 0) && (opRow.getOpd().getCode() > 0)) {
-				rowManager.updateOperationRow(opRow);
+				try {
+					rowManager.updateOperationRow(opRow);
+				} catch (OHServiceException e1) {
+					OHServiceExceptionUtil.showMessages(e1);
+				}
 			}
 			if ((opRow.getId() <= 0) && (opRow.getOpd().getCode() > 0)) {
-				rowManager.newOperationRow(opRow);
+				try {
+					rowManager.newOperationRow(opRow);
+				} catch (OHServiceException e1) {
+					OHServiceExceptionUtil.showMessages(e1);
+				}
 			}
 			if ((opRow.getId() <= 0) && (opRow.getOpd().getCode() <= 0)) {
 				opRow.setOpd(opd);
-				rowManager.newOperationRow(opRow);
+				try {
+					rowManager.newOperationRow(opRow);
+				} catch (OHServiceException e1) {
+					OHServiceExceptionUtil.showMessages(e1);
+				}
 			}
 		}
 	}

--- a/src/main/java/org/isf/operation/gui/OperationRowOpd.java
+++ b/src/main/java/org/isf/operation/gui/OperationRowOpd.java
@@ -73,11 +73,7 @@ public class OperationRowOpd extends OperationRowBase implements SurgeryListener
 		OperationRow operationRow = new OperationRow();
 		operationRow.setOpDate(this.textDate.getLocalDateTime());
 		operationRow.setOpResult(operationBrowserManager.getResultDescriptionKey((String) comboResult.getSelectedItem()));
-		try {
-			operationRow.setTransUnit(Float.parseFloat(this.textFieldUnit.getText()));
-		} catch (NumberFormatException e) {
-			operationRow.setTransUnit(0.0F);
-		}
+		operationRow.setTransUnit(getTransUnitValue());
 		Operation op = (Operation) this.comboOperation.getSelectedItem();
 		operationRow.setOperation(op);
 		if (myOpd != null) {
@@ -93,7 +89,7 @@ public class OperationRowOpd extends OperationRowBase implements SurgeryListener
 			opeInter.setOpDate(this.textDate.getLocalDateTime());
 			String opResult = operationBrowserManager.getResultDescriptionKey((String) comboResult.getSelectedItem());
 			opeInter.setOpResult(opResult);
-			opeInter.setTransUnit(Float.parseFloat(this.textFieldUnit.getText()));
+			opeInter.setTransUnit(getTransUnitValue());
 			op = (Operation) this.comboOperation.getSelectedItem();
 			opeInter.setOperation(op);
 			opeInter.setPrescriber(MainMenu.getUser().getUserName());


### PR DESCRIPTION
Part of OP-1429 (Improve the Operations management GUI in the admission workflow): https://openhospital.atlassian.net/browse/OP-1429

Robustness/usability pass on the admission/OPD operations panel (the behaviour of a compulsory result and the Add→Update button landed with OP-1404):

- `OperationRowBase.addToForm` guards against a click with no row selected (was throwing `IndexOutOfBoundsException` on a deselecting click).
- The Trans Unit parse is unified in `OperationRowBase` by declaring the field as `VoFloatTextField` and using its `getValue()` (parse-or-0), removing the duplicated try/catch across the add and edit branches of `OperationRowAdm`/`OperationRowOpd`.
- `OperationRowOpd.saveAllOpeRow` now catches per row like `OperationRowAdm`, so one invalid row no longer aborts the loop and silently drops the newly added rows.

Depends on the core PR for the mandatory-result validation.

Companion PRs: core informatici/openhospital-core#1644 · doc informatici/openhospital-doc#293
