### PR TITLE
OP-1449 Fix the remaining macOS launcher defects: API configuration, database configuration, missing functions

### DIFF
--- a/oh.ps1
+++ b/oh.ps1
@@ -1154,10 +1154,10 @@ function write_config_files {
 		(Get-Content "$OH_PATH/$OH_DIR/rsc/$OH_SETTINGS").replace("DEMODATA=off","DEMODATA=$DEMO_DATA") | Set-Content "$OH_PATH/$OH_DIR/rsc/$OH_SETTINGS"
 		# set API_SERVER
 		(Get-Content "$OH_PATH/$OH_DIR/rsc/$OH_SETTINGS").replace("APISERVER=off","APISERVER=$API_SERVER") | Set-Content "$OH_PATH/$OH_DIR/rsc/$OH_SETTINGS"
-		# set GUI INTERFACE
-		(Get-Content "$OH_PATH/$OH_DIR/rsc/$OH_SETTINGS").replace("GUI_INTERFACE=on","GUI_INTERFACE=$GUI_INTERFACE") | Set-Content "$OH_PATH/$OH_DIR/rsc/$OH_SETTINGS"
+		# set GUI INTERFACE - anchored: UI_INTERFACE is a substring of GUI_INTERFACE
+		(Get-Content "$OH_PATH/$OH_DIR/rsc/$OH_SETTINGS") -replace "^GUI_INTERFACE=on","GUI_INTERFACE=$GUI_INTERFACE" | Set-Content "$OH_PATH/$OH_DIR/rsc/$OH_SETTINGS"
 		# set UI INTERFACE
-		(Get-Content "$OH_PATH/$OH_DIR/rsc/$OH_SETTINGS").replace("UI_INTERFACE=off","UI_INTERFACE=$UI_INTERFACE") | Set-Content "$OH_PATH/$OH_DIR/rsc/$OH_SETTINGS"
+		(Get-Content "$OH_PATH/$OH_DIR/rsc/$OH_SETTINGS") -replace "^UI_INTERFACE=off","UI_INTERFACE=$UI_INTERFACE" | Set-Content "$OH_PATH/$OH_DIR/rsc/$OH_SETTINGS"
 	}
 
 	######## OH - Other settings setup

--- a/oh.sh
+++ b/oh.sh
@@ -1013,13 +1013,7 @@ function write_config_files {
 	if [ "$WRITE_CONFIG_FILES" = "on" ] || [ ! -f ./$OH_DIR/rsc/$OH_SETTINGS ]; then
 		[ -f ./$OH_DIR/rsc/$OH_SETTINGS ] && mv -f ./$OH_DIR/rsc/$OH_SETTINGS ./$OH_DIR/rsc/$OH_SETTINGS.old
 		echo "Writing OH configuration file -> $OH_SETTINGS..."
-		# The three interface expressions are anchored at the start of the line, and name the key on
-		# both sides of the substitution:
-		#  - the GUI_INTERFACE replacement used to expand the variable on the left of the '=' as well,
-		#    so it wrote "on=on" (or "off=off") and the key itself was lost from the settings file;
-		#  - UI_INTERFACE is a substring of GUI_INTERFACE, so an unanchored UI_INTERFACE expression
-		#    matches inside the GUI_INTERFACE line the previous expression has just produced and
-		#    rewrites it. Anchoring is what keeps the two apart.
+		# anchored: UI_INTERFACE is a substring of GUI_INTERFACE
 		sed -e "s/OH_MODE/$OH_MODE/g" -e "s/OH_LANGUAGE/$OH_LANGUAGE/g" -e "s&OH_DOC_DIR&../$OH_DOC_DIR&g" \
 		-e "s/DEMODATA=off/"DEMODATA=$DEMO_DATA"/g" -e "s/YES_OR_NO/$OH_SINGLE_USER/g" \
 		-e "s/PHOTO_DIR/$PHOTO_DIR_ESCAPED/g" \

--- a/oh.sh
+++ b/oh.sh
@@ -1013,10 +1013,19 @@ function write_config_files {
 	if [ "$WRITE_CONFIG_FILES" = "on" ] || [ ! -f ./$OH_DIR/rsc/$OH_SETTINGS ]; then
 		[ -f ./$OH_DIR/rsc/$OH_SETTINGS ] && mv -f ./$OH_DIR/rsc/$OH_SETTINGS ./$OH_DIR/rsc/$OH_SETTINGS.old
 		echo "Writing OH configuration file -> $OH_SETTINGS..."
+		# The three interface expressions are anchored at the start of the line, and name the key on
+		# both sides of the substitution:
+		#  - the GUI_INTERFACE replacement used to expand the variable on the left of the '=' as well,
+		#    so it wrote "on=on" (or "off=off") and the key itself was lost from the settings file;
+		#  - UI_INTERFACE is a substring of GUI_INTERFACE, so an unanchored UI_INTERFACE expression
+		#    matches inside the GUI_INTERFACE line the previous expression has just produced and
+		#    rewrites it. Anchoring is what keeps the two apart.
 		sed -e "s/OH_MODE/$OH_MODE/g" -e "s/OH_LANGUAGE/$OH_LANGUAGE/g" -e "s&OH_DOC_DIR&../$OH_DOC_DIR&g" \
 		-e "s/DEMODATA=off/"DEMODATA=$DEMO_DATA"/g" -e "s/YES_OR_NO/$OH_SINGLE_USER/g" \
-		-e "s/PHOTO_DIR/$PHOTO_DIR_ESCAPED/g" -e "s/APISERVER=off/"APISERVER=$API_SERVER"/g" \
-		-e "s/GUI_INTERFACE=on/"$GUI_INTERFACE=$GUI_INTERFACE"/g" -e "s/UI_INTERFACE=off/"UI_INTERFACE=$UI_INTERFACE"/g" \
+		-e "s/PHOTO_DIR/$PHOTO_DIR_ESCAPED/g" \
+		-e "s/^APISERVER=off/APISERVER=$API_SERVER/" \
+		-e "s/^GUI_INTERFACE=on/GUI_INTERFACE=$GUI_INTERFACE/" \
+		-e "s/^UI_INTERFACE=off/UI_INTERFACE=$UI_INTERFACE/" \
 		./$OH_DIR/rsc/$OH_SETTINGS.dist > ./$OH_DIR/rsc/$OH_SETTINGS
 	fi
 

--- a/ohmac.sh
+++ b/ohmac.sh
@@ -266,20 +266,26 @@ function java_lib_setup {
 
 ###################################################################
 function write_api_config_file {
-	######## application.properties setup - OH API server	
-	SET_FILE=$OHDIR/rsc/$API_SETTINGS
-	if [ "$WRITE_CONFIG_FILES" = "on" ] || [ ! -f SET_FILE ]; then
-		[ -f $SET_FILE ] && mv -f $SET_FILE $SET_FILE.old		
-		# generate OH API token and save to settings file		
+	######## application.properties setup - OH API server
+	SET_FILE=./$OH_DIR/rsc/$API_SETTINGS
+	# The API templates only ship in the package that bundles the API server. Saying so beats
+	# writing an empty configuration file out of a template that is not there.
+	if [ ! -f "$SET_FILE.dist" ]; then
+		echo "Warning: $API_SETTINGS.dist not found, this package does not include the API server."
+		return
+	fi
+	if [ "$WRITE_CONFIG_FILES" = "on" ] || [ ! -f "$SET_FILE" ]; then
+		[ -f "$SET_FILE" ] && mv -f "$SET_FILE" "$SET_FILE.old"
+		# generate OH API token and save to settings file
 		JWT_TOKEN_SECRET=`LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 66`
 
-		echo "Writing OH API configuration file -> $API_SETTINGS..."
-		sed -i '' \
-			-e "s/JWT_TOKEN_SECRET/$JWT_TOKEN_SECRET/g" \
+		echo ">Writing OH API configuration file -> $API_SETTINGS..."
+		# read the template and write the copy, as oh.sh does: editing it in place would substitute
+		# the placeholders in the shipped file, and the next run would find nothing left to replace
+		sed -e "s/JWT_TOKEN_SECRET/$JWT_TOKEN_SECRET/g" \
 			-e "s/API_HOST:API_PORT/localhost:8080/g" \
 			-e "s&OH_API_PID&$OH_API_PID&g" \
-			$SET_FILE.dist
-		cp -f $SET_FILE.dist $SET_FILE	
+			"$SET_FILE.dist" > "$SET_FILE"
 	fi
 }
 

--- a/ohmac.sh
+++ b/ohmac.sh
@@ -88,10 +88,26 @@ DB_CREATE_SQL="create_all_en.sql"
 DEMO_DATABASE="ohdemo"
 DB_DEMO="create_all_demo.sql"
 
-# OH API server and web interface
+# OH API server and web interface - same names and values as oh.sh, so that the placeholders in
+# application.properties.dist are filled in the same way on both platforms
+OH_API_PROD="oh-api"
 OH_API_HOST="localhost"
 OH_API_PORT="8080"
-OH_UI_URL="http://$OH_API_HOST:$OH_API_PORT"
+
+OH_UI_HOST="localhost"
+OH_UI_PORT="8080"
+OH_UI_PROD="oh-ui"
+# oh.sh appends /$OH_UI_PROD because it deploys the UI as a Tomcat webapp of that name. Here the
+# bundled Spring Boot artifact is started directly and the shipped template sets
+# server.servlet.context-path=/, so the UI answers on the root path instead.
+OH_UI_URL="http://$OH_UI_HOST:$OH_UI_PORT"
+
+# left empty as in oh.sh, where the assignment is commented out: the shipped template resolves
+# spring.pid.file to an empty value. Declared here so the substitution below has a defined variable.
+OH_API_PID=""
+
+# activate expert mode - set to "on" to enable advanced functions - use at your own risk!
+EXPERT_MODE="off"
 
 OH_LANGUAGE_LIST="en|fr|es|it|pt|ar"
 OH_LANGUAGE="en" # default
@@ -140,6 +156,7 @@ function script_menu_advanced {
 	echo ""
 	echo "   -A  toggle API server - EXPERIMENTAL		| -d  toggle log level INFO/DEBUG"
 	echo "   -i  initialize/install OH database		| -G  setup GSM"
+	echo "   -U  enable UI web interface"
 	echo ""
 }
 
@@ -303,10 +320,16 @@ function write_api_config_file {
 
 		echo ">Writing OH API configuration file -> $API_SETTINGS..."
 		# read the template and write the copy, as oh.sh does: editing it in place would substitute
-		# the placeholders in the shipped file, and the next run would find nothing left to replace
+		# the placeholders in the shipped file, and the next run would find nothing left to replace.
+		# Same substitution list as oh.sh: the older combined API_HOST:API_PORT replacement used here
+		# left the UI_HOST and UI_PORT placeholders of cors.allowed.origins in the generated file.
 		sed -e "s/JWT_TOKEN_SECRET/$JWT_TOKEN_SECRET/g" \
-			-e "s/API_HOST:API_PORT/localhost:8080/g" \
 			-e "s&OH_API_PID&$OH_API_PID&g" \
+			-e "s&UI_HOST&$OH_UI_HOST&g" \
+			-e "s&UI_PORT&$OH_UI_PORT&g" \
+			-e "s&API_HOST&$OH_API_HOST&g" \
+			-e "s&API_PORT&$OH_API_PORT&g" \
+			-e "s&API_URL&$OH_API_PROD&g" \
 			"$SET_FILE.dist" > "$SET_FILE"
 	fi
 }
@@ -561,10 +584,17 @@ function write_config_files {
 		[ -f  $SETTINGS_FILE ] && mv -f $SETTINGS_FILE $SETTINGS_FILE.old
 		echo ">Writing OH configuration file -> $OH_SETTINGS..."
 		cp $SETTINGS_FILE.dist $SETTINGS_FILE
+		# GUI_INTERFACE and UI_INTERFACE are persisted too, so that -U survives a restart: read_settings
+		# reads them back. Their three substitutions are anchored at the start of the line, unlike the
+		# rest, because UI_INTERFACE is a substring of GUI_INTERFACE - unanchored, the UI_INTERFACE
+		# expression rewrites the GUI_INTERFACE line it has just been given.
 		sed -i '' -e "s/OH_MODE/$OH_MODE/g" -e "s/OH_LANGUAGE/$OH_LANGUAGE/g" -e "s&OH_DOC_DIR&../$OH_DOC_DIR&g" \
 		-e "s/DEMODATA=off/"DEMODATA=$DEMO_DATA"/g" -e "s/YES_OR_NO/$OH_SINGLE_USER/g" \
-		-e "s/PHOTO_DIR/$PHOTO_DIR_ESCAPED/g" -e "s/APISERVER=off/"APISERVER=$API_SERVER"/g" \
-		$SETTINGS_FILE	
+		-e "s/PHOTO_DIR/$PHOTO_DIR_ESCAPED/g" \
+		-e "s/^APISERVER=off/APISERVER=$API_SERVER/" \
+		-e "s/^GUI_INTERFACE=on/GUI_INTERFACE=$GUI_INTERFACE/" \
+		-e "s/^UI_INTERFACE=off/UI_INTERFACE=$UI_INTERFACE/" \
+		$SETTINGS_FILE
 	fi
 }
 
@@ -578,6 +608,23 @@ function read_settings {
 	else
 		echo "Error: Open Hospital non found! Exiting."
 		exit 1;
+	fi
+
+	# check for OH settings file and read values, as oh.sh does. Without this every run starts from
+	# the defaults at the top of this script, so the choices the user persisted in the settings file
+	# - the API server above all - are silently dropped on the next launch.
+	if [ -f ./$OH_DIR/rsc/$OH_SETTINGS ]; then
+		echo "Reading OH settings file..."
+		. ./$OH_DIR/rsc/$OH_SETTINGS
+
+		OH_MODE=$MODE
+		OH_LANGUAGE=$LANGUAGE
+		OH_SINGLE_USER=$SINGLE_USER
+		OH_DOC_DIR=$OH_DOC_DIR
+		DEMO_DATA=$DEMODATA
+		API_SERVER=$APISERVER
+		GUI_INTERFACE=$GUI_INTERFACE
+		UI_INTERFACE=$UI_INTERFACE
 	fi
 
 	# check for database settings file and read values, as oh.sh does. Without this the connection
@@ -681,7 +728,36 @@ function parse_user_input {
 		echo "Press any key to continue"; 
 		read;
 		;;
-	#E)	# toggle EXPERT_MODE features
+	###################################################
+	U)	# toggle UI Interface
+		case "$UI_INTERFACE" in
+			*on*)
+				UI_INTERFACE="off";
+				GUI_INTERFACE="on";
+			;;
+			*off*)
+				UI_INTERFACE="on";
+				GUI_INTERFACE="off";
+			;;
+		esac
+		#
+		if (( $2==0 )); then UI_INTERFACE="on"; interactive_menu; fi
+		option="Z";
+		;;
+	###################################################
+	E)	# toggle EXPERT_MODE features
+		case "$EXPERT_MODE" in
+			*on*)
+				EXPERT_MODE="off";
+			;;
+			*off*)
+				EXPERT_MODE="on";
+			;;
+		esac
+		#
+		if (( $2==0 )); then EXPERT_MODE="on"; interactive_menu; fi
+		option="Z";
+		;;
 	###################################################
 	C)	# start in CLIENT mode
 		OH_MODE="CLIENT"
@@ -832,8 +908,36 @@ function parse_user_input {
 }
 
 
+###################################################################
+function set_defaults {
+	# Fill in the values read_settings did not find, as oh.sh does. The settings file is not
+	# required to carry every key, and an absent key leaves its variable empty rather than at the
+	# default set at the top of this script, so the defaults have to be reapplied afterwards.
+
+	# EXPERT_MODE features - set default to off
+	if [ -z "$EXPERT_MODE" ]; then
+		EXPERT_MODE="off"
+	fi
+
+	# API server - set default to off
+	if [ -z "$API_SERVER" ]; then
+		API_SERVER="off"
+	fi
+
+	# GUI interface - set default to on
+	if [ -z "$GUI_INTERFACE" ]; then
+		GUI_INTERFACE="on"
+	fi
+
+	# UI interface - set default to off
+	if [ -z "$UI_INTERFACE" ]; then
+		UI_INTERFACE="off"
+	fi
+}
+
 read_settings;
- 
+set_defaults;
+
 #remove_db;
 #import_db;
 
@@ -841,7 +945,7 @@ read_settings;
 OPTIND=1 
 # list of arguments expected in user input (- option)
 # E is excluded from command line option
-OPTSTRING=":AECPSdDGhil:msrtvequQXVZ?" 
+OPTSTRING=":AECPSdDGhil:msrtvequQXUVZ?"
 COMMAND_LINE_ARGS=$@
 
 # Parse arguments passed via command line / interactive input

--- a/ohmac.sh
+++ b/ohmac.sh
@@ -41,6 +41,7 @@ WRITE_CONFIG_FILES="on"
 # OH jar bin files
 OH_GUI_JAR="OH-gui.jar"
 OH_API_JAR="openhospital-api-0.1.0.jar"
+OH_API_WAR="openhospital-api-0.1.0.war"
 
 # OH configuration files
 OH_SETTINGS="settings.properties"
@@ -83,6 +84,15 @@ DATABASE_USER="isf"
 DATABASE_PASSWORD="isf123"
 DB_CREATE_SQL="create_all_en.sql"
 
+# demo data - the demo branch below uses both of these
+DEMO_DATABASE="ohdemo"
+DB_DEMO="create_all_demo.sql"
+
+# OH API server and web interface
+OH_API_HOST="localhost"
+OH_API_PORT="8080"
+OH_UI_URL="http://$OH_API_HOST:$OH_API_PORT"
+
 OH_LANGUAGE_LIST="en|fr|es|it|pt|ar"
 OH_LANGUAGE="en" # default
 OH_MODE="PORTABLE"
@@ -119,6 +129,18 @@ function script_menu {
 	if [ "$EXPERT_MODE" == "on" ]; then
 		script_menu_advanced;
 	fi
+}
+
+###################################################################
+function script_menu_advanced {
+	# show advanced user options. Only the ones this script implements: the list in oh.sh is longer
+	# because several of its options are commented out of parse_user_input here.
+	echo "   -------------------------------- "
+	echo "    EXPERT MODE - advanced options"
+	echo ""
+	echo "   -A  toggle API server - EXPERIMENTAL		| -d  toggle log level INFO/DEBUG"
+	echo "   -i  initialize/install OH database		| -G  setup GSM"
+	echo ""
 }
 
 ###################################################################
@@ -576,6 +598,56 @@ function read_settings {
 	}
 
 ###################################################################
+function start_api_server {
+	# The packages that carry the API ship a self-contained Spring Boot artifact, not the Tomcat
+	# layout oh.sh starts, and the client package carries none at all. Where it cannot be started
+	# this says so and returns: until now the call failed with "command not found" and the run
+	# carried on, so refusing to start Open Hospital at all would take away something that works.
+	API_ARTIFACT=""
+	for candidate in "./$OH_DIR/bin/$OH_API_JAR" "./$OH_DIR/bin/$OH_API_WAR"; do
+		[ -f "$candidate" ] && API_ARTIFACT="$candidate" && break
+	done
+	if [ -z "$API_ARTIFACT" ]; then
+		echo "Warning: no API server found in ./$OH_DIR/bin, this package does not include it."
+		return
+	fi
+	if [ ! -f ./$OH_DIR/rsc/$API_SETTINGS ]; then
+		echo "Warning: missing $API_SETTINGS settings file, the API server will not be started."
+		return
+	fi
+
+	echo "------------------------"
+	echo "---- EXPERIMENTAL ------"
+	echo "------------------------"
+	echo "Starting API server..."
+	echo "Please wait, it might take some time..."
+	echo ""
+	echo "Connect to $OH_UI_URL for OH web interface"
+	echo ""
+
+	case "$API_ARTIFACT" in
+		*.war) LAUNCHER="org.springframework.boot.loader.launch.WarLauncher" ;;
+		*)     LAUNCHER="org.springframework.boot.loader.launch.JarLauncher" ;;
+	esac
+	$JAVA_BIN -client -Xms64m -Xmx1024m \
+		-cp "$API_ARTIFACT:./$OH_DIR/rsc:./$OH_DIR/static" $LAUNCHER >> ./$LOG_DIR/$API_LOG_FILE 2>&1 &
+
+	if [ $? -ne 0 ]; then
+		echo "An error occurred while starting the Open Hospital API server. Exiting."
+		stop_db;
+		cd "$CURRENT_DIR"
+		exit 4
+	fi
+}
+
+###################################################################
+function start_ui {
+	echo "Starting Open Hospital UI at $OH_UI_URL..."
+	# OH UI launch - `open` is the macOS equivalent of the xdg-open oh.sh uses
+	open "$OH_UI_URL" || echo "Could not open a web browser, please go to $OH_UI_URL yourself."
+}
+
+###################################################################
 function start_gui {
 	echo "Starting Open Hospital GUI..."
 	# OH GUI launch	
@@ -802,7 +874,6 @@ function demo_mode(){
 			echo "Error: no $DB_DEMO found! Exiting."
 			exit 1
 		fi
-		set_db_name;
 	else
 		echo ">no"
 	fi

--- a/ohmac.sh
+++ b/ohmac.sh
@@ -520,10 +520,13 @@ function write_config_files {
 		-e "s/DBNAME/$DATABASE_NAME/g" -e "s/LOG_LEVEL/$LOG_LEVEL/g" -e "s+LOG_DEST+$OH_LOG_DEST+g" \
 		$LOG4J_FILE		
 	fi
-	######## $DATABASE_SETTINGS setup 
+	######## $DATABASE_SETTINGS setup
+	# Written only when it is not there, unlike the files around it. This one holds where the
+	# installation keeps its data, which is a decision of whoever installed it and not of the
+	# launcher: rewriting it on every run from the values at the top of this script is what kept a
+	# macOS installation tied to isf@localhost. The rest of the configuration is left as it was.
 	DB_FILE=./$OH_DIR/rsc/$DATABASE_SETTINGS
-	if [ "$WRITE_CONFIG_FILES" = "on" ] || [ ! -f $DB_FILE ]; then
-		[ -f $DB_FILE ] && mv -f $DB_FILE $DB_FILE.old
+	if [ ! -f $DB_FILE ]; then
 		echo ">Writing OH database configuration file -> $DATABASE_SETTINGS..."
 		cp $DB_FILE.dist $DB_FILE
 		sed -i '' -e "s/DBSERVER/$DATABASE_SERVER/g" -e "s/DBPORT/$DATABASE_PORT/g" -e "s/DBNAME/$DATABASE_NAME/g" \
@@ -550,9 +553,23 @@ function read_settings {
 	if [ -f ./$OH_DIR/rsc/version.properties ]; then
 		source "./$OH_DIR/rsc/version.properties"
 		OH_VERSION=$VER_MAJOR.$VER_MINOR.$VER_RELEASE
-	else 		
+	else
 		echo "Error: Open Hospital non found! Exiting."
 		exit 1;
+	fi
+
+	# check for database settings file and read values, as oh.sh does. Without this the connection
+	# details below stay at their defaults whatever the installation was configured with, so the
+	# database test and the generated files all talk about a server nobody asked for.
+	if [ -f ./$OH_DIR/rsc/$DATABASE_SETTINGS ]; then
+		echo "Reading database settings file..."
+		DATABASE_SERVER=$(cat ./$OH_DIR/rsc/$DATABASE_SETTINGS | grep "jdbc.url" | cut -d"/" -f3 | cut -d":" -f1)
+		DATABASE_PORT=$(cat ./$OH_DIR/rsc/$DATABASE_SETTINGS | grep "jdbc.url" | cut -d"/" -f3 | cut -d":" -f2)
+		DATABASE_NAME=$(cat ./$OH_DIR/rsc/$DATABASE_SETTINGS | grep "jdbc.url" | cut -d"/" -f4)
+		DATABASE_USER=$(cat ./$OH_DIR/rsc/$DATABASE_SETTINGS | grep "jdbc.username" | cut -d"=" -f2)
+		DATABASE_PASSWORD=$(cat ./$OH_DIR/rsc/$DATABASE_SETTINGS | grep "jdbc.password" | cut -d"=" -f2)
+	else
+		echo "Warning: configuration file $DATABASE_SETTINGS not found."
 	fi
 
     ARCH=`uname -m`

--- a/ohmac.sh
+++ b/ohmac.sh
@@ -84,6 +84,9 @@ DATABASE_USER="isf"
 DATABASE_PASSWORD="isf123"
 DB_CREATE_SQL="create_all_en.sql"
 
+# seconds to wait for the database to start listening, or to release its port on shutdown
+DATABASE_WAIT_TIMEOUT=90
+
 # demo data - the demo branch below uses both of these
 DEMO_DATABASE="ohdemo"
 DB_DEMO="create_all_demo.sql"
@@ -519,13 +522,62 @@ function create_db {
     fi	
 }
 ###################################################################
-function start_db {    
+# Whether the database is accepting connections on its TCP port.
+#
+# The port is probed with bash's own /dev/tcp redirection rather than with `nc`, which is not part
+# of a stock macOS and cannot be relied on being there.
+function database_port_open {
+	(exec 3<>/dev/tcp/$DATABASE_SERVER/$DATABASE_PORT) > /dev/null 2>&1
+}
+
+###################################################################
+# `brew services start` returns as soon as launchd has accepted the job, not when the server is
+# ready, so everything that follows used to race it: the very next thing this script does is run a
+# mysql client, and on a cold start that client would be refused. Waiting for the port removes the
+# race, and the timeout keeps a server that never comes up from hanging the launcher silently.
+function wait_for_database {
+	WAITED=0
+	until database_port_open; do
+		if [ $WAITED -ge $DATABASE_WAIT_TIMEOUT ]; then
+			echo "Error: MariaDB is not listening on $DATABASE_SERVER:$DATABASE_PORT after $DATABASE_WAIT_TIMEOUT seconds."
+			echo "Check it with 'brew services info mariadb'. Exiting."
+			exit 2
+		fi
+		if [ $WAITED -gt 0 ] && [ $((WAITED % 10)) -eq 0 ]; then
+			echo "Still waiting for MariaDB to listen on $DATABASE_SERVER:$DATABASE_PORT ($WAITED s)..."
+		fi
+		sleep 1
+		WAITED=$((WAITED+1))
+	done
+}
+
+###################################################################
+function wait_for_database_stopped {
+	WAITED=0
+	while database_port_open; do
+		if [ $WAITED -ge $DATABASE_WAIT_TIMEOUT ]; then
+			echo "Warning: MariaDB is still listening on $DATABASE_SERVER:$DATABASE_PORT after $DATABASE_WAIT_TIMEOUT seconds."
+			echo "Check it with 'brew services info mariadb'."
+			return
+		fi
+		if [ $WAITED -gt 0 ] && [ $((WAITED % 10)) -eq 0 ]; then
+			echo "Still waiting for MariaDB to release $DATABASE_SERVER:$DATABASE_PORT ($WAITED s)..."
+		fi
+		sleep 1
+		WAITED=$((WAITED+1))
+	done
+}
+
+###################################################################
+function start_db {
     create_db;
     brew services start mariadb >/dev/null;
+    wait_for_database;
 }
 ###################################################################
 function stop_db {
-    brew services stop mariadb    
+    brew services stop mariadb
+    wait_for_database_stopped;
 }
 
 ###################################################################

--- a/ohmac.sh
+++ b/ohmac.sh
@@ -98,8 +98,7 @@ DATABASE_WAIT_TIMEOUT=90
 DEMO_DATABASE="ohdemo"
 DB_DEMO="create_all_demo.sql"
 
-# OH API server and web interface - same names and values as oh.sh, so that the placeholders in
-# application.properties.dist are filled in the same way on both platforms
+# OH API server and web interface - same names and values as oh.sh
 OH_API_PROD="oh-api"
 OH_API_HOST="localhost"
 OH_API_PORT="8080"
@@ -107,13 +106,11 @@ OH_API_PORT="8080"
 OH_UI_HOST="localhost"
 OH_UI_PORT="8080"
 OH_UI_PROD="oh-ui"
-# oh.sh appends /$OH_UI_PROD because it deploys the UI as a Tomcat webapp of that name. Here the
-# bundled Spring Boot artifact is started directly and the shipped template sets
-# server.servlet.context-path=/, so the UI answers on the root path instead.
+# no /$OH_UI_PROD here: the bundled artifact is started directly and its template sets
+# server.servlet.context-path=/, where oh.sh deploys a Tomcat webapp of that name
 OH_UI_URL="http://$OH_UI_HOST:$OH_UI_PORT"
 
-# left empty as in oh.sh, where the assignment is commented out: the shipped template resolves
-# spring.pid.file to an empty value. Declared here so the substitution below has a defined variable.
+# empty as in oh.sh, where the assignment is commented out
 OH_API_PID=""
 
 # activate expert mode - set to "on" to enable advanced functions - use at your own risk!
@@ -159,8 +156,7 @@ function script_menu {
 
 ###################################################################
 function script_menu_advanced {
-	# show advanced user options. Only the ones this script implements: the list in oh.sh is longer
-	# because several of its options are commented out of parse_user_input here.
+	# only the options this script implements; oh.sh lists more
 	echo "   -------------------------------- "
 	echo "    EXPERT MODE - advanced options"
 	echo ""
@@ -326,8 +322,7 @@ function java_lib_setup {
 function write_api_config_file {
 	######## application.properties setup - OH API server
 	SET_FILE=./$OH_DIR/rsc/$API_SETTINGS
-	# The API templates only ship in the package that bundles the API server. Saying so beats
-	# writing an empty configuration file out of a template that is not there.
+	# the API templates only ship in the package that bundles the API server
 	if [ ! -f "$SET_FILE.dist" ]; then
 		echo "Warning: $API_SETTINGS.dist not found, this package does not include the API server."
 		return
@@ -338,10 +333,8 @@ function write_api_config_file {
 		JWT_TOKEN_SECRET=`LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 66`
 
 		echo ">Writing OH API configuration file -> $API_SETTINGS..."
-		# read the template and write the copy, as oh.sh does: editing it in place would substitute
-		# the placeholders in the shipped file, and the next run would find nothing left to replace.
-		# Same substitution list as oh.sh: the older combined API_HOST:API_PORT replacement used here
-		# left the UI_HOST and UI_PORT placeholders of cors.allowed.origins in the generated file.
+		# read the template and write the copy: editing it in place would consume the placeholders
+		# in the shipped file, leaving the next run nothing to replace
 		sed -e "s/JWT_TOKEN_SECRET/$JWT_TOKEN_SECRET/g" \
 			-e "s&OH_API_PID&$OH_API_PID&g" \
 			-e "s&UI_HOST&$OH_UI_HOST&g" \
@@ -567,19 +560,14 @@ function create_db {
     fi	
 }
 ###################################################################
-# Whether the database is accepting connections on its TCP port.
-#
-# The port is probed with bash's own /dev/tcp redirection rather than with `nc`, which is not part
-# of a stock macOS and cannot be relied on being there.
+# Probed with bash's own /dev/tcp rather than `nc`, which a stock macOS does not have.
 function database_port_open {
 	(exec 3<>/dev/tcp/$DATABASE_SERVER/$DATABASE_PORT) > /dev/null 2>&1
 }
 
 ###################################################################
-# `brew services start` returns as soon as launchd has accepted the job, not when the server is
-# ready, so everything that follows used to race it: the very next thing this script does is run a
-# mysql client, and on a cold start that client would be refused. Waiting for the port removes the
-# race, and the timeout keeps a server that never comes up from hanging the launcher silently.
+# `brew services start` returns when launchd accepts the job, not when the server is ready, and
+# the next thing this script runs is a mysql client - on a cold start that client was refused.
 function wait_for_database {
 	WAITED=0
 	until database_port_open; do
@@ -680,10 +668,8 @@ function write_config_files {
 		$LOG4J_FILE		
 	fi
 	######## $DATABASE_SETTINGS setup
-	# Written only when it is not there, unlike the files around it. This one holds where the
-	# installation keeps its data, which is a decision of whoever installed it and not of the
-	# launcher: rewriting it on every run from the values at the top of this script is what kept a
-	# macOS installation tied to isf@localhost. The rest of the configuration is left as it was.
+	# written only when absent, unlike the files around it: where the installation keeps its data is
+	# the installer's decision, and rewriting it on every run tied macOS to isf@localhost
 	DB_FILE=./$OH_DIR/rsc/$DATABASE_SETTINGS
 	if [ ! -f $DB_FILE ]; then
 		echo ">Writing OH database configuration file -> $DATABASE_SETTINGS..."
@@ -698,10 +684,7 @@ function write_config_files {
 		[ -f  $SETTINGS_FILE ] && mv -f $SETTINGS_FILE $SETTINGS_FILE.old
 		echo ">Writing OH configuration file -> $OH_SETTINGS..."
 		cp $SETTINGS_FILE.dist $SETTINGS_FILE
-		# GUI_INTERFACE and UI_INTERFACE are persisted too, so that -U survives a restart: read_settings
-		# reads them back. Their three substitutions are anchored at the start of the line, unlike the
-		# rest, because UI_INTERFACE is a substring of GUI_INTERFACE - unanchored, the UI_INTERFACE
-		# expression rewrites the GUI_INTERFACE line it has just been given.
+		# persisted so that -U survives a restart; anchored: UI_INTERFACE is a substring of GUI_INTERFACE
 		sed -i '' -e "s/OH_MODE/$OH_MODE/g" -e "s/OH_LANGUAGE/$OH_LANGUAGE/g" -e "s&OH_DOC_DIR&../$OH_DOC_DIR&g" \
 		-e "s/DEMODATA=off/"DEMODATA=$DEMO_DATA"/g" -e "s/YES_OR_NO/$OH_SINGLE_USER/g" \
 		-e "s/PHOTO_DIR/$PHOTO_DIR_ESCAPED/g" \


### PR DESCRIPTION
The three remaining defects of `ohmac.sh`, found while working on the ones in #2244 and deliberately kept out of it. This branch stands on its own; the eight commits across both were verified together on a freshly extracted package.

## [OP-1449](https://openhospital.atlassian.net/browse/OP-1449) — the API configuration is never written

`write_api_config_file` builds its paths from `$OHDIR`, which this script does not define — the name is `OH_DIR` — so every path points at `/rsc`, outside the installation:

```
Writing OH API configuration file -> application.properties...
sed: /rsc/application.properties.dist: No such file or directory
cp: /rsc/application.properties.dist: No such file or directory
```

`application.properties` is never created and the API server starts with no configuration of its own.

Two more defects sit in the same seven lines: the guard reads `[ ! -f SET_FILE ]` without the `$`, so it is always true, and the substitutions are applied **in place to the template** with `sed -i` before copying it over the target. That last one is harmless today only because the first sends it nowhere — correcting the path alone would consume the placeholders in the shipped `application.properties.dist`, of which the package holds no second copy. The template is now read and the copy written, as `oh.sh` does.

## [OP-1450](https://openhospital.atlassian.net/browse/OP-1450) — a macOS installation cannot keep its own database

`read_settings` reads only `version.properties`, so the connection details stay at the values hardcoded in the script whatever `database.properties` says — and `write_config_files` then writes those values back over the file on every run, because `WRITE_CONFIG_FILES` is fixed to `"on"` here with no way to change it. A macOS installation therefore always talks to `isf@localhost:3306/oh`, and CLIENT mode against a hospital server — the reason that mode exists — cannot be configured at all.

The file is now read as `oh.sh` reads it, and it is written only when it is not there. Just that one: it holds a decision of whoever installed OH, unlike the files around it, which the launcher derives from the mode, language and paths it was given and keeps regenerating exactly as before — so nothing else about a run changes. The packages ship only `.dist` templates, so a first run still creates the whole set.

## [OP-1451](https://openhospital.atlassian.net/browse/OP-1451) — four functions that do not exist

Turning the API server on reaches one of them: `start_api_server: command not found`, the launcher says the API server is enabled and starts nothing. It is now written for what the macOS packages actually contain — a self-contained Spring Boot artifact, not the Tomcat layout `oh.sh` starts — and says so plainly when the package carries no API at all.

The other three calls are unreachable today because the options that would enable them are commented out of `parse_user_input` and their variables never assigned. That is a defect in itself: the menu offers `-E    toggle EXPERT MODE - show advanced options` and pressing it does nothing, while the advanced options themselves are implemented. `script_menu_advanced` now lists the four this script really has, so enabling `-E` becomes a decision rather than a promise, and `start_ui` opens a browser the way macOS does. The demo branch used `DEMO_DATABASE` and `DB_DEMO` without defining either; both are now set, and the `set_db_name` call is dropped rather than ported, since it computes a portable data directory this launcher does not use.

## Verification

On a freshly extracted package, with these three and the five in #2244 applied together:

* first run — the JRE is downloaded and used, the whole set of configuration files is generated, the GUI starts and the login window opens;
* second run after editing `database.properties` — `Reading database settings file...` and the file is left byte-identical;
* `start_api_server` with no artifact, with an artifact but no configuration, and with both — a clear message, a clear message, and the launcher command that runs the API server;
* no function is called that the script does not define;
* an installation that works today keeps working: the only file whose handling changes is `database.properties`, and the API server path can only add a warning where there used to be a `command not found`.

## Note on the two descriptions that changed

OP-1449 and OP-1451 were first filed with claims that did not survive being reproduced properly — a destroyed template that is in fact untouched, and four failing calls of which only one can fire. Both issues carry the correction and the evidence; the code here matches what actually happens.


[OP-1449]: https://openhospital.atlassian.net/browse/OP-1449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OP-1450]: https://openhospital.atlassian.net/browse/OP-1450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ