### PR TITLE
OP-1439 Clear the macOS quarantine flag from the bundled native libraries

### DIFF
--- a/ohmac.sh
+++ b/ohmac.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Open Hospital (www.open-hospital.org)
-# Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+# Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
 #
 # Open Hospital is a free and open source software for healthcare data management.
 #
@@ -231,6 +231,18 @@ function java_lib_setup {
         NATIVE_LIB_PATH="./$OH_DIR/lib/native/macOS/arm64"
         ;;
 	esac
+
+	# macOS tags everything extracted from a downloaded archive with a quarantine
+	# flag. The bundled OpenCV native is only ad-hoc signed, so Gatekeeper refuses
+	# to load it and warns the user that it may contain malware. Clear the flag on
+	# the native libraries, before the JVM tries to load them: once a load has been
+	# blocked, clearing it afterwards no longer helps.
+	# Nothing happens when the flag is absent, e.g. when running from a checkout.
+	if [ -d "$NATIVE_LIB_PATH" ] && ls "$NATIVE_LIB_PATH"/*.dylib >/dev/null 2>&1 &&
+		xattr "$NATIVE_LIB_PATH"/*.dylib 2>/dev/null | grep -q "com.apple.quarantine"; then
+		echo "Removing the macOS quarantine flag from the bundled native libraries..."
+		xattr -dr com.apple.quarantine "$NATIVE_LIB_PATH"
+	fi
 
 	# CLASSPATH setup
 	# include OH jar file


### PR DESCRIPTION
Fixes [OP-1439](https://openhospital.atlassian.net/browse/OP-1439).

On macOS the bundled OpenCV native cannot be loaded when the package was downloaded through a browser. What the user gets is not a technical error but a security warning naming a library shipped inside Open Hospital:

> **libopencv_java.dylib non è stata aperta**
> Apple non è in grado di verificare che libopencv_java.dylib non contenga malware che potrebbero danneggiare il Mac o compromettere la tua privacy.
> [ Sposta nel Cestino ] [ Fine ]

*("libopencv_java.dylib was not opened. Apple is unable to verify that libopencv_java.dylib does not contain malware that could harm your Mac or compromise your privacy." — buttons: Move to Trash / Done. The screenshot was taken with the system in Italian.)*

The library load blocks until the user answers, so the application appears to freeze when a DICOM image is opened. If the user picks **Move to Trash**, the native is deleted and the installation is permanently broken with no hint as to why.

## Why it happens

The native is signed **ad-hoc only**:

```
Format=Mach-O thin (arm64)
CodeDirectory v=20400 ... flags=0x20002(adhoc,linker-signed)
Signature=adhoc
```

An ad-hoc signature is enough to *execute* on Apple Silicon, but not enough for Gatekeeper to clear a file carrying `com.apple.quarantine`. A browser sets that attribute on the downloaded archive, and Archive Utility propagates it to every extracted file, so the library inherits it.

Files from a git checkout never carry the attribute. That is why this is invisible during development — including when the macOS native was originally added — and only appears on the distributed package.

## The change

Clear the flag on the native library directory in `java_lib_setup`, which runs before the JVM is launched.

Three properties are deliberate:

- it acts **only when the flag is actually present**, so running from a checkout is unaffected;
- it **reports what it does** instead of doing it silently;
- it is scoped to `lib/native`, not the whole package, because the library is the only file that goes through `dlopen` — jars are not subject to Gatekeeper.

Timing matters: the flag must be cleared **before the first load attempt**. Once a load has been blocked, clearing it afterwards does not unblock it in that session.

## Verification

Run end-to-end against `OpenHospital-v1.15.1-multiarch-client.zip`, with the quarantine attribute set on the archive and the package extracted through Archive Utility, so the attribute reaches the library exactly as it does for a user downloading from a browser. The launcher's JRE was set to Java 17 for the test, otherwise the application does not start at all (OP-1438).

| Step | Result |
| --- | --- |
| Before running the launcher | `com.apple.quarantine` present on the library |
| Launcher run | prints `Removing the macOS quarantine flag from the bundled native libraries...` |
| After the run | attribute gone |
| Loading the library afterwards | loads immediately, no dialog |
| Launcher run again on the clean package | prints nothing, does nothing |

Without the change the same sequence blocks, with the process stopped inside `dyld4::APIs::dlopen` waiting on the system policy daemon that drives the dialog.

## What this is not

This is a workaround, and it **removes a security marker on the user's behalf**. That is common practice for self-distributed open source software, and the user is deliberately running the launcher, but it deserves an explicit decision rather than passing unnoticed in a patch.

The correct fix is to sign the native with a **Developer ID certificate and notarise it**, after which no warning appears and no workaround is needed. That requires an Apple developer account, the signing identity stored as a secret and a notarisation step in the release pipeline, so it is separate work that cannot ship with 1.15.1.

The manual remedy (`xattr -dr com.apple.quarantine` on the package folder) is worth documenting either way, since it is the only option for anyone who has already downloaded an affected package.

## Related

Independent of #2242 (OP-1438), which fixes the launcher installing a Java 11 JRE for a Java 17 application. Both are needed for the macOS package to be usable: without OP-1438 the application does not start, and with it DICOM rendering ends at this dialog.

The change touches no database object, so it is eligible for the 1.15.1 patch if the approach is accepted.

[OP-1439]: https://openhospital.atlassian.net/browse/OP-1439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ