### PR TITLE
OP-1459 Stop the database import at the first failed statement

### DIFF
--- a/oh.bat
+++ b/oh.bat
@@ -305,7 +305,9 @@ if not EXIST %OH_PATH%\%DATA_DIR%\%DATABASE_NAME% (
 
 	echo Importing database %DATABASE_NAME% with user %DATABASE_USER%@%DATABASE_SERVER%...
 	cd /d %OH_PATH%\%SQL_DIR%
-	start /b /min /wait %OH_PATH%\%MYSQL_DIR%\bin\mysql.exe --local-infile=1 -u %DATABASE_USER% -p%DATABASE_PASSWORD% --host=%DATABASE_SERVER% --port=%DATABASE_PORT% %DATABASE_NAME% < "%OH_PATH%\sql\%DB_CREATE_SQL%"  >> "%OH_PATH%\%LOG_DIR%\%LOG_FILE%" 2>&1
+	rem --abort-source-on-error: without it the client carries on after a failed statement inside a
+	rem sourced file and still exits 0, so a half-loaded database reported success
+	start /b /min /wait %OH_PATH%\%MYSQL_DIR%\bin\mysql.exe --abort-source-on-error --local-infile=1 -u %DATABASE_USER% -p%DATABASE_PASSWORD% --host=%DATABASE_SERVER% --port=%DATABASE_PORT% %DATABASE_NAME% < "%OH_PATH%\sql\%DB_CREATE_SQL%"  >> "%OH_PATH%\%LOG_DIR%\%LOG_FILE%" 2>&1
 	if ERRORLEVEL 1 (goto error)
 	cd /d %OH_PATH%
 	echo Database imported!

--- a/oh.bat
+++ b/oh.bat
@@ -305,8 +305,7 @@ if not EXIST %OH_PATH%\%DATA_DIR%\%DATABASE_NAME% (
 
 	echo Importing database %DATABASE_NAME% with user %DATABASE_USER%@%DATABASE_SERVER%...
 	cd /d %OH_PATH%\%SQL_DIR%
-	rem --abort-source-on-error: without it the client carries on after a failed statement inside a
-	rem sourced file and still exits 0, so a half-loaded database reported success
+	rem --abort-source-on-error: the client otherwise carries on after a failed statement inside a sourced file and still exits 0
 	start /b /min /wait %OH_PATH%\%MYSQL_DIR%\bin\mysql.exe --abort-source-on-error --local-infile=1 -u %DATABASE_USER% -p%DATABASE_PASSWORD% --host=%DATABASE_SERVER% --port=%DATABASE_PORT% %DATABASE_NAME% < "%OH_PATH%\sql\%DB_CREATE_SQL%"  >> "%OH_PATH%\%LOG_DIR%\%LOG_FILE%" 2>&1
 	if ERRORLEVEL 1 (goto error)
 	cd /d %OH_PATH%

--- a/oh.ps1
+++ b/oh.ps1
@@ -1007,7 +1007,7 @@ function import_database {
 	cd "./$SQL_DIR"
 
     $SQLCOMMAND=@"
-   --local-infile=1 -u $DATABASE_USER -p$DATABASE_PASSWORD -h $DATABASE_SERVER --port=$DATABASE_PORT --protocol=tcp $DATABASE_NAME -e "source ./$DB_CREATE_SQL"
+   --abort-source-on-error --local-infile=1 -u $DATABASE_USER -p$DATABASE_PASSWORD -h $DATABASE_SERVER --port=$DATABASE_PORT --protocol=tcp $DATABASE_NAME -e "source ./$DB_CREATE_SQL"
 "@
 	try {
 		Start-Process -FilePath "$OH_PATH\$MYSQL_DIR\bin\mysql.exe" -ArgumentList ("$SQLCOMMAND") -Wait -NoNewWindow -RedirectStandardOutput "$LOG_DIR/$LOG_FILE" -RedirectStandardError "$LOG_DIR/$LOG_FILE_ERR"

--- a/oh.ps1
+++ b/oh.ps1
@@ -1010,7 +1010,12 @@ function import_database {
    --abort-source-on-error --local-infile=1 -u $DATABASE_USER -p$DATABASE_PASSWORD -h $DATABASE_SERVER --port=$DATABASE_PORT --protocol=tcp $DATABASE_NAME -e "source ./$DB_CREATE_SQL"
 "@
 	try {
-		Start-Process -FilePath "$OH_PATH\$MYSQL_DIR\bin\mysql.exe" -ArgumentList ("$SQLCOMMAND") -Wait -NoNewWindow -RedirectStandardOutput "$LOG_DIR/$LOG_FILE" -RedirectStandardError "$LOG_DIR/$LOG_FILE_ERR"
+		$process = Start-Process -PassThru -FilePath "$OH_PATH\$MYSQL_DIR\bin\mysql.exe" -ArgumentList ("$SQLCOMMAND") -Wait -NoNewWindow -RedirectStandardOutput "$LOG_DIR/$LOG_FILE" -RedirectStandardError "$LOG_DIR/$LOG_FILE_ERR"
+		# Start-Process does not fail on a non-zero exit status, so the client reporting the failure
+		# would go unnoticed just like the failure itself did
+		if ($process.ExitCode -ne 0) {
+			throw "mysql exited with status $($process.ExitCode)"
+		}
  	}
 	catch {
 		Write-Host "Error: Database not imported! Exiting." -ForeGroundColor Red

--- a/oh.sh
+++ b/oh.sh
@@ -904,8 +904,7 @@ function import_database {
 	echo "Importing database [$DATABASE_NAME] with user [$DATABASE_USER@$DATABASE_SERVER]..."
 	cd "./$SQL_DIR"
 #	../$MYSQL_DIR/bin/mysql --local-infile=1 -u $DATABASE_ROOT_USER -p$DATABASE_ROOT_PW --host=$DATABASE_SERVER --port=$DATABASE_PORT --protocol=tcp $DATABASE_NAME < ./$DB_CREATE_SQL >> ../$LOG_DIR/$LOG_FILE 2>&1
-	# --abort-source-on-error: without it the client carries on after a failed statement inside a
-	# sourced file and still exits 0, so a half-loaded database reported success
+	# --abort-source-on-error: the client otherwise carries on after a failed statement inside a sourced file and still exits 0
 	../$MYSQL_DIR/bin/mysql --abort-source-on-error --local-infile=1 -u $DATABASE_USER -p$DATABASE_PASSWORD --host=$DATABASE_SERVER --port=$DATABASE_PORT --protocol=tcp $DATABASE_NAME < ./$DB_CREATE_SQL >> ../$LOG_DIR/$LOG_FILE 2>&1
 	if [ $? -ne 0 ]; then
 		echo "Error: Database not imported! Exiting."

--- a/oh.sh
+++ b/oh.sh
@@ -904,7 +904,9 @@ function import_database {
 	echo "Importing database [$DATABASE_NAME] with user [$DATABASE_USER@$DATABASE_SERVER]..."
 	cd "./$SQL_DIR"
 #	../$MYSQL_DIR/bin/mysql --local-infile=1 -u $DATABASE_ROOT_USER -p$DATABASE_ROOT_PW --host=$DATABASE_SERVER --port=$DATABASE_PORT --protocol=tcp $DATABASE_NAME < ./$DB_CREATE_SQL >> ../$LOG_DIR/$LOG_FILE 2>&1
-	../$MYSQL_DIR/bin/mysql --local-infile=1 -u $DATABASE_USER -p$DATABASE_PASSWORD --host=$DATABASE_SERVER --port=$DATABASE_PORT --protocol=tcp $DATABASE_NAME < ./$DB_CREATE_SQL >> ../$LOG_DIR/$LOG_FILE 2>&1
+	# --abort-source-on-error: without it the client carries on after a failed statement inside a
+	# sourced file and still exits 0, so a half-loaded database reported success
+	../$MYSQL_DIR/bin/mysql --abort-source-on-error --local-infile=1 -u $DATABASE_USER -p$DATABASE_PASSWORD --host=$DATABASE_SERVER --port=$DATABASE_PORT --protocol=tcp $DATABASE_NAME < ./$DB_CREATE_SQL >> ../$LOG_DIR/$LOG_FILE 2>&1
 	if [ $? -ne 0 ]; then
 		echo "Error: Database not imported! Exiting."
 		shutdown_database;

--- a/ohmac.sh
+++ b/ohmac.sh
@@ -516,8 +516,7 @@ function import_db {
 
 		CURRPATH=`pwd`
 		cd "$SCRIPTDIR"
-		# --abort-source-on-error: without it the client carries on after a failed statement inside
-		# a sourced file and still exits 0, so a half-loaded database reported success
+		# --abort-source-on-error: the client otherwise carries on after a failed statement inside a sourced file and still exits 0
 		mysql --abort-source-on-error --local-infile=1 -u $USER $DATABASE_NAME < $SCRIPT
 		if [ $? -ne 0 ]; then
 			echo "  >Error: Database not imported! Exiting."

--- a/ohmac.sh
+++ b/ohmac.sh
@@ -516,7 +516,9 @@ function import_db {
 
 		CURRPATH=`pwd`
 		cd "$SCRIPTDIR"
-		mysql --local-infile=1 -u $USER $DATABASE_NAME < $SCRIPT
+		# --abort-source-on-error: without it the client carries on after a failed statement inside
+		# a sourced file and still exits 0, so a half-loaded database reported success
+		mysql --abort-source-on-error --local-infile=1 -u $USER $DATABASE_NAME < $SCRIPT
 		if [ $? -ne 0 ]; then
 			echo "  >Error: Database not imported! Exiting."
 			stop_db;


### PR DESCRIPTION
## [OP-1459](https://openhospital.atlassian.net/browse/OP-1459)

The launchers do check whether the import worked:

```
if [ $? -ne 0 ]; then
	echo "Error: Database not imported! Exiting."
```

but the client carries on after a statement fails inside a sourced file and still exits 0, so the check never fires: an installation over a half-loaded database reports success and the errors stay buried in the log.

`--abort-source-on-error` makes the failure visible where the check already is. Added to the four launchers: `oh.sh`, `ohmac.sh`, `oh.bat`, `oh.ps1`.

## Verified

On MariaDB 10.6, importing the 1.15.1 demo data through `create_all_demo.sql`:

| | errors printed | exit status | outcome |
|---|---|---|---|
| without the flag | 2 | **0** | the load continues, one movement silently missing |
| with the flag | 1 | **1** | stops at the first failure, the launcher reports it |

## Note on merge order

This turns a silent failure into a loud one, which is the point — but it means that while the demo data still carries the malformed statement of [OP-1457](https://openhospital.atlassian.net/browse/OP-1457), a demo installation will stop instead of completing. On the release line this should land together with, or after, the demo data correction.

[OP-1459]: https://openhospital.atlassian.net/browse/OP-1459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OP-1457]: https://openhospital.atlassian.net/browse/OP-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ