### PR TITLE
OP-1438 Install a Java 17 JRE in the macOS launcher

### DIFF
--- a/ohmac.sh
+++ b/ohmac.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Open Hospital (www.open-hospital.org)
-# Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+# Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
 #
 # Open Hospital is a free and open source software for healthcare data management.
 #
@@ -69,7 +69,7 @@ TMP_DIR_ESCAPED=$(echo $TMP_DIR | sed -e 's/\//\\\//g')
 
 ##################### Java configuration #######################
 JAVA_URL="https://cdn.azul.com/zulu/bin"
-JAVA_DISTRO="zulu11.64.19-ca-jre11.0.19-macosx_aarch64"
+JAVA_DISTRO="zulu17.60.17-ca-jre17.0.16-macosx_aarch64"
 JAVA_DIR=$JAVA_DISTRO
 JAVA_ARCH="arm64"
 EXT="tar.gz"


### PR DESCRIPTION
Fixes [OP-1438](https://openhospital.atlassian.net/browse/OP-1438).

`ohmac.sh` downloads a Java 11 JRE while the application is compiled for Java 17, so on macOS the JVM rejects the main class before any application code runs:

```
Error: LinkageError occurred while loading main class org.isf.Application
    java.lang.UnsupportedClassVersionError: org/isf/Application has been compiled by a more recent
    version of the Java Runtime (class file version 61.0), this version of the Java Runtime only
    recognizes class file versions up to 55.0
```

Class file version 61 is Java 17, version 55 is Java 11. When the project moved to Java 17 `oh.sh` was updated to `zulu17.60.17-ca-jre17.0.16-linux_$JAVA_PACKAGE_ARCH`, but the macOS launcher was left on the Java 11 distribution. `oh.sh` is not a workaround here: it has no Darwin handling and would fetch a Linux JRE.

This was reported by a user testing on macOS, and it is the reason the application never reaches the DICOM code path on a Mac.

## Change

One line: pin the same Zulu 17 version already used by `oh.sh`, in its macOS aarch64 build.

```diff
-JAVA_DISTRO="zulu11.64.19-ca-jre11.0.19-macosx_aarch64"
+JAVA_DISTRO="zulu17.60.17-ca-jre17.0.16-macosx_aarch64"
```

## Verified against the 1.15.1 package

Using `OpenHospital-v1.15.1-multiarch-client.zip`, which ships no JRE of its own:

- the shipped classes in `oh/bin/OH-gui.jar` begin with `cafe babe 0000 003d`, i.e. class file version 61 (Java 17);
- downloading exactly the JRE the current script fetches and running the shipped application reproduces the error above verbatim;
- downloading the JRE this change pins and running the same application starts it correctly — `Starting Application using Java 17.0.16`, with initialisation stopping only at `DatabaseConfig`, which is expected for a client package with no database configured.

The macOS arm64 OpenCV native and the `--add-opens` flags are untouched, so DICOM rendering keeps working.

## Notes

The change touches no database object, so it is eligible for the 1.15.1 patch. Without it the macOS package cannot start at all, so it may be worth cherry-picking onto `release_1_15_1` before publishing.

Two related observations, left out of scope:

- in the multiarch package `ohmac.sh` sits inside `oh/` while `oh.sh`, `oh.bat` and `oh.ps1` are in the package root, and it has to be run from the root because it looks for `./oh/rsc/version.properties`;
- `JAVA_ARCH` is hard-coded to `arm64`, so Intel Macs are not covered by the script; no macOS x86_64 OpenCV native is shipped either.

[OP-1438]: https://openhospital.atlassian.net/browse/OP-1438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ