### PR TITLE
OP-1463 Build the companion core from the pull request's base branch

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -79,7 +79,11 @@ jobs:
         run: |
           git clone --depth=1 --no-single-branch https://github.com/${{ env.FORK_REPO }}.git openhospital-core
           pushd openhospital-core
-          git checkout -B ${{ env.BRANCH_NAME }} origin/${{ env.BRANCH_NAME }} || git checkout develop
+          # a branch of the same name comes first, as before; a pull request against a release
+          # branch then builds core from that same branch, and anything else falls back to develop
+          git checkout -B ${{ env.BRANCH_NAME }} origin/${{ env.BRANCH_NAME }} \
+            || git checkout "${{ github.base_ref }}" \
+            || git checkout develop
           popd
         
       - name: Install core


### PR DESCRIPTION
## [OP-1463](https://openhospital.atlassian.net/browse/OP-1463)

The cross-repository build resolves the core it needs with

```
git checkout -B $BRANCH_NAME origin/$BRANCH_NAME || git checkout develop
```

A branch named like the one under review wins; anything else falls back to `develop`, which carries a different version than a release branch. A pull request against `release_1_15_1` therefore fails at dependency resolution — `Could not find artifact org.isf:OH-core:jar:1.15.1` — unless a core branch of the same name is created by hand purely to satisfy the first alternative.

This adds the pull request's base branch in between. Three steps, in order: a branch of the same name, as today; the base branch of the pull request, when that repository has one; `develop` otherwise. On a `push` event `github.base_ref` is empty, the command fails and the run falls back to `develop` exactly as before, so nothing that is green today changes.

## Verified

Tried end to end on a fork, with a pull request against `release_1_15_1` and deliberately no core branch of the same name:

```
fatal: 'origin/OP-ci-base-ref-1151' is not a commit and a branch cannot be created from it
Switched to a new branch 'release_1_15_1'
```

The core was built from the release branch and the build passed.

Companion pull request in the other repository, same change.

[OP-1463]: https://openhospital.atlassian.net/browse/OP-1463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ