### PR TITLE
OP-1442 Open the patient form where the webcam native is missing

### DIFF
--- a/src/main/java/org/isf/video/gui/PatientPhotoPanel.java
+++ b/src/main/java/org/isf/video/gui/PatientPhotoPanel.java
@@ -153,10 +153,10 @@ public class PatientPhotoPanel extends JPanel {
 				}
 			});
 
-			// only touch the webcam stack when the video module is enabled; Webcam.getDefault() loads a native library
+			// only touch the webcam stack when the video module is enabled; the lookup loads a native library
 			// (BridJ) that is not available on every platform (e.g. Apple Silicon), and calling it unconditionally
 			// would throw an UnsatisfiedLinkError and break the whole patient form even with the video module off
-			final Webcam webcam = GeneralData.VIDEOMODULEENABLED ? defaultWebcam() : null;
+			final Webcam webcam = GeneralData.VIDEOMODULEENABLED ? WebcamProvider.getDefault() : null;
 
 			if (webcam != null) {
 				JButton jGetPhotoButton = new JButton(MessageBundle.getMessage("angal.patientphoto.newphoto.btn"));
@@ -190,25 +190,6 @@ public class PatientPhotoPanel extends JPanel {
 		}
 
 		add(jPhotoPanel);
-	}
-
-	
-	/**
-	 * The default webcam, or {@code null} when none can be used.
-	 * <p>
-	 * Enabling the video module only states that the user wants a webcam, not that the platform can provide one: the
-	 * capture driver loads a native library (BridJ) that ships for a limited set of architectures, so on the others the
-	 * lookup fails at run time. Without this the failure escapes the constructor and no patient can be opened at all,
-	 * which is a far worse outcome than losing the photo booth. Falling back to {@code null} reuses the path already
-	 * taken when the video module is off, where the photo is attached from a file instead.
-	 */
-	private static Webcam defaultWebcam() {
-		try {
-			return Webcam.getDefault();
-		} catch (RuntimeException | LinkageError e) {
-			LOGGER.warn("No usable webcam on this platform: taking the photo from a file instead.", e);
-			return null;
-		}
 	}
 
 	private JPanel setMyBorder(JPanel c, String title) {

--- a/src/main/java/org/isf/video/gui/PatientPhotoPanel.java
+++ b/src/main/java/org/isf/video/gui/PatientPhotoPanel.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2023 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -156,7 +156,7 @@ public class PatientPhotoPanel extends JPanel {
 			// only touch the webcam stack when the video module is enabled; Webcam.getDefault() loads a native library
 			// (BridJ) that is not available on every platform (e.g. Apple Silicon), and calling it unconditionally
 			// would throw an UnsatisfiedLinkError and break the whole patient form even with the video module off
-			final Webcam webcam = GeneralData.VIDEOMODULEENABLED ? Webcam.getDefault() : null;
+			final Webcam webcam = GeneralData.VIDEOMODULEENABLED ? defaultWebcam() : null;
 
 			if (webcam != null) {
 				JButton jGetPhotoButton = new JButton(MessageBundle.getMessage("angal.patientphoto.newphoto.btn"));
@@ -193,6 +193,24 @@ public class PatientPhotoPanel extends JPanel {
 	}
 
 	
+	/**
+	 * The default webcam, or {@code null} when none can be used.
+	 * <p>
+	 * Enabling the video module only states that the user wants a webcam, not that the platform can provide one: the
+	 * capture driver loads a native library (BridJ) that ships for a limited set of architectures, so on the others the
+	 * lookup fails at run time. Without this the failure escapes the constructor and no patient can be opened at all,
+	 * which is a far worse outcome than losing the photo booth. Falling back to {@code null} reuses the path already
+	 * taken when the video module is off, where the photo is attached from a file instead.
+	 */
+	private static Webcam defaultWebcam() {
+		try {
+			return Webcam.getDefault();
+		} catch (RuntimeException | LinkageError e) {
+			LOGGER.warn("No usable webcam on this platform: taking the photo from a file instead.", e);
+			return null;
+		}
+	}
+
 	private JPanel setMyBorder(JPanel c, String title) {
 		Border b1 = BorderFactory.createLineBorder(Color.lightGray);
 		Border b2 = BorderFactory.createTitledBorder(b1, title, TitledBorder.LEFT, TitledBorder.TOP);

--- a/src/main/java/org/isf/video/gui/PhotoboothComponentImpl.java
+++ b/src/main/java/org/isf/video/gui/PhotoboothComponentImpl.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -97,8 +97,10 @@ public final class PhotoboothComponentImpl extends PhotoboothComponent {
         this.photoboothPanelPresentationModel = model;
         this.owner = owner;
 
-        this.allWebcams = Webcam.getWebcams();
-        this.webcam = Webcam.getDefault();
+        // through the provider, so a platform whose capture driver cannot load fails here the way it
+        // does in PatientPhotoPanel: once, rather than with a stack trace per patient
+        this.allWebcams = WebcamProvider.getWebcams();
+        this.webcam = WebcamProvider.getDefault();
 
         this.supportedResolutions = new ArrayList<>();
         Collections.addAll(supportedResolutions, webcam.getDevice().getResolutions());

--- a/src/main/java/org/isf/video/gui/WebcamProvider.java
+++ b/src/main/java/org/isf/video/gui/WebcamProvider.java
@@ -1,0 +1,84 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.video.gui;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.sarxos.webcam.Webcam;
+
+/**
+ * Access to the capture devices, guarding the calls that can fail on a platform the capture driver
+ * does not support.
+ * <p>
+ * Enabling the video module states that the user wants a webcam, not that the platform can provide
+ * one: the driver loads a native library (BridJ) that ships for a limited set of architectures, and
+ * on the others the very first lookup fails at run time. Left to escape, that failure takes down
+ * whatever was being built at the time - the patient form could not be opened at all.
+ * <p>
+ * A failure of that kind is permanent for the life of the process: the native library will not
+ * appear later, and once its class has failed to initialize every further call fails again. It is
+ * therefore remembered, so the cost and the stack trace are paid once rather than on every patient.
+ * An ordinary absence of devices is not remembered: {@code null} simply means none is connected
+ * right now, and a webcam plugged in after startup is still found.
+ */
+public final class WebcamProvider {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(WebcamProvider.class);
+
+	/** Set when the capture driver has failed to load; never cleared. */
+	private static volatile boolean driverUnavailable;
+
+	private WebcamProvider() {
+	}
+
+	/**
+	 * The default webcam, or {@code null} when the platform cannot provide one.
+	 */
+	public static Webcam getDefault() {
+		return guarded(Webcam::getDefault, null);
+	}
+
+	/**
+	 * The available webcams, or an empty list when the platform cannot provide any.
+	 */
+	public static List<Webcam> getWebcams() {
+		return guarded(Webcam::getWebcams, List.of());
+	}
+
+	private static <T> T guarded(Supplier<T> lookup, T whenUnavailable) {
+		if (driverUnavailable) {
+			return whenUnavailable;
+		}
+		try {
+			return lookup.get();
+		} catch (RuntimeException | LinkageError e) {
+			driverUnavailable = true;
+			LOGGER.warn("No usable webcam on this platform: taking the photo from a file instead.", e);
+			return whenUnavailable;
+		}
+	}
+
+}

--- a/src/test/java/org/isf/video/gui/WebcamProviderTest.java
+++ b/src/test/java/org/isf/video/gui/WebcamProviderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.video.gui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The point of the provider is that a platform without a usable capture driver is answered rather
+ * than thrown at: the lookup escaping is what stopped the patient form from opening at all.
+ * <p>
+ * These run on any platform. Where the driver loads they exercise the ordinary path, where it does
+ * not - Apple Silicon, or any architecture BridJ does not ship a native for - they exercise the
+ * failure path, and neither is allowed to raise.
+ */
+class WebcamProviderTest {
+
+	@Test
+	void theLookupNeverEscapes() {
+		assertThatCode(WebcamProvider::getDefault).doesNotThrowAnyException();
+		assertThatCode(WebcamProvider::getWebcams).doesNotThrowAnyException();
+	}
+
+	@Test
+	void repeatingTheLookupKeepsAnswering() {
+		WebcamProvider.getDefault();
+
+		// the second call is the one a second patient form makes: once a driver failure has been
+		// remembered it must short-circuit, and it must still answer rather than raise
+		assertThatCode(WebcamProvider::getDefault).doesNotThrowAnyException();
+		assertThat(WebcamProvider.getWebcams()).isNotNull();
+	}
+}


### PR DESCRIPTION
Fixes [OP-1442](https://openhospital.atlassian.net/browse/OP-1442).

Enabling the video module states that the user wants a webcam, not that the platform can provide one. The capture driver loads a native library through BridJ, which ships for a limited set of architectures; where it is absent `Webcam.getDefault()` throws, the failure escapes the `PatientPhotoPanel` constructor and **no patient can be opened at all**:

```
java.lang.RuntimeException: Failed to initialize BridJ
Caused by: java.lang.UnsatisfiedLinkError: ... libbridj.dylib:
    (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64'))
```

`VIDEOMODULEENABLED=yes` is what the packages ship, so this is the configuration users actually get. OP-1417 had already made the *disabled* case harmless; this is the enabled one.

The lookup now falls back to no webcam, which is the path already taken when the video module is off: the photo is attached from a file instead. The reason is logged once, so an installation that expected a working webcam can still be diagnosed.

## Not only macOS

The bundled `bridj-0.7.0.jar` carries natives for `darwin_universal`, `linux_x64`, `linux_x86`, `linux_armhf`, `win32` and `win64`. There is **no `linux_arm64`**, so a 64-bit ARM machine — a Raspberry Pi, which is not an exotic deployment for Open Hospital — fails in exactly the same way. It is visible today on Apple Silicon because that is where the mismatch was hit.

## Verification

Driven against the running application, before and after, with the video module enabled as shipped:

* before — the patient form does not open, six native errors in the log;
* after — the form opens, and the only entry left is the single warning explaining why the photo booth is not offered.

The case is part of the GUI regression suite, so a future change that lets the exception escape again will be caught.


[OP-1442]: https://openhospital.atlassian.net/browse/OP-1442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ