### PR TITLE
OP-1460 Run Open Hospital from the directory its own paths are resolved against

### DIFF
--- a/ohmac.sh
+++ b/ohmac.sh
@@ -320,8 +320,9 @@ function java_lib_setup {
 	OH_CLASSPATH=$OH_CLASSPATH:"$OH_PATH"/$OH_DIR/lib
 
 	# include all jar files under lib/
-	DIRLIBS="$OH_PATH"/$OH_DIR/lib/*.jar
-	for i in ${DIRLIBS}
+	# the pattern is expanded by the loop itself: going through a variable would split an
+	# installation path that contains a space and leave the jars out of the classpath
+	for i in "$OH_PATH"/$OH_DIR/lib/*.jar
 	do
 		OH_CLASSPATH="$i":$OH_CLASSPATH
 	done
@@ -801,7 +802,7 @@ function start_api_server {
 		*)     LAUNCHER="org.springframework.boot.loader.launch.JarLauncher" ;;
 	esac
 	cd "$OH_PATH/$OH_DIR" # workaround for hard coded paths
-	$JAVA_BIN -client -Xms64m -Xmx1024m \
+	"$JAVA_BIN" -client -Xms64m -Xmx1024m \
 		-cp "$API_ARTIFACT:$OH_PATH/$OH_DIR/rsc:$OH_PATH/$OH_DIR/static" $LAUNCHER >> "$OH_PATH/$LOG_DIR/$API_LOG_FILE" 2>&1 &
 
 	if [ $? -ne 0 ]; then
@@ -826,7 +827,7 @@ function start_gui {
 	# OH GUI launch	
 	cd "$OH_PATH/$OH_DIR" # workaround for hard coded paths
 
-	$JAVA_BIN -client --add-opens java.desktop/javax.imageio.stream=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED -Xms64m -Xmx1024m -Dsun.java2d.dpiaware=false -Djava.library.path=${NATIVE_LIB_PATH} -classpath $OH_CLASSPATH org.isf.Application >> "$OH_PATH/$LOG_DIR/$LOG_FILE" 2>&1
+	"$JAVA_BIN" -client --add-opens java.desktop/javax.imageio.stream=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED -Xms64m -Xmx1024m -Dsun.java2d.dpiaware=false -Djava.library.path="${NATIVE_LIB_PATH}" -classpath "$OH_CLASSPATH" org.isf.Application >> "$OH_PATH/$LOG_DIR/$LOG_FILE" 2>&1
 
 	if [ $? -ne 0 ]; then
 		echo "An error occurred while starting Open Hospital. Exiting."
@@ -930,7 +931,7 @@ function parse_user_input {
 		echo "Setting up GSM..."
 		java_check;
 		java_lib_setup;
-		$JAVA_BIN -Djava.library.path=${NATIVE_LIB_PATH} -classpath "$OH_CLASSPATH" org.isf.utils.sms.SetupGSM "$@"
+		"$JAVA_BIN" -Djava.library.path="${NATIVE_LIB_PATH}" -classpath "$OH_CLASSPATH" org.isf.utils.sms.SetupGSM "$@"
 		echo "Done!"
 		if (( $2==0 )); then exit 0; else echo "Press any key to continue"; read; fi
 		;;  

--- a/ohmac.sh
+++ b/ohmac.sh
@@ -30,6 +30,15 @@ PHOTO_DIR="data/photo"
 BACKUP_DIR="data/dump"
 
 OH_DIR="oh"
+# Open Hospital resolves part of its own paths against the working directory - the reports are
+# looked up as rpt_base/... - so the application has to run from inside $OH_DIR, and every path
+# handed to the JVM has to be absolute to survive that. oh.sh carries the same workaround in its
+# own start_gui. The script already used $OH_PATH without ever setting it, so the DICOM storage
+# path was written as /data/dicom_storage, at the filesystem root.
+# Derived from the script location, as oh.sh does, and overridable the same way.
+if [ -z "${OH_PATH+x}" ]; then
+	OH_PATH=$(cd "$(dirname "$0")" && pwd)
+fi
 OH_DOC_DIR="doc"
 CONF_DIR="data/conf"
 DATA_DIR="data/db"
@@ -242,7 +251,7 @@ echo "is java installed?"
 # exactly at this path, so it has to be set before that too: leaving the variable empty would make
 # the launch command start with its first argument instead of the java binary.
 if [ -z "${JAVA_BIN:-}" ] || [ ! -x "$JAVA_BIN" ]; then
-	JAVA_BIN="./$OH_DIR/$JAVA_DIR/bin/java"
+	JAVA_BIN="$OH_PATH/$OH_DIR/$JAVA_DIR/bin/java"
 fi
 
 # if JAVA_BIN is not found download JRE
@@ -281,7 +290,7 @@ function java_lib_setup {
 	# NATIVE LIB setup
 	case $JAVA_ARCH in
         arm64)
-        NATIVE_LIB_PATH="./$OH_DIR/lib/native/macOS/arm64"
+        NATIVE_LIB_PATH="$OH_PATH/$OH_DIR/lib/native/macOS/arm64"
         ;;
 	esac
 
@@ -299,19 +308,19 @@ function java_lib_setup {
 
 	# CLASSPATH setup
 	# include OH jar file
-	OH_CLASSPATH=$OH_DIR/bin/$OH_GUI_JAR
+	OH_CLASSPATH="$OH_PATH"/$OH_DIR/bin/$OH_GUI_JAR
 	
 	# include all needed directories
-	OH_CLASSPATH=$OH_CLASSPATH:$OH_DIR/bundle
-	OH_CLASSPATH=$OH_CLASSPATH:$OH_DIR/rpt_base
-	OH_CLASSPATH=$OH_CLASSPATH:$OH_DIR/rpt_extra
-	OH_CLASSPATH=$OH_CLASSPATH:$OH_DIR/rpt_stat
-	OH_CLASSPATH=$OH_CLASSPATH:$OH_DIR/rsc
-	OH_CLASSPATH=$OH_CLASSPATH:$OH_DIR/rsc/images
-	OH_CLASSPATH=$OH_CLASSPATH:$OH_DIR/lib
+	OH_CLASSPATH=$OH_CLASSPATH:"$OH_PATH"/$OH_DIR/bundle
+	OH_CLASSPATH=$OH_CLASSPATH:"$OH_PATH"/$OH_DIR/rpt_base
+	OH_CLASSPATH=$OH_CLASSPATH:"$OH_PATH"/$OH_DIR/rpt_extra
+	OH_CLASSPATH=$OH_CLASSPATH:"$OH_PATH"/$OH_DIR/rpt_stat
+	OH_CLASSPATH=$OH_CLASSPATH:"$OH_PATH"/$OH_DIR/rsc
+	OH_CLASSPATH=$OH_CLASSPATH:"$OH_PATH"/$OH_DIR/rsc/images
+	OH_CLASSPATH=$OH_CLASSPATH:"$OH_PATH"/$OH_DIR/lib
 
 	# include all jar files under lib/
-	DIRLIBS=./$OH_DIR/lib/*.jar
+	DIRLIBS="$OH_PATH"/$OH_DIR/lib/*.jar
 	for i in ${DIRLIBS}
 	do
 		OH_CLASSPATH="$i":$OH_CLASSPATH
@@ -766,7 +775,7 @@ function start_api_server {
 	# this says so and returns: until now the call failed with "command not found" and the run
 	# carried on, so refusing to start Open Hospital at all would take away something that works.
 	API_ARTIFACT=""
-	for candidate in "./$OH_DIR/bin/$OH_API_JAR" "./$OH_DIR/bin/$OH_API_WAR"; do
+	for candidate in "$OH_PATH/$OH_DIR/bin/$OH_API_JAR" "$OH_PATH/$OH_DIR/bin/$OH_API_WAR"; do
 		[ -f "$candidate" ] && API_ARTIFACT="$candidate" && break
 	done
 	if [ -z "$API_ARTIFACT" ]; then
@@ -791,8 +800,9 @@ function start_api_server {
 		*.war) LAUNCHER="org.springframework.boot.loader.launch.WarLauncher" ;;
 		*)     LAUNCHER="org.springframework.boot.loader.launch.JarLauncher" ;;
 	esac
+	cd "$OH_PATH/$OH_DIR" # workaround for hard coded paths
 	$JAVA_BIN -client -Xms64m -Xmx1024m \
-		-cp "$API_ARTIFACT:./$OH_DIR/rsc:./$OH_DIR/static" $LAUNCHER >> ./$LOG_DIR/$API_LOG_FILE 2>&1 &
+		-cp "$API_ARTIFACT:$OH_PATH/$OH_DIR/rsc:$OH_PATH/$OH_DIR/static" $LAUNCHER >> "$OH_PATH/$LOG_DIR/$API_LOG_FILE" 2>&1 &
 
 	if [ $? -ne 0 ]; then
 		echo "An error occurred while starting the Open Hospital API server. Exiting."
@@ -800,6 +810,7 @@ function start_api_server {
 		cd "$CURRENT_DIR"
 		exit 4
 	fi
+	cd "$OH_PATH"
 }
 
 ###################################################################
@@ -813,8 +824,9 @@ function start_ui {
 function start_gui {
 	echo "Starting Open Hospital GUI..."
 	# OH GUI launch	
-	
-	$JAVA_BIN -client --add-opens java.desktop/javax.imageio.stream=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED -Xms64m -Xmx1024m -Dsun.java2d.dpiaware=false -Djava.library.path=${NATIVE_LIB_PATH} -classpath $OH_CLASSPATH org.isf.Application >> ./$LOG_DIR/$LOG_FILE 2>&1
+	cd "$OH_PATH/$OH_DIR" # workaround for hard coded paths
+
+	$JAVA_BIN -client --add-opens java.desktop/javax.imageio.stream=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED -Xms64m -Xmx1024m -Dsun.java2d.dpiaware=false -Djava.library.path=${NATIVE_LIB_PATH} -classpath $OH_CLASSPATH org.isf.Application >> "$OH_PATH/$LOG_DIR/$LOG_FILE" 2>&1
 
 	if [ $? -ne 0 ]; then
 		echo "An error occurred while starting Open Hospital. Exiting."
@@ -822,6 +834,7 @@ function start_gui {
 		cd "$CURRENT_DIR"
 		exit 4
 	fi
+	cd "$OH_PATH"
 }
 ###################################################################
 function parse_user_input {


### PR DESCRIPTION
## [OP-1460](https://openhospital.atlassian.net/browse/OP-1460)

On macOS no report can be generated. The viewer never opens and the application log records:

```
net.sf.jasperreports.engine.JRException: java.io.FileNotFoundException: rpt_base/examslist.jasper
```

Reports are looked up **relative to the working directory** — `PrintManager.java:80` builds `new File("rpt_base/" + filename + ".jasper")`, and `JasperReportsManager` declares `RPT_BASE = "rpt_base"` — while in the package they live in `oh/rpt_base`. `oh.sh` knows it, and its `start_gui` opens with

```
cd "$OH_PATH/$OH_DIR" # workaround for hard coded paths
```

`ohmac.sh` never had it, so the application ran from the package root. The API server fails the same way, since no launcher starts it from inside `oh`: `/reports/diseases-list` and `/reports/exams-list` answer 500 with the same `FileNotFoundException`.

A second defect lives in the same lines. `$OH_PATH` was already used at line 64 to build `OH_PATH_ESCAPED`, but never set, so `dicom.properties` was written as

```
dicom.storage.filesystem=/data/dicom_storage
```

at the filesystem root, and every run printed an empty `OH_PATH is set to`.

## What changed

* `OH_PATH` is derived from the script location, the way `oh.sh` derives it, and can still be set from outside;
* everything handed to the JVM — classpath, native library path, java binary, API artifact — is absolute, so it survives the change of directory;
* `start_gui` and `start_api_server` change into `$OH_DIR` and return afterwards; the log files keep their current location.

## Verified

On the released v1.15.1 multiarch client package, running the patched `ohmac.sh`:

* the JVM's working directory is `<package>/oh` — before the change, the package root;
* Exams Report renders: JasperViewer opens on *Page 1 of 5*. Before, no viewer appeared and the log carried the exception above;
* `dicom.storage.filesystem` is written inside the installation instead of `/data/dicom_storage`;
* the launcher prints the real path in `OH_PATH is set to ...`.

The same report was generated from the Linux portable package for comparison, where `oh.sh` already worked.

Not a regression of 1.15.1: `ohmac.sh` has never carried the workaround.

[OP-1460]: https://openhospital.atlassian.net/browse/OP-1460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ