### PR TITLE
OP-1431 Reject reusing the current password on the forced password change

### DIFF
--- a/bundle/language_en.properties
+++ b/bundle/language_en.properties
@@ -1869,6 +1869,7 @@ angal.userbrowser.passwordmustnotbeblank.msg                                    
 angal.userbrowser.passwordsdonotmatchpleasecorrect.msg                                                 = Passwords do not match; please correct.
 angal.userbrowser.passwordsdonotmatchpleaseretry.msg                                                   = Passwords do not match; please retry.
 angal.userbrowser.passwordsmustcontainatleastonealphabeticnumericandspecialcharacter.msg               = Password must contain at least one alphabetic, numeric, and special character.
+angal.userbrowser.newpasswordmustbedifferentfromthecurrentone.msg                                      = The new password must be different from the current one.
 angal.userbrowser.pleaseprovideapassword.msg                                                           = Please provide a password.
 angal.userbrowser.pleaseprovideavalidusername.msg                                                      = Please provide a valid user name.
 angal.userbrowser.pleaseprovidetheretypepassword.msg                                                   = Please provide the 'retype' password.

--- a/src/main/java/org/isf/menu/gui/ChangePasswordDialog.java
+++ b/src/main/java/org/isf/menu/gui/ChangePasswordDialog.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/menu/gui/ChangePasswordDialog.java
+++ b/src/main/java/org/isf/menu/gui/ChangePasswordDialog.java
@@ -34,6 +34,7 @@ import javax.swing.event.AncestorListener;
 import org.isf.generaldata.GeneralData;
 import org.isf.generaldata.MessageBundle;
 import org.isf.menu.manager.UserBrowsingManager;
+import org.isf.menu.model.User;
 import org.isf.utils.db.BCrypt;
 import org.isf.utils.jobjects.MessageDialog;
 
@@ -56,10 +57,11 @@ public final class ChangePasswordDialog {
 	 *
 	 * @param parent the parent component for the dialogs
 	 * @param userBrowsingManager used to check the password strength policy
+	 * @param user the user whose password is being changed, used to reject reusing the current password (may be {@code null} to skip that check)
 	 * @param title the title shown on the dialogs
 	 * @return the BCrypt-hashed new password, or {@code null} if the user cancelled or the two entries did not match
 	 */
-	public static String promptForNewPassword(Component parent, UserBrowsingManager userBrowsingManager, String title) {
+	public static String promptForNewPassword(Component parent, UserBrowsingManager userBrowsingManager, User user, String title) {
 		JPasswordField pwd = new JPasswordField(10);
 		pwd.addAncestorListener(new AncestorListener() {
 
@@ -106,6 +108,11 @@ public final class ChangePasswordDialog {
 					pwd.setText("");
 				} else if (!userBrowsingManager.isPasswordStrong(newPassword)) {
 					MessageDialog.error(parent, "angal.userbrowser.passwordsmustcontainatleastonealphabeticnumericandspecialcharacter.msg");
+					newPassword = "";
+					pwd.setText("");
+				} else if (userBrowsingManager.isSameAsCurrentPassword(user, newPassword)) {
+					// OP-1431: a forced/self password change must not reuse the current password
+					MessageDialog.error(parent, "angal.userbrowser.newpasswordmustbedifferentfromthecurrentone.msg");
 					newPassword = "";
 					pwd.setText("");
 				}

--- a/src/main/java/org/isf/menu/gui/Login.java
+++ b/src/main/java/org/isf/menu/gui/Login.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/menu/gui/Login.java
+++ b/src/main/java/org/isf/menu/gui/Login.java
@@ -213,7 +213,7 @@ public class Login extends JDialog implements ActionListener, KeyListener {
 					} else {
 						MessageDialog.info(this, "angal.login.yourpasswordwasresetbyanadministrator.msg");
 					}
-					String hashed = ChangePasswordDialog.promptForNewPassword(this, userBrowsingManager,
+					String hashed = ChangePasswordDialog.promptForNewPassword(this, userBrowsingManager, user,
 						MessageBundle.getMessage("angal.login.changepassword.title"));
 					if (hashed == null) {
 						MessageDialog.error(this, "angal.login.youmustchangethepasswordbeforeloggingin.msg");

--- a/src/main/java/org/isf/menu/gui/UserBrowsing.java
+++ b/src/main/java/org/isf/menu/gui/UserBrowsing.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/menu/gui/UserBrowsing.java
+++ b/src/main/java/org/isf/menu/gui/UserBrowsing.java
@@ -143,7 +143,8 @@ public class UserBrowsing extends ModalJFrame implements UserListener {
 				selectedrow = table.getSelectedRow();
 				user = (User) model.getValueAt(table.getSelectedRow(), -1);
 
-				String hashed = ChangePasswordDialog.promptForNewPassword(this, userBrowsingManager,
+				// null user: an administrator reset does not check the target user's current password (the admin does not know it)
+				String hashed = ChangePasswordDialog.promptForNewPassword(this, userBrowsingManager, null,
 					MessageBundle.getMessage("angal.userbrowser.resetpassword.title"));
 				if (hashed == null) {
 					return;


### PR DESCRIPTION
## What

`ChangePasswordDialog.promptForNewPassword` now takes the `User` being changed and rejects a new password equal to the current one (via the core `isSameAsCurrentPassword`), re-prompting with a message instead of accepting it.

## Why

Follow-up to the password-policy work (OP-896 / OP-1430): the mandatory password change at login must not accept the current password as the "new" one. The check is wired for the forced/self change at login; the administrator "reset password" action passes `null` (an admin does not know the target user's current password), so that flow is unaffected.

## Notes

- New message key `angal.userbrowser.newpasswordmustbedifferentfromthecurrentone.msg` in the English bundle.

Depends on openhospital-core: OP-1431 (`isSameAsCurrentPassword`).

Jira: OP-1431

---
Related PRs: openhospital-core #1648 · openhospital-api #608 · openhospital-gui #2236
