### PR TITLE
OP-1461 Show the reason when there is no log folder to open

### DIFF
--- a/src/main/java/org/isf/help/LogViewer.java
+++ b/src/main/java/org/isf/help/LogViewer.java
@@ -47,10 +47,9 @@ public class LogViewer extends JDialog {
 		} catch (IOException e) {
 			// the path is null when no file appender is configured, and then the reason why there is
 			// no folder to open is all this dialog can show
-			MessageDialog.error(this, "angal.log.foldererror.fmt.msg",
-							logfile == null ? e.getMessage() : new File(logfile).getAbsoluteFile().getParent());
+			String folder = logfile != null ? new File(logfile).getAbsoluteFile().getParent() : e.getMessage();
+			MessageDialog.error(this, "angal.log.foldererror.fmt.msg", folder);
 		}
-
 	}
 
 }

--- a/src/main/java/org/isf/help/LogViewer.java
+++ b/src/main/java/org/isf/help/LogViewer.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -45,7 +45,10 @@ public class LogViewer extends JDialog {
 			LOGGER.debug("Opening location for: {}", logfile);
 			LogUtil.openLogFileLocation();
 		} catch (IOException e) {
-			MessageDialog.error(this, "angal.log.foldererror.fmt.msg", new File(logfile).getParent());
+			// the path is null when no file appender is configured, and then the reason why there is
+			// no folder to open is all this dialog can show
+			MessageDialog.error(this, "angal.log.foldererror.fmt.msg",
+							logfile == null ? e.getMessage() : new File(logfile).getAbsoluteFile().getParent());
 		}
 
 	}


### PR DESCRIPTION
## [OP-1461](https://openhospital.atlassian.net/browse/OP-1461)

`LogViewer` already reports a failure to the user, but its handler dereferenced the log file path:

```java
} catch (IOException e) {
	MessageDialog.error(this, "angal.log.foldererror.fmt.msg", new File(logfile).getParent());
}
```

`logfile` is null exactly when the failure being reported happens — no file appender configured — so the message never appeared and a `NullPointerException` reached the event dispatch thread instead.

The dialog now shows the reason when the path is unknown, and the folder when it is known.

**Merge order: informatici/openhospital-core#1675 first.** The null comes from core's `LogUtil`, which that pull request makes throw `IOException` instead; without it this handler is never reached.

[OP-1461]: https://openhospital.atlassian.net/browse/OP-1461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ