### PR TITLE
OP-1403 Compile stale JRXML reports at startup when enabled

### DIFF
--- a/rsc/settings.properties.dist
+++ b/rsc/settings.properties.dist
@@ -68,6 +68,10 @@ EXAMINATIONCHART=patient_examination
 OPDCHART=patient_opd_chart
 PATIENTSHEET=patient_clinical_sheet_ver3
 VISITSHEET=WardVisits
+# Compile the .jrxml report templates into .jasper at startup when the .jasper is missing or older than the .jrxml.
+# WARNING: JRXML templates can contain executable expressions; only enable this when the report files are trusted
+# (i.e. not writable by untrusted users). Default: no.
+AUTOCOMPILEJRXML=no
 
 # security
 SESSIONTIMEOUT=5

--- a/src/main/java/org/isf/menu/gui/Menu.java
+++ b/src/main/java/org/isf/menu/gui/Menu.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -26,6 +26,7 @@ import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
 import java.io.File;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Scanner;
 import java.util.regex.Pattern;
 
@@ -39,6 +40,7 @@ import org.isf.generaldata.GeneralData;
 import org.isf.generaldata.MessageBundle;
 import org.isf.generaldata.Version;
 import org.isf.menu.manager.Context;
+import org.isf.stat.manager.JasperReportCompiler;
 import org.isf.utils.jobjects.WaitCursorEventQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,10 +63,22 @@ public class Menu {
 		checkOHVersion();
 		checkJavaVersion();
 		fontChecker();
+		compileReports();
 		JFrame.setDefaultLookAndFeelDecorated(false);
 		new SplashWindow3("rsc" + File.separator + "images" + File.separator + "splash.png", null, 3000);
 		WaitCursorEventQueue waitQueue = new WaitCursorEventQueue(10, Toolkit.getDefaultToolkit().getSystemEventQueue());
 		Toolkit.getDefaultToolkit().getSystemEventQueue().push(waitQueue);
+	}
+
+	/**
+	 * When {@code AUTOCOMPILEJRXML} is enabled, (re)compiles at startup every report template whose {@code .jasper} is
+	 * missing or older than its {@code .jrxml} (OP-1403). Disabled by default; see the security note in the settings.
+	 */
+	private static void compileReports() {
+		if (GeneralData.AUTOCOMPILEJRXML) {
+			int compiled = JasperReportCompiler.compileStaleReports(List.of("rpt_base", "rpt_extra", "rpt_stat"));
+			LOGGER.info("Automatic JRXML compilation is enabled: {} report(s) (re)compiled.", compiled);
+		}
 	}
 
 	private static void checkOHVersion() {


### PR DESCRIPTION
## OP-1403

When `AUTOCOMPILEJRXML` is enabled, the launcher scans the `rpt_base`, `rpt_extra` and `rpt_stat` folders at startup and (re)compiles every report template whose `.jasper` is missing or older than the `.jrxml` (via `JasperReportCompiler`, added in the core PR).

### Changes
- `Menu`: new `compileReports()` step, run at startup right after the settings are loaded, guarded by `GeneralData.AUTOCOMPILEJRXML`.
- `settings.properties.dist`: new `AUTOCOMPILEJRXML=no` default, with a security note.

### Notes
- Depends on informatici/openhospital-core#1649 (`GeneralData.AUTOCOMPILEJRXML` + `JasperReportCompiler`); CI will be red until the core PR is merged, as usual for dependent PRs.
- Verified live: with the flag on, a JasperReports 7 template with a missing `.jasper` is compiled at startup, and legacy JasperReports 6 templates are skipped (logged) without stopping startup.
- Documentation is in openhospital-doc.