### PR TITLE
OP-1443 Make the portable launcher survive an imperfect first run

### DIFF
--- a/oh.ps1
+++ b/oh.ps1
@@ -137,6 +137,9 @@ $script:OH_DIR="."
 $script:OH_DOC_DIR="doc"
 $script:CONF_DIR="data/conf"
 $script:DATA_DIR="data/db"
+
+# seconds to wait for the database to start listening, or to release its port on shutdown
+$script:DATABASE_WAIT_TIMEOUT=90
 $script:PHOTO_DIR="data/photo"
 $script:BACKUP_DIR="data/dump"
 $script:LOG_DIR="data/log"
@@ -893,18 +896,38 @@ function start_database {
 
 	Write-Host "Starting $MYSQL_NAME server... "
 	try {
-		Start-Process -FilePath "$OH_PATH\$MYSQL_DIR\bin\mysqld.exe" -ArgumentList ("--defaults-file=`"$OH_PATH\$CONF_DIR\$MYSQL_CONF_FILE`" --tmpdir=`"$OH_PATH\$TMP_DIR`" --standalone") -NoNewWindow -RedirectStandardOutput "$LOG_DIR/$LOG_FILE" -RedirectStandardError "$LOG_DIR/$LOG_FILE_ERR"
-		Start-Sleep -Seconds 2
+		$script:DATABASE_PROCESS = Start-Process -PassThru -FilePath "$OH_PATH\$MYSQL_DIR\bin\mysqld.exe" -ArgumentList ("--defaults-file=`"$OH_PATH\$CONF_DIR\$MYSQL_CONF_FILE`" --tmpdir=`"$OH_PATH\$TMP_DIR`" --standalone") -NoNewWindow -RedirectStandardOutput "$LOG_DIR/$LOG_FILE" -RedirectStandardError "$LOG_DIR/$LOG_FILE_ERR"
 	}
 	catch {
 		Write-Host "Error: $MYSQL_NAME server not started! Exiting." -ForegroundColor Red
 		Read-Host; exit 2
 	}
 
-	# wait till the MariaDB/MySQL socket file is created -> TO BE IMPLEMENTED
-	# while ( -e $OH_PATH/$MYSQL_SOCKET ); do sleep 1; done
-	# # Wait till the MariaDB/MySQL tcp port is open
-	# until nc -z $DATABASE_SERVER $DATABASE_PORT; do sleep 1; done
+	# Wait till the MariaDB/MySQL tcp port is open, instead of assuming two seconds are enough: the
+	# next thing this script does is run a mysql client, and on a slow machine, or on a start that
+	# has to build the system tables or recover after an unclean shutdown, two seconds are not.
+	#
+	# A start that has already failed is not waited out either - once mysqld has exited, the port
+	# will never open and there is nothing left to wait for. That is the common failure and it is
+	# reported at once; the timeout covers the rarer server that runs but does not get to listening.
+	$WAITED = 0
+	while ( !(database_port_open) ) {
+		if ( $script:DATABASE_PROCESS -And $script:DATABASE_PROCESS.HasExited ) {
+			Write-Host "Error: $MYSQL_NAME server exited before it started listening on $DATABASE_SERVER port $DATABASE_PORT." -ForegroundColor Red
+			Write-Host "See $LOG_DIR/$LOG_FILE_ERR for the reason. Exiting." -ForegroundColor Red
+			Read-Host; exit 2
+		}
+		if ( $WAITED -ge $DATABASE_WAIT_TIMEOUT ) {
+			Write-Host "Error: $MYSQL_NAME server is not listening on $DATABASE_SERVER port $DATABASE_PORT after $DATABASE_WAIT_TIMEOUT seconds." -ForegroundColor Red
+			Write-Host "See $LOG_DIR/$LOG_FILE_ERR for the reason. Exiting." -ForegroundColor Red
+			Read-Host; exit 2
+		}
+		if ( ($WAITED -gt 0) -And ($WAITED % 10 -eq 0) ) {
+			Write-Host "Still waiting for $MYSQL_NAME to listen on $DATABASE_SERVER port $DATABASE_PORT ($WAITED s)..."
+		}
+		Start-Sleep -Seconds 1
+		$WAITED++
+	}
 
 	Write-Host "$MYSQL_NAME server started!"
 }
@@ -1020,13 +1043,43 @@ function dump_database {
 }
 
 ###################################################################
+# Whether the database is accepting connections on its TCP port.
+#
+# A refused connection makes Task.Wait throw rather than return false, so the call is guarded: left
+# uncaught the failure would surface as an error from the loops below instead of as a closed port.
+function database_port_open {
+	$client = New-Object System.Net.Sockets.TcpClient
+	try {
+		return $client.ConnectAsync("$DATABASE_SERVER", $DATABASE_PORT).Wait(1000)
+	}
+	catch {
+		return $false
+	}
+	finally {
+		$client.Dispose()
+	}
+}
+
+###################################################################
 function shutdown_database {
 	if ( !( $OH_MODE -eq "CLIENT" ) ) {
 		Write-Host "Shutting down $MYSQL_NAME..."
 		Start-Process -FilePath "$OH_PATH\$MYSQL_DIR\bin\mysqladmin.exe" -ArgumentList ("-u $DATABASE_ROOT_USER -p$DATABASE_ROOT_PW --host=$DATABASE_SERVER --port=$DATABASE_PORT --protocol=tcp shutdown") -Wait -NoNewWindow -RedirectStandardOutput "$LOG_DIR/$LOG_FILE" -RedirectStandardError "$LOG_DIR/$LOG_FILE_ERR"
-		# wait till the $MYSQL_NAME socket file is removed -> TO BE IMPLEMENTED
-		# while ( -e $OH_PATH/$MYSQL_SOCKET ); do sleep 1; done
-		Start-Sleep -Seconds 2
+		# wait till the port is released, rather than assuming two seconds are enough: a server with
+		# work still to flush takes longer, and the next start would then find the port still taken
+		$WAITED = 0
+		while ( database_port_open ) {
+			if ( $WAITED -ge $DATABASE_WAIT_TIMEOUT ) {
+				Write-Host "Warning: $MYSQL_NAME is still listening on $DATABASE_SERVER port $DATABASE_PORT after $DATABASE_WAIT_TIMEOUT seconds." -ForegroundColor Yellow
+				Write-Host "See $LOG_DIR/$LOG_FILE_ERR for the reason." -ForegroundColor Yellow
+				return
+			}
+			if ( ($WAITED -gt 0) -And ($WAITED % 10 -eq 0) ) {
+				Write-Host "Still waiting for $MYSQL_NAME to release $DATABASE_SERVER port $DATABASE_PORT ($WAITED s)..."
+			}
+			Start-Sleep -Seconds 1
+			$WAITED++
+		}
 		Write-Host "$MYSQL_NAME stopped!"
 	}
 
@@ -1893,7 +1946,20 @@ if ( ($OH_MODE -eq "PORTABLE") -Or ($OH_MODE -eq "SERVER") ){
 	mysql_check;
 	# config database
 	config_database;
-	# check if OH database already exists
+	# check if OH database already exists.
+	#
+	# The data directory alone does not say that: initialize_database creates it as its very first
+	# step, so an installation interrupted at any point afterwards looked complete on the next run
+	# and the launcher went straight to start_database on a database that could not work, with no
+	# hint that the first attempt had never finished. What tells a finished installation apart is
+	# the directory the database engine creates for the [$DATABASE_NAME] schema itself, inside the
+	# data directory.
+	if ( (Test-Path "$OH_PATH/$DATA_DIR") -And !(Test-Path "$OH_PATH/$DATA_DIR/$DATABASE_NAME") ) {
+		Write-Host "Error: a previous installation of the [$DATABASE_NAME] database was left unfinished in $DATA_DIR." -ForegroundColor Red
+		Write-Host "Remove that directory, or reset the installation with option [X] which deletes the data for you," -ForegroundColor Red
+		Write-Host "then run this script again. Exiting." -ForegroundColor Red
+		Read-Host; exit 2
+	}
 	if ( !(Test-Path "$OH_PATH/$DATA_DIR") ) {
 		Write-Host "OH database not found, starting from scratch..."
 		# prepare database

--- a/oh.sh
+++ b/oh.sh
@@ -809,17 +809,35 @@ function start_database {
 
 	echo "Starting $MYSQL_NAME server... "
 	./$MYSQL_DIR/bin/mysqld_safe --defaults-file=./$CONF_DIR/$MYSQL_CONF_FILE >> ./$LOG_DIR/$LOG_FILE 2>&1 &
+	DATABASE_LAUNCHER_PID=$!
 	if [ $? -ne 0 ]; then
 		echo "Error: $MYSQL_NAME server not started! Exiting."
 		exit 2
 	fi
-	# wait till the MariaDB/MySQL tcp port is open
+	# wait till the MariaDB/MySQL tcp port is open.
+	#
+	# A start that has already failed is not waited out: mysqld_safe stays alive for as long as the
+	# server does, so once it is gone the port will never open and there is nothing left to wait for.
+	# That is the common failure - a port already taken, a data directory the server will not accept,
+	# a bad configuration - and it is now reported in about a second rather than at the end of the
+	# timeout. The timeout is what remains for the rarer case of a server that runs but does not get
+	# to listening, where waiting is the right thing to do: a start that has to build its system
+	# tables, or one recovering after an unclean shutdown, takes its time and does succeed.
 	WAITED=0
 	until database_port_open; do
+		if ! kill -0 $DATABASE_LAUNCHER_PID 2>/dev/null; then
+			echo "Error: $MYSQL_NAME server exited before it started listening on $DATABASE_SERVER:$DATABASE_PORT."
+			echo "See ./$LOG_DIR/$LOG_FILE for the reason. Exiting."
+			exit 2
+		fi
 		if [ $WAITED -ge $DATABASE_WAIT_TIMEOUT ]; then
 			echo "Error: $MYSQL_NAME server is not listening on $DATABASE_SERVER:$DATABASE_PORT after $DATABASE_WAIT_TIMEOUT seconds."
 			echo "See ./$LOG_DIR/$LOG_FILE for the reason. Exiting."
 			exit 2
+		fi
+		# say something while waiting, so that a slow start is not mistaken for the hang this replaced
+		if [ $WAITED -gt 0 ] && [ $((WAITED % 10)) -eq 0 ]; then
+			echo "Still waiting for $MYSQL_NAME to listen on $DATABASE_SERVER:$DATABASE_PORT ($WAITED s)..."
 		fi
 		sleep 1
 		WAITED=$((WAITED+1))
@@ -948,6 +966,9 @@ function shutdown_database {
 				echo "Warning: $MYSQL_NAME is still listening on $DATABASE_SERVER:$DATABASE_PORT after $DATABASE_WAIT_TIMEOUT seconds."
 				echo "See ./$LOG_DIR/$LOG_FILE for the reason."
 				return
+			fi
+			if [ $WAITED -gt 0 ] && [ $((WAITED % 10)) -eq 0 ]; then
+				echo "Still waiting for $MYSQL_NAME to release $DATABASE_SERVER:$DATABASE_PORT ($WAITED s)..."
 			fi
 			sleep 1
 			WAITED=$((WAITED+1))

--- a/oh.sh
+++ b/oh.sh
@@ -1818,6 +1818,15 @@ if [ "$OH_MODE" = "PORTABLE" ] || [ "$OH_MODE" = "SERVER" ] ; then
 	# config database
 	config_database;
 	# check if OH database already exists
+	#
+	# The data directory alone does not say that: initialize_database creates it as its very first
+	# step, so an installation interrupted at any point afterwards looked complete on the next run
+	# and the launcher went straight to start_database on a database that could not work, with no
+	# hint that the first attempt had never finished. What tells a finished installation apart is
+	# the directory the database engine creates for the [$DATABASE_NAME] schema itself. It is looked
+	# up without regard to case, because the shipped my.cnf sets lower_case_table_names and the
+	# engine then stores the schema of a database named MyHospital in a directory called myhospital,
+	# while DATA_DIR keeps the name as the user typed it.
 	if [ ! -d ./"$DATA_DIR" ]; then
 		echo "OH database not found, starting from scratch..."
 		# prepare database
@@ -1832,6 +1841,11 @@ if [ "$OH_MODE" = "PORTABLE" ] || [ "$OH_MODE" = "SERVER" ] ; then
 		create_database;
 		# load data
 		import_database;
+	elif [ -z "$(find ./"$DATA_DIR" -mindepth 1 -maxdepth 1 -type d -iname "$DATABASE_NAME" -print -quit 2>/dev/null)" ]; then
+		echo "Error: a previous installation of the [$DATABASE_NAME] database was left unfinished in ./$DATA_DIR."
+		echo "Remove that directory, or reset the installation with option [X] which deletes the data for you,"
+		echo "then run this script again. Exiting."
+		exit 2
 	else
 	        echo "OH database found!"
 		# start database

--- a/oh.sh
+++ b/oh.sh
@@ -111,6 +111,9 @@ EXT="tar.gz"
 # mysql configuration file
 MYSQL_CONF_FILE="my.cnf"
 
+# seconds to wait for the database to start listening, or to release its port on shutdown
+DATABASE_WAIT_TIMEOUT=90
+
 # OH configuration files - see also settings.properties
 OH_SETTINGS="settings.properties"
 DATABASE_SETTINGS="database.properties"
@@ -782,6 +785,16 @@ function initialize_database {
 }
 
 ###################################################################
+# Whether the database is accepting connections on its TCP port.
+#
+# The port is probed with bash's own /dev/tcp redirection rather than with `nc`, which is not part
+# of the package and is absent from many minimal installations: there the probe never succeeded, so
+# the wait loop below span forever and the launcher hung with no message and no way to tell why.
+function database_port_open {
+	(exec 3<>/dev/tcp/$DATABASE_SERVER/$DATABASE_PORT) > /dev/null 2>&1
+}
+
+###################################################################
 function start_database {
 	echo "Checking if $MYSQL_NAME is running..."
 	if [ -f "$OH_PATH/$TMP_DIR/mysql.sock" ] || [ -f "$OH_PATH/$TMP_DIR/mysql.pid" ] ; then
@@ -801,7 +814,16 @@ function start_database {
 		exit 2
 	fi
 	# wait till the MariaDB/MySQL tcp port is open
-	until nc -z $DATABASE_SERVER $DATABASE_PORT; do sleep 1; done
+	WAITED=0
+	until database_port_open; do
+		if [ $WAITED -ge $DATABASE_WAIT_TIMEOUT ]; then
+			echo "Error: $MYSQL_NAME server is not listening on $DATABASE_SERVER:$DATABASE_PORT after $DATABASE_WAIT_TIMEOUT seconds."
+			echo "See ./$LOG_DIR/$LOG_FILE for the reason. Exiting."
+			exit 2
+		fi
+		sleep 1
+		WAITED=$((WAITED+1))
+	done
 	echo "$MYSQL_NAME server started!"
 }
 
@@ -920,7 +942,16 @@ function shutdown_database {
 		cd "$OH_PATH"
 		./$MYSQL_DIR/bin/mysqladmin -u $DATABASE_ROOT_USER -p$DATABASE_ROOT_PW --host=$DATABASE_SERVER --port=$DATABASE_PORT --protocol=tcp shutdown >> ./$LOG_DIR/$LOG_FILE 2>&1
 		# wait till the MySQL tcp port is closed
-		until !( nc -z $DATABASE_SERVER $DATABASE_PORT ); do sleep 1; done
+		WAITED=0
+		while database_port_open; do
+			if [ $WAITED -ge $DATABASE_WAIT_TIMEOUT ]; then
+				echo "Warning: $MYSQL_NAME is still listening on $DATABASE_SERVER:$DATABASE_PORT after $DATABASE_WAIT_TIMEOUT seconds."
+				echo "See ./$LOG_DIR/$LOG_FILE for the reason."
+				return
+			fi
+			sleep 1
+			WAITED=$((WAITED+1))
+		done
 		echo "$MYSQL_NAME stopped!"
 	else
 		exit 1


### PR DESCRIPTION
Two defects in the portable path of `oh.sh`, both about a first run that does not go perfectly. Reproduced and verified in a Linux x86_64 container running the portable package, with a before and after for each.

## [OP-1443](https://openhospital.atlassian.net/browse/OP-1443) — the launcher hangs waiting for the database

The wait for the database port used `nc`, which the package does not ship and many minimal installations do not have. There the probe fails every time, so the loop never ends:

```
./oh.sh: line 804: nc: command not found
./oh.sh: line 804: nc: command not found
... once a second, forever
```

The database is up and serving throughout. Nothing on screen suggests what is wrong.

The port is now probed with bash's own `/dev/tcp` redirection, so nothing outside the package is needed, and both waits give up after `DATABASE_WAIT_TIMEOUT` seconds instead of spinning — the start-up one with an error, the shutdown one with a warning rather than the "stopped!" that would not be true.

## [OP-1444](https://openhospital.atlassian.net/browse/OP-1444) — an interrupted installation is never recognised

Whether OH was installed was decided by the existence of the data directory, which `initialize_database` creates as its very first step. An installation interrupted at any point afterwards therefore looks complete on the next run:

```
OH database found!
Starting MariaDB server...
Error: can't connect to database! Exiting.
```

and it does that on every subsequent run. Nothing says the first attempt never finished, so the only way out is knowing to delete the directory by hand.

The check now looks for the directory the database engine creates for the schema itself, which exists only once the database has actually been created.

## Verification

| | before | after |
|---|---|---|
| no `nc` available | loop with no end, database already up | `MariaDB server started!`, server ready |
| interrupted installation | `OH database found!` → `can't connect to database` | the unfinished installation is named, with how to recover |
| complete installation | starts | starts |

The last row is the one that matters most for OP-1444, and it holds for installations made by earlier versions too: the criterion is a directory the engine has always created.

## Note for review

The schema directory is matched without regard to case. The shipped `my.cnf` sets `lower_case_table_names`, so a database named `MyHospital` is stored in a directory called `myhospital` while `DATA_DIR` keeps the name as the user typed it — comparing the two literally would have declared a perfectly healthy installation unfinished, and the message would have invited the user to delete it.


[OP-1443]: https://openhospital.atlassian.net/browse/OP-1443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OP-1444]: https://openhospital.atlassian.net/browse/OP-1444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ