### PR TITLE
OP-1426 Keep the inventory window open when a save-on-close fails

### DIFF
--- a/src/main/java/org/isf/medicalinventory/gui/InventoryEdit.java
+++ b/src/main/java/org/isf/medicalinventory/gui/InventoryEdit.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -257,6 +257,8 @@ public class InventoryEdit extends ModalJFrame {
 	private MovBrowserManager movBrowserManager = Context.getApplicationContext().getBean(MovBrowserManager.class);
 	private boolean allMedicals;
 	private boolean allMedicalsChosen;
+	// OP-1426: set by the save action, read by the close action so the window is only disposed on a successful save
+	private boolean saveSucceeded;
 	private Object[] allMedicalsOrList = {
 			MessageBundle.getMessage("angal.inventory.yesallmedicals.btn"),
 			MessageBundle.getMessage("angal.inventory.noonlytheonesinthelist.btn")
@@ -584,6 +586,7 @@ public class InventoryEdit extends ModalJFrame {
 		saveButton = new JButton(MessageBundle.getMessage("angal.common.save.btn"));
 		saveButton.setMnemonic(MessageBundle.getMnemonic("angal.common.save.btn.key"));
 		saveButton.addActionListener(actionEvent -> {
+			saveSucceeded = false;
 			try {
 				if (inventoryRowSearchList == null || inventoryRowSearchList.isEmpty()) {
 					MessageDialog.error(null, "angal.inventory.cannotsaveinventorywithoutproducts.msg");
@@ -638,6 +641,7 @@ public class InventoryEdit extends ModalJFrame {
 					validateButton.setEnabled(true);
 					confirmButton.setEnabled(false);
 					resetVariables();
+					saveSucceeded = true;
 
 				} else if (mode.equals("update")) {
 					int response = MessageDialog.yesNo(null, "angal.inventory.doyouwanttoupdatethisinventory.msg");
@@ -718,6 +722,7 @@ public class InventoryEdit extends ModalJFrame {
 						resetVariables();
 						validateButton.setEnabled(true);
 						confirmButton.setEnabled(false);
+						saveSucceeded = true;
 					}
 				}
 			} catch (OHServiceException e) {
@@ -1055,7 +1060,9 @@ public class InventoryEdit extends ModalJFrame {
 				int reset = MessageDialog.yesNoCancel(null, "angal.inventory.doyouwanttosavethechanges.msg");
 				if (reset == JOptionPane.YES_OPTION) {
 					this.saveButton.doClick();
-					dispose();
+					if (saveSucceeded) {
+						dispose();
+					}
 				}
 				if (reset == JOptionPane.NO_OPTION) {
 					resetVariables();

--- a/src/main/java/org/isf/medicalinventory/gui/InventoryWardEdit.java
+++ b/src/main/java/org/isf/medicalinventory/gui/InventoryWardEdit.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -246,6 +246,8 @@ public class InventoryWardEdit extends ModalJFrame {
 	private MovWardBrowserManager movWardBrowserManager = Context.getApplicationContext().getBean(MovWardBrowserManager.class);
 	private boolean allMedicals;
 	private boolean allMedicalsChosen;
+	// OP-1426: set by the save action, read by the close action so the window is only disposed on a successful save
+	private boolean saveSucceeded;
 	private Object[] allMedicalsOrList = {
 			MessageBundle.getMessage("angal.inventory.yesallmedicals.btn"),
 			MessageBundle.getMessage("angal.inventory.noonlytheonesinthelist.btn")
@@ -535,6 +537,7 @@ public class InventoryWardEdit extends ModalJFrame {
 		saveButton = new JButton(MessageBundle.getMessage("angal.common.save.btn"));
 		saveButton.setMnemonic(MessageBundle.getMnemonic("angal.common.save.btn.key"));
 		saveButton.addActionListener(actionEvent -> {
+			saveSucceeded = false;
 			try {
 				if (inventoryRowSearchList == null || inventoryRowSearchList.isEmpty()) {
 					MessageDialog.error(null, "angal.inventory.cannotsaveinventorywithoutproducts.msg");
@@ -586,6 +589,7 @@ public class InventoryWardEdit extends ModalJFrame {
 					validateButton.setEnabled(true);
 					confirmButton.setEnabled(false);
 					resetVariables();
+					saveSucceeded = true;
 
 				} else if (mode.equals("update")) {
 					int response = MessageDialog.yesNo(null, "angal.inventory.doyouwanttoupdatethisinventory.msg");
@@ -662,6 +666,7 @@ public class InventoryWardEdit extends ModalJFrame {
 						resetVariables();
 						validateButton.setEnabled(true);
 						confirmButton.setEnabled(false);
+						saveSucceeded = true;
 					}
 				}
 			} catch (OHServiceException e) {
@@ -974,7 +979,9 @@ public class InventoryWardEdit extends ModalJFrame {
 				int reset = MessageDialog.yesNoCancel(null, "angal.inventory.doyouwanttosavethechanges.msg");
 				if (reset == JOptionPane.YES_OPTION) {
 					this.saveButton.doClick();
-					dispose();
+					if (saveSucceeded) {
+						dispose();
+					}
 				}
 				if (reset == JOptionPane.NO_OPTION) {
 					resetVariables();


### PR DESCRIPTION
## OP-1426

Closing an inventory edit window with unsaved changes offers to save them, but if the save failed validation the window closed anyway and the entered data was lost.

### Root cause
In both `InventoryEdit.getCloseButton()` and `InventoryWardEdit.getCloseButton()` the *Yes* branch ran `saveButton.doClick()` and then called `dispose()` **unconditionally** — the save outcome was never checked, so any validation failure (e.g. a missing inventory reference) still ended in the window being disposed.

### Fix
Track whether the save actually succeeded with a `saveSucceeded` flag: reset to `false` at the start of the save action and set to `true` only at the successful end of the new/update paths (a validation failure throws an `OHServiceException` caught before that point). The close button now disposes the window only when `saveSucceeded` is true. Applied to both InventoryEdit and InventoryWardEdit.

### Steps to reproduce (now fixed)
Pharmacy → Inventory → New → *Add medicals by* → Select → All → OK (populates the table) → leave *Inventory's reference* empty → Close → Yes → the save fails with "You must enter a reference." After dismissing the error the window now stays open with the rows intact, so the reference can be entered and the inventory saved.

Compiles; copyright year bumped to 2026.